### PR TITLE
Fix static asset URLs in templates

### DIFF
--- a/ai-stock-platform/ui/templates/404.html
+++ b/ai-stock-platform/ui/templates/404.html
@@ -7,7 +7,7 @@
     <div class="auth-card text-center">
         <div class="auth-header">
             <a href="/" class="auth-logo">
-                <img src="{{ url_for('static', path='/img/logo.svg') }}" alt="QuantumVestAI">
+                <img src="{{ url_for('static', path='img/logo.svg') }}" alt="QuantumVestAI">
             </a>
             <h1 class="auth-title">404 - Not Found</h1>
             <p class="auth-subtitle">The page you are looking for does not exist.</p>

--- a/ai-stock-platform/ui/templates/admin/dashboard.html
+++ b/ai-stock-platform/ui/templates/admin/dashboard.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='/css/admin.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', path='css/admin.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -237,7 +237,7 @@
                                 <td>
                                     <div class="d-flex align-items-center">
                                         <div class="avatar avatar-sm me-2">
-                                            <img src="{{ user.avatar_url or url_for('static', path='/img/avatars/default.png') }}" alt="{{ user.username }}">
+                                            <img src="{{ user.avatar_url or url_for('static', path='img/avatars/default.png') }}" alt="{{ user.username }}">
                                         </div>
                                         <div>{{ user.username }}</div>
                                     </div>

--- a/ai-stock-platform/ui/templates/admin/models.html
+++ b/ai-stock-platform/ui/templates/admin/models.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='/css/admin.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', path='css/admin.css') }}">
 {% endblock %}
 
 {% block content %}

--- a/ai-stock-platform/ui/templates/admin/users.html
+++ b/ai-stock-platform/ui/templates/admin/users.html
@@ -9,8 +9,8 @@
 {% endblock %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='/css/admin.css') }}">
-<link rel="stylesheet" href="{{ url_for('static', path='/vendors/datatables/dataTables.min.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', path='css/admin.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', path='vendors/datatables/dataTables.min.css') }}">
 {% endblock %}
 
 {% block content %}

--- a/ai-stock-platform/ui/templates/api_status.html
+++ b/ai-stock-platform/ui/templates/api_status.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='/css/admin.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', path='css/admin.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -238,7 +238,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="{{ url_for('static', path='/vendors/chart.js/chart.min.js') }}"></script>
+<script src="{{ url_for('static', path='vendors/chart.js/chart.min.js') }}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         // Initialize API Performance Chart

--- a/ai-stock-platform/ui/templates/base.html
+++ b/ai-stock-platform/ui/templates/base.html
@@ -16,14 +16,14 @@
     <meta property="og:url" content="{{ request.url }}">
     <meta property="og:title" content="{% block og_title %}{{ self.title() }}{% endblock %}">
     <meta property="og:description" content="{% block og_description %}{{ self.description() }}{% endblock %}">
-    <meta property="og:image" content="{{ url_for('static', path='/img/og-image.jpg') }}">
+    <meta property="og:image" content="{{ url_for('static', path='img/og-image.jpg') }}">
     
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="{{ request.url }}">
     <meta property="twitter:title" content="{% block twitter_title %}{{ self.title() }}{% endblock %}">
     <meta property="twitter:description" content="{% block twitter_description %}{{ self.description() }}{% endblock %}">
-    <meta property="twitter:image" content="{{ url_for('static', path='/img/twitter-card.jpg') }}">
+    <meta property="twitter:image" content="{{ url_for('static', path='img/twitter-card.jpg') }}">
     
     <!-- Preconnect to external resources -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -34,36 +34,36 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Poppins:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     
     <!-- Critical CSS -->
-    <link rel="stylesheet" href="{{ url_for('static', path='/css/bootstrap.min.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', path='/css/quantum-enhancements.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', path='/css/quantum-dashboard.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', path='/css/quantum-mobile-enhanced.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='css/bootstrap.min.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='css/quantum-enhancements.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='css/quantum-dashboard.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='css/quantum-mobile-enhanced.css') }}">
     
     <!-- Progressive CSS Loading -->
-    <link rel="preload" href="{{ url_for('static', path='/css/styles.css') }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <link rel="preload" href="{{ url_for('static', path='/css/dark-mode.css') }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <link rel="preload" href="{{ url_for('static', path='/css/realtime-dashboard.css') }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <link rel="preload" href="{{ url_for('static', path='/css/responsive.css') }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" href="{{ url_for('static', path='css/styles.css') }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" href="{{ url_for('static', path='css/dark-mode.css') }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" href="{{ url_for('static', path='css/realtime-dashboard.css') }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" href="{{ url_for('static', path='css/responsive.css') }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
     
     <!-- Fallback for preload -->
     <noscript>
-        <link rel="stylesheet" href="{{ url_for('static', path='/css/styles.css') }}">
-        <link rel="stylesheet" href="{{ url_for('static', path='/css/dark-mode.css') }}">
-        <link rel="stylesheet" href="{{ url_for('static', path='/css/realtime-dashboard.css') }}">
-        <link rel="stylesheet" href="{{ url_for('static', path='/css/responsive.css') }}">
+        <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
+        <link rel="stylesheet" href="{{ url_for('static', path='css/dark-mode.css') }}">
+        <link rel="stylesheet" href="{{ url_for('static', path='css/realtime-dashboard.css') }}">
+        <link rel="stylesheet" href="{{ url_for('static', path='css/responsive.css') }}">
     </noscript>
     
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.2/font/bootstrap-icons.css">
     
     <!-- PWA Manifest -->
-    <link rel="manifest" href="{{ url_for('static', path='/manifest.json') }}">
+    <link rel="manifest" href="{{ url_for('static', path='manifest.json') }}">
     
     <!-- Favicons -->
-    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', path='/img/favicon.svg') }}">
-    <link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('static', path='/img/favicon-32x32.png') }}">
-    <link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('static', path='/img/favicon-16x16.png') }}">
-    <link rel="apple-touch-icon" href="{{ url_for('static', path='/img/apple-touch-icon.png') }}">
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', path='img/favicon.svg') }}">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('static', path='img/favicon-32x32.png') }}">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('static', path='img/favicon-16x16.png') }}">
+    <link rel="apple-touch-icon" href="{{ url_for('static', path='img/apple-touch-icon.png') }}">
     
     <!-- Theme Color -->
     <meta name="theme-color" content="#4facfe">
@@ -186,8 +186,8 @@
         <aside class="sidebar quantum-glass" id="sidebar" role="navigation" aria-label="Secondary navigation">
             <div class="sidebar-header">
                 <a href="/" class="sidebar-logo quantum-nav-brand">
-                    <img src="{{ url_for('static', path='/img/logo.svg') }}" alt="QuantumVestAI Logo" class="logo-default">
-                    <img src="{{ url_for('static', path='/img/logo-collapsed.svg') }}" alt="QV" class="logo-collapsed">
+                    <img src="{{ url_for('static', path='img/logo.svg') }}" alt="QuantumVestAI Logo" class="logo-default">
+                    <img src="{{ url_for('static', path='img/logo-collapsed.svg') }}" alt="QV" class="logo-collapsed">
                 </a>
                 <button class="sidebar-toggle quantum-btn" id="sidebarToggle" aria-label="Toggle sidebar">
                     <i class="bi bi-chevron-left"></i>
@@ -271,7 +271,7 @@
                     {% if user %}
                     <div class="user-info">
                         <div class="user-avatar">
-                            <img src="{{ url_for('static', path='/img/avatars/default.png') }}" alt="User">
+                            <img src="{{ url_for('static', path='img/avatars/default.png') }}" alt="User">
                         </div>
                         <div class="user-details">
                             <span class="user-name">{{ user.username }}</span>
@@ -407,27 +407,27 @@
     </div>
 
     <!-- JavaScript Libraries -->
-    <script src="{{ url_for('static', path='/js/bootstrap.bundle.min.js') }}"></script>
-    <script src="{{ url_for('static', path='/vendors/chart.js/chart.min.js') }}"></script>
+    <script src="{{ url_for('static', path='js/bootstrap.bundle.min.js') }}"></script>
+    <script src="{{ url_for('static', path='vendors/chart.js/chart.min.js') }}"></script>
     
     <!-- Enhanced QuantumVestAI Features -->
-    <script src="{{ url_for('static', path='/js/quantum-enhancements.js') }}" defer></script>
-    <script src="{{ url_for('static', path='/js/quantum-i18n.js') }}" defer></script>
-    <script src="{{ url_for('static', path='/js/quantum-search.js') }}" defer></script>
-    <script src="{{ url_for('static', path='/js/quantum-community.js') }}" defer></script>
-    <script src="{{ url_for('static', path='/js/quantum-charts.js') }}" defer></script>
-    <script src="{{ url_for('static', path='/js/quantum-ai.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/quantum-enhancements.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/quantum-i18n.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/quantum-search.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/quantum-community.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/quantum-charts.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/quantum-ai.js') }}" defer></script>
     <!-- Modern Quantum Components -->
-    <script src="{{ url_for('static', path='/js/quantum-dashboard.js') }}" defer></script>
-    <script src="{{ url_for('static', path='/js/quantum-content.js') }}" defer></script>
-    <script src="{{ url_for('static', path='/js/quantum-enhanced-charts.js') }}" defer></script>
-    <script src="{{ url_for('static', path='/js/quantum-pwa.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/quantum-dashboard.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/quantum-content.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/quantum-enhanced-charts.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/quantum-pwa.js') }}" defer></script>
     
     <!-- Legacy UI Scripts -->
-    <script src="{{ url_for('static', path='/js/enhanced-ui.js') }}" defer></script>
-    <script src="{{ url_for('static', path='/js/navigation.js') }}" defer></script>
-    <script src="{{ url_for('static', path='/js/app.js') }}" defer></script>
-    <script src="{{ url_for('static', path='/js/auth.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/enhanced-ui.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/navigation.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/app.js') }}" defer></script>
+    <script src="{{ url_for('static', path='js/auth.js') }}" defer></script>
     
     <!-- Progressive Web App Support -->
     <script>

--- a/ai-stock-platform/ui/templates/dashboard/index.html
+++ b/ai-stock-platform/ui/templates/dashboard/index.html
@@ -3,11 +3,11 @@
 {% block title %}Dashboard | QuantumVestAI{% endblock %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='/css/dashboard.css') }}">
-<link rel="stylesheet" href="{{ url_for('static', path='/css/dashboard-enhancements.css') }}">
-<script src="{{ url_for('static', path='/js/dashboard.js') }}" defer></script>
-<script src="{{ url_for('static', path='/js/realtime-dashboard.js') }}" defer></script>
-<script src="{{ url_for('static', path='/js/dashboard-enhancements.js') }}" defer></script>
+<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', path='css/dashboard-enhancements.css') }}">
+<script src="{{ url_for('static', path='js/dashboard.js') }}" defer></script>
+<script src="{{ url_for('static', path='js/realtime-dashboard.js') }}" defer></script>
+<script src="{{ url_for('static', path='js/dashboard-enhancements.js') }}" defer></script>
 <meta name="last-updated" content="2025-06-20 02:53:45">
 <meta name="updated-by" content="daparthi001">
 {% endblock %}

--- a/ai-stock-platform/ui/templates/forecast.html
+++ b/ai-stock-platform/ui/templates/forecast.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='/css/stockanalysis.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', path='css/stockanalysis.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -25,7 +25,7 @@
     <div class="card-body">
         <div class="stock-info">
             <div class="stock-logo">
-                <img src="https://logo.clearbit.com/{{ ticker.lower() }}.com" alt="{{ stock_info.name }}" onerror="this.src='{{ url_for('static', path='/img/stock-placeholder.png') }}'">
+                <img src="https://logo.clearbit.com/{{ ticker.lower() }}.com" alt="{{ stock_info.name }}" onerror="this.src='{{ url_for('static', path='img/stock-placeholder.png') }}'">
             </div>
             <div class="stock-details">
                 <h2 class="stock-name">{{ stock_info.name }}</h2>
@@ -563,7 +563,7 @@
                         {% for article in news %}
                         <div class="card news-card">
                             <div class="news-image-wrapper">
-                                <img src="{{ article.thumbnail }}" class="news-image" alt="{{ article.title }}" onerror="this.src='{{ url_for('static', path='/img/news-placeholder.jpg') }}'">
+                                <img src="{{ article.thumbnail }}" class="news-image" alt="{{ article.title }}" onerror="this.src='{{ url_for('static', path='img/news-placeholder.jpg') }}'">
                             </div>
                             <div class="news-content">
                                 <div class="news-meta">
@@ -644,8 +644,8 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="{{ url_for('static', path='/js/chart.js') }}"></script>
-<script src="{{ url_for('static', path='/js/forecast.js') }}"></script>
+<script src="{{ url_for('static', path='js/chart.js') }}"></script>
+<script src="{{ url_for('static', path='js/forecast.js') }}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // Initialize forecast charts and interactivity

--- a/ai-stock-platform/ui/templates/home.html
+++ b/ai-stock-platform/ui/templates/home.html
@@ -171,7 +171,7 @@
                             <td>
                                 <div class="stock-symbol">
                                     <div class="symbol-logo me-2">
-                                        <img src="https://logo.clearbit.com/{{ stock.symbol.lower() }}.com" alt="{{ stock.name }}" onerror="this.src='{{ url_for('static', path='/img/stock-placeholder.png') }}'">
+                                        <img src="https://logo.clearbit.com/{{ stock.symbol.lower() }}.com" alt="{{ stock.name }}" onerror="this.src='{{ url_for('static', path='img/stock-placeholder.png') }}'">
                                     </div>
                                     <div>
                                         <div class="symbol">{{ stock.symbol }}</div>
@@ -330,7 +330,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="{{ url_for('static', path='/js/charts.js') }}"></script>
+<script src="{{ url_for('static', path='js/charts.js') }}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         // Hero Chart

--- a/ai-stock-platform/ui/templates/login.html
+++ b/ai-stock-platform/ui/templates/login.html
@@ -4,7 +4,7 @@
 
 {% block head_extra %}
 <!-- Enhanced UI scripts -->
-<script src="{{ url_for('static', path='/js/enhanced-ui.js') }}"></script>
+<script src="{{ url_for('static', path='js/enhanced-ui.js') }}"></script>
 {% endblock %}
 
 {% block content %}
@@ -12,7 +12,7 @@
     <div class="auth-card">
         <div class="auth-header">
             <a href="/" class="auth-logo">
-                <img src="{{ url_for('static', path='/img/logo.svg') }}" alt="QuantumVestAI">
+                <img src="{{ url_for('static', path='img/logo.svg') }}" alt="QuantumVestAI">
             </a>
             <h1 class="auth-title">Sign In</h1>
             <p class="auth-subtitle">Access your QuantumVestAI account</p>

--- a/ai-stock-platform/ui/templates/password_reset.html
+++ b/ai-stock-platform/ui/templates/password_reset.html
@@ -7,7 +7,7 @@
     <div class="auth-card">
         <div class="auth-header">
             <a href="/" class="auth-logo">
-                <img src="{{ url_for('static', path='/img/logo.svg') }}" alt="QuantumVestAI" onerror="this.src='{{ url_for('static', path='/img/logo-placeholder.png') }}'">
+                <img src="{{ url_for('static', path='img/logo.svg') }}" alt="QuantumVestAI" onerror="this.src='{{ url_for('static', path='img/logo-placeholder.png') }}'">
             </a>
             <h1 class="auth-title">Reset Password</h1>
             <p class="auth-subtitle">Enter your email to receive reset instructions</p>

--- a/ai-stock-platform/ui/templates/predictability.html
+++ b/ai-stock-platform/ui/templates/predictability.html
@@ -3,7 +3,7 @@
 {% block title %}QuantumVestAI - Stock Predictability Analysis{% endblock %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='/css/predictability.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', path='css/predictability.css') }}">
 {% endblock %}
 
 {% block breadcrumb %}
@@ -48,8 +48,8 @@
     <div class="card-body">
         <div class="stock-info">
             <div class="stock-logo">
-                <img src="{{ url_for('static', path='/img/stock-logos/' + ticker.lower() + '.png') }}" alt="{{ ticker }}" 
-                    onerror="this.src='{{ url_for('static', path='/img/stock-logos/default.png') }}'">
+                <img src="{{ url_for('static', path='img/stock-logos/' + ticker.lower() + '.png') }}" alt="{{ ticker }}" 
+                    onerror="this.src='{{ url_for('static', path='img/stock-logos/default.png') }}'">
             </div>
             <div class="stock-details">
                 <h2 class="stock-name">{{ stock_info.name }}</h2>
@@ -318,8 +318,8 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="{{ url_for('static', path='/js/chart.js') }}"></script>
-<script src="{{ url_for('static', path='/js/predictability.js') }}"></script>
+<script src="{{ url_for('static', path='js/chart.js') }}"></script>
+<script src="{{ url_for('static', path='js/predictability.js') }}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // Initialize predictability charts and gauges

--- a/ai-stock-platform/ui/templates/profile.html
+++ b/ai-stock-platform/ui/templates/profile.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='/css/profile.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', path='css/profile.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -776,7 +776,7 @@
             <div class="modal-body">
                 <div class="avatar-upload-container">
                     <div class="avatar-preview">
-                        <img src="{{ user.avatar_url or url_for('static', path='/img/avatars/default.png') }}" alt="Preview" id="avatarPreview">
+                        <img src="{{ user.avatar_url or url_for('static', path='img/avatars/default.png') }}" alt="Preview" id="avatarPreview">
                     </div>
                     <div class="avatar-upload">
                         <label for="avatarFile" class="form-label">Select Image</label>
@@ -806,7 +806,7 @@
                     <h5>Step 1: Scan QR Code</h5>
                     <p>Scan this QR code with your authentication app (Google Authenticator, Authy, etc.)</p>
                     <div class="qr-code-container text-center mb-4">
-                        <img src="{{ url_for('static', path='/img/sample-qr.png') }}" alt="QR Code" class="mb-2">
+                        <img src="{{ url_for('static', path='img/sample-qr.png') }}" alt="QR Code" class="mb-2">
                         <div class="text-muted">
                             Can't scan? Use this code: <code>ABCD-EFGH-IJKL-MNOP</code>
                         </div>
@@ -833,7 +833,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="{{ url_for('static', path='/js/profile.js') }}"></script>
+<script src="{{ url_for('static', path='js/profile.js') }}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         // Toggle password visibility

--- a/ai-stock-platform/ui/templates/register.html
+++ b/ai-stock-platform/ui/templates/register.html
@@ -4,7 +4,7 @@
 
 {% block head_extra %}
 <!-- Enhanced UI scripts -->
-<script src="{{ url_for('static', path='/js/enhanced-ui.js') }}"></script>
+<script src="{{ url_for('static', path='js/enhanced-ui.js') }}"></script>
 {% endblock %}
 
 {% block content %}
@@ -12,7 +12,7 @@
     <div class="auth-card">
         <div class="auth-header">
             <a href="/" class="auth-logo">
-                <img src="{{ url_for('static', path='/img/logo.svg') }}" alt="QuantumVestAI">
+                <img src="{{ url_for('static', path='img/logo.svg') }}" alt="QuantumVestAI">
             </a>
             <h1 class="auth-title">Create Account</h1>
             <p class="auth-subtitle">Join QuantumVestAI to start your investment journey</p>

--- a/ai-stock-platform/ui/templates/subscription/plans.html
+++ b/ai-stock-platform/ui/templates/subscription/plans.html
@@ -3,8 +3,8 @@
 {% block title %}Subscription Plans | QuantumVestAI{% endblock %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='/css/quantum-mobile-enhanced.css') }}">
-<script src="{{ url_for('static', path='/js/quantum-pwa.js') }}" defer></script>
+<link rel="stylesheet" href="{{ url_for('static', path='css/quantum-mobile-enhanced.css') }}">
+<script src="{{ url_for('static', path='js/quantum-pwa.js') }}" defer></script>
 <style>
     .pricing-section {
         background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);

--- a/ai-stock-platform/ui/templates/watchlist.html
+++ b/ai-stock-platform/ui/templates/watchlist.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block head_extra %}
-<link rel="stylesheet" href="{{ url_for('static', path='/css/watchlist.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', path='css/watchlist.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -128,7 +128,7 @@
                         <td>
                             <a href="/forecast?ticker={{ alert.ticker }}" class="d-flex align-items-center">
                                 <div class="symbol-logo me-2">
-                                    <img src="https://logo.clearbit.com/{{ alert.ticker.lower() }}.com" alt="{{ alert.ticker }}" onerror="this.src='{{ url_for('static', path='/img/stock-placeholder.png') }}'">
+                                    <img src="https://logo.clearbit.com/{{ alert.ticker.lower() }}.com" alt="{{ alert.ticker }}" onerror="this.src='{{ url_for('static', path='img/stock-placeholder.png') }}'">
                                 </div>
                                 <span class="font-weight-bold">{{ alert.ticker }}</span>
                             </a>
@@ -167,7 +167,7 @@
             <div class="stock-card-header">
                 <div class="stock-card-title">
                     <div class="stock-logo">
-                        <img src="https://logo.clearbit.com/{{ item.ticker.lower() }}.com" alt="{{ item.ticker }}" onerror="this.src='{{ url_for('static', path='/img/stock-placeholder.png') }}'">
+                        <img src="https://logo.clearbit.com/{{ item.ticker.lower() }}.com" alt="{{ item.ticker }}" onerror="this.src='{{ url_for('static', path='img/stock-placeholder.png') }}'">
                     </div>
                     <div class="stock-name">
                         <h4>{{ item.ticker }}</h4>
@@ -286,7 +286,7 @@
                         <td>
                             <div class="stock-cell">
                                 <div class="stock-logo">
-                                    <img src="https://logo.clearbit.com/{{ item.ticker.lower() }}.com" alt="{{ item.ticker }}" onerror="this.src='{{ url_for('static', path='/img/stock-placeholder.png') }}'">
+                                    <img src="https://logo.clearbit.com/{{ item.ticker.lower() }}.com" alt="{{ item.ticker }}" onerror="this.src='{{ url_for('static', path='img/stock-placeholder.png') }}'">
                                 </div>
                                 <div>
                                     <div class="stock-symbol">{{ item.ticker }}</div>
@@ -521,8 +521,8 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="{{ url_for('static', path='/vendors/chart.js/chart.min.js') }}"></script>
-<script src="{{ url_for('static', path='/js/watchlist.js') }}"></script>
+<script src="{{ url_for('static', path='vendors/chart.js/chart.min.js') }}"></script>
+<script src="{{ url_for('static', path='js/watchlist.js') }}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         // Mini charts for grid view - implementation would go here


### PR DESCRIPTION
## Summary
- remove leading slashes from `url_for('static', path=...)` calls
- ensure generated paths work with FastAPI static file handler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for requests, sqlalchemy, httpx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686d28b58614832aa2bd9a041c0ba410