### PR TITLE
Add nav translations

### DIFF
--- a/ai-stock-platform/ui/static/js/quantum-i18n.js
+++ b/ai-stock-platform/ui/static/js/quantum-i18n.js
@@ -48,6 +48,9 @@ class QuantumI18n {
                 'nav.login': 'Login',
                 'nav.logout': 'Logout',
                 'nav.register': 'Register',
+                'nav.brand': 'QuantumVestAI',
+                'nav.forecast': 'Forecast',
+                'nav.profile': 'Profile',
 
                 // Dashboard
                 'dashboard.title': 'QuantumVestAI Dashboard',
@@ -136,6 +139,9 @@ class QuantumI18n {
                 'nav.login': 'Iniciar Sesión',
                 'nav.logout': 'Cerrar Sesión',
                 'nav.register': 'Registrarse',
+                'nav.brand': 'QuantumVestAI',
+                'nav.forecast': 'Pronóstico',
+                'nav.profile': 'Perfil',
 
                 // Dashboard
                 'dashboard.title': 'Panel de QuantumVestAI',
@@ -186,6 +192,9 @@ class QuantumI18n {
                 'nav.login': 'Connexion',
                 'nav.logout': 'Déconnexion',
                 'nav.register': 'Inscription',
+                'nav.brand': 'QuantumVestAI',
+                'nav.forecast': 'Prévisions',
+                'nav.profile': 'Profil',
 
                 // Dashboard
                 'dashboard.title': 'Tableau de Bord QuantumVestAI',
@@ -210,6 +219,9 @@ class QuantumI18n {
                 'nav.login': 'Anmelden',
                 'nav.logout': 'Abmelden',
                 'nav.register': 'Registrieren',
+                'nav.brand': 'QuantumVestAI',
+                'nav.forecast': 'Prognose',
+                'nav.profile': 'Profil',
 
                 // Dashboard
                 'dashboard.title': 'QuantumVestAI Dashboard',
@@ -234,6 +246,9 @@ class QuantumI18n {
                 'nav.login': '登录',
                 'nav.logout': '退出',
                 'nav.register': '注册',
+                'nav.brand': 'QuantumVestAI',
+                'nav.forecast': '预测',
+                'nav.profile': '个人资料',
 
                 // Dashboard
                 'dashboard.title': 'QuantumVestAI 仪表板',

--- a/ai-stock-platform/ui/templates/base.html
+++ b/ai-stock-platform/ui/templates/base.html
@@ -207,7 +207,7 @@
                             </a>
                         </li>
                         <li class="nav-item {% if '/forecast' in request.url.path %}active{% endif %}">
-                            <a href="/ticker-search" class="nav-link">
+                            <a href="/ticker-search" class="nav-link" data-i18n="nav.forecast">
                                 <i class="bi bi-graph-up"></i>
                                 <span class="nav-text">Forecast</span>
                             </a>
@@ -227,13 +227,13 @@
                         </li>
                         {% endif %}
                         <li class="nav-item {% if '/market' in request.url.path %}active{% endif %}">
-                            <a href="/market" class="nav-link">
+                            <a href="/market" class="nav-link" data-i18n="nav.market">
                                 <i class="bi bi-currency-exchange"></i>
                                 <span class="nav-text">Market</span>
                             </a>
                         </li>
                         <li class="nav-item {% if '/news' in request.url.path %}active{% endif %}">
-                            <a href="/news" class="nav-link">
+                            <a href="/news" class="nav-link" data-i18n="nav.news">
                                 <i class="bi bi-newspaper"></i>
                                 <span class="nav-text">News</span>
                             </a>
@@ -287,17 +287,17 @@
                                 <i class="bi bi-three-dots-vertical"></i>
                             </button>
                             <ul class="dropdown-menu dropdown-menu-end">
-                                <li><a class="dropdown-item" href="/profile">Profile</a></li>
-                                <li><a class="dropdown-item" href="/settings">Settings</a></li>
+                                <li><a class="dropdown-item" href="/profile" data-i18n="nav.profile">Profile</a></li>
+                                <li><a class="dropdown-item" href="/settings" data-i18n="nav.settings">Settings</a></li>
                                 <li><hr class="dropdown-divider"></li>
-                                <li><a class="dropdown-item" href="/logout">Logout</a></li>
+                                <li><a class="dropdown-item" href="/logout" data-i18n="nav.logout">Logout</a></li>
                             </ul>
                         </div>
                     </div>
                     {% else %}
                     <div class="auth-buttons">
-                        <a href="/login" class="btn btn-outline-primary btn-sm">Login</a>
-                        <a href="/register" class="btn btn-primary btn-sm">Register</a>
+                        <a href="/login" class="btn btn-outline-primary btn-sm" data-i18n="nav.login">Login</a>
+                        <a href="/register" class="btn btn-primary btn-sm" data-i18n="nav.register">Register</a>
                     </div>
                     {% endif %}
                 </div>


### PR DESCRIPTION
## Summary
- add missing i18n hooks for sidebar links and dropdown items
- ensure nav links use translated labels

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686d5ad063c0832a9fa84a0d83466bd5