### PR TITLE
Add shared template retrieval

### DIFF
--- a/ai-stock-platform/ui/config/controllers.dashboard_controller.py
+++ b/ai-stock-platform/ui/config/controllers.dashboard_controller.py
@@ -24,6 +24,10 @@ router = APIRouter()
 # Set up templates
 templates = Jinja2Templates(directory="templates")
 
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 # API client timeout (configurable via environment variable)
 TIMEOUT = float(os.getenv("API_TIMEOUT", "10.0"))
 
@@ -182,12 +186,12 @@ async def dashboard(
             endpoint="/dashboard"
         ).observe(duration)
         
-        return templates.TemplateResponse("dashboard/index.html", context)
+        return get_templates(request).TemplateResponse("dashboard/index.html", context)
     
     except httpx.RequestError as e:
 
         logger.error(f"Request error: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html", 
             {
                 "request": request,
@@ -200,7 +204,7 @@ async def dashboard(
         raise e
     except Exception as e:
         logger.exception(f"Unexpected error: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html", 
             {
                 "request": request,

--- a/ai-stock-platform/ui/controllers/auth_controller.py
+++ b/ai-stock-platform/ui/controllers/auth_controller.py
@@ -16,10 +16,11 @@ from pathlib import Path
 router = APIRouter()
 logger = logging.getLogger("quantumvestai.auth_controller")
 
-# Get templates from app state
-def get_templates():
-    from main import app
-    return app.state.templates
+templates = Jinja2Templates(directory=str(Path("templates")))
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
 
 # Get API URL from environment or use default
 API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000/api/v1")
@@ -64,8 +65,8 @@ def format_error_message(error_data):
 @router.get("/auth/login", response_class=HTMLResponse)
 async def login_page(request: Request, next: str = "/dashboard", msg: str = None):
     """Render login page"""
-    templates = get_templates()
-    return templates.TemplateResponse(
+    templates = get_templates(request)
+    return get_templates(request).TemplateResponse(
         "auth/login.html", 
         {
             "request": request, 
@@ -86,7 +87,7 @@ async def login_post(
 ):
     """Process login form submission"""
     logger.info(f"Login attempt for username: {username}")
-    templates = get_templates()
+    templates = get_templates(request)
     
     try:
         # TODO: Add main API login logic here
@@ -124,7 +125,7 @@ async def login_post(
                 logger.info(f"Emergency login successful for {username}")
                 return response
                 
-            return templates.TemplateResponse(
+            return get_templates(request).TemplateResponse(
                 "auth/login.html",
                 {
                     "request": request, 
@@ -182,7 +183,7 @@ async def login_post(
             logger.info(f"Emergency login successful for {username}")
             return response
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/login.html",
             {
                 "request": request, 
@@ -194,7 +195,7 @@ async def login_post(
         )
     except Exception as e:
         logger.error(f"Unexpected error during login: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/login.html",
             {
                 "request": request, 
@@ -220,8 +221,8 @@ async def logout_shortcut():
 @router.get("/auth/register", response_class=HTMLResponse)
 async def register_page(request: Request):
     """Render registration page"""
-    templates = get_templates()
-    return templates.TemplateResponse(
+    templates = get_templates(request)
+    return get_templates(request).TemplateResponse(
         "auth/register.html", 
         {
             "request": request,
@@ -242,11 +243,11 @@ async def register_post(
 ):
     """Process registration form submission"""
     logger.info(f"Registration attempt for username: {username}")
-    templates = get_templates()
+    templates = get_templates(request)
     
     # Check if terms were accepted
     if not terms:
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/register.html",
             {
                 "request": request, 
@@ -260,7 +261,7 @@ async def register_post(
     
     # Check if passwords match
     if password != confirm_password:
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/register.html",
             {
                 "request": request, 
@@ -307,7 +308,7 @@ async def register_post(
                 error_msg = f"Registration failed: {response.text[:100]}"
         
         logger.warning(f"Registration failed for {username}: {error_msg}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/register.html",
             {
                 "request": request, 
@@ -330,7 +331,7 @@ async def register_post(
             )
         
         # If not in emergency mode, show error
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/register.html",
             {
                 "request": request, 
@@ -343,7 +344,7 @@ async def register_post(
         )
     except Exception as e:
         logger.exception(f"Unexpected error during registration: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/register.html",
             {
                 "request": request, 
@@ -358,8 +359,8 @@ async def register_post(
 @router.get("/auth/password-reset", response_class=HTMLResponse)
 async def password_reset_page(request: Request):
     """Render password reset request page"""
-    templates = get_templates()
-    return templates.TemplateResponse(
+    templates = get_templates(request)
+    return get_templates(request).TemplateResponse(
         "auth/password_reset.html", 
         {
             "request": request,
@@ -370,14 +371,14 @@ async def password_reset_page(request: Request):
 @router.post("/auth/password-reset")
 async def password_reset_post(request: Request, email: str = Form(...)):
     """Process password reset request"""
-    templates = get_templates()
+    templates = get_templates(request)
     
     try:
         # TODO: Add password reset logic here
         # For now, just show success message
         
         # Always show success message for security (don't reveal if email exists)
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/password_reset.html",
             {
                 "request": request,
@@ -390,7 +391,7 @@ async def password_reset_post(request: Request, email: str = Form(...)):
     except Exception as e:
         logger.error(f"Error during password reset: {str(e)}")
         # Still show success message for security
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/password_reset.html",
             {
                 "request": request,

--- a/ai-stock-platform/ui/controllers/feature_controller.py
+++ b/ai-stock-platform/ui/controllers/feature_controller.py
@@ -17,9 +17,11 @@ router = APIRouter(prefix="/features", tags=["features"])
 logger = logging.getLogger("quantumvestai.feature_controller")
 
 # Get templates from app state
-def get_templates():
-    from main import app
-    return app.state.templates
+templates = Jinja2Templates(directory=str(Path("templates")))
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
 
 # Get API URL from environment or use default
 API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000/api/v1")
@@ -54,7 +56,7 @@ async def debug_features(request: Request):
     return RedirectResponse(url="/login?msg=Debug+features+require+authentication+(demo+mode)", status_code=302)
 =======
     """Advanced features page"""
-    templates = get_templates()
+    templates = get_templates(request)
     if not user:
         logger.warning("Unauthenticated user tried to access advanced features page")
         return RedirectResponse(url="/login?next=/features/advanced", status_code=302)
@@ -82,10 +84,10 @@ async def debug_features(request: Request):
     if activated:
         feature_status["advanced"] = True
     
-    return templates.TemplateResponse(
+    return get_templates(request).TemplateResponse(
         "features/advanced.html",
         {
-            "request": request, 
+            "request": request,
             "user": None,
             "features": feature_status,
             "activated": activated
@@ -95,7 +97,7 @@ async def debug_features(request: Request):
 @router.post("/activate")
 async def activate_features(request: Request):
     """Activate advanced features directly"""
-    templates = get_templates()
+    templates = get_templates(request)
     if not user:
         logger.warning("Unauthenticated user tried to activate features")
         return JSONResponse(
@@ -116,7 +118,7 @@ async def activate_features(request: Request):
                 error_message = f"API error: {response.status_code}"
                 
             logger.error(f"API error activating features: {error_message}")
-            return templates.TemplateResponse(
+            return get_templates(request).TemplateResponse(
                 "features/advanced.html",
                 {
                     "request": request,
@@ -128,7 +130,7 @@ async def activate_features(request: Request):
             )
     except Exception as e:
         logger.error(f"Error activating features: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "features/advanced.html",
             {
                 "request": request,

--- a/ai-stock-platform/ui/controllers/forecast_controller.py
+++ b/ai-stock-platform/ui/controllers/forecast_controller.py
@@ -15,6 +15,11 @@ from typing import Optional, Dict, Any
 # Setup router
 router = APIRouter(prefix="/forecast", tags=["forecast"])
 templates = Jinja2Templates(directory=str(Path("templates")))
+
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
 logger = logging.getLogger(__name__)
 
 # Get API URL from environment
@@ -89,7 +94,7 @@ async def forecast_home(request: Request):
         }
         
         # Render the forecast dashboard
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "forecast/index.html",
             {
                 "request": request,
@@ -104,7 +109,7 @@ async def forecast_home(request: Request):
         
     except Exception as e:
         logger.error(f"Error rendering forecast dashboard: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,
@@ -167,7 +172,7 @@ async def stock_forecast(
             ]
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "forecast/stock_detail.html",
             {
                 "request": request,
@@ -182,7 +187,7 @@ async def stock_forecast(
         
     except Exception as e:
         logger.error(f"Error loading stock forecast for {symbol}: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,

--- a/ai-stock-platform/ui/controllers/market_controller.py
+++ b/ai-stock-platform/ui/controllers/market_controller.py
@@ -157,7 +157,7 @@ async def market_overview(
         templates = get_templates(request)
         
         # Render template
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "market/overview.html",
             {
                 "request": request,
@@ -177,7 +177,7 @@ async def market_overview(
         # Get templates
         templates = get_templates(request)
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,
@@ -273,7 +273,7 @@ async def stock_details(
         templates = get_templates(request)
         
         # Render template
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "market/stock_details.html",
             {
                 "request": request,
@@ -294,7 +294,7 @@ async def stock_details(
         # Get templates
         templates = get_templates(request)
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,

--- a/ai-stock-platform/ui/controllers/news_controller.py
+++ b/ai-stock-platform/ui/controllers/news_controller.py
@@ -15,6 +15,11 @@ from datetime import datetime
 router = APIRouter()
 BASE_DIR = Path(__file__).resolve().parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
 logger = logging.getLogger("quantumvestai.news_controller")
 
 # Get API URL from environment or use default
@@ -95,7 +100,7 @@ async def news_page(
             "trending": ["AI", "Federal Reserve", "EV Market", "Cryptocurrency"]
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "news/index.html",
             {
                 "request": request, 
@@ -107,7 +112,7 @@ async def news_page(
         )
     except Exception as e:
         logger.error(f"News page error: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request, 
@@ -148,7 +153,7 @@ async def news_article(
             "sentiment": {"status": "available", "score": 0.7, "label": "positive"}
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "news/article.html",
             {
                 "request": request, 
@@ -162,7 +167,7 @@ async def news_article(
         raise e
     except Exception as e:
         logger.error(f"News article error for {article_id}: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request, 
@@ -171,5 +176,4 @@ async def news_article(
                 "demo_mode": True,
                 "page_title": "Article Error"
             },
-            status_code=500
-        )
+            status_code=500        )

--- a/ai-stock-platform/ui/controllers/profile_controller.py
+++ b/ai-stock-platform/ui/controllers/profile_controller.py
@@ -16,6 +16,11 @@ API_URL = "http://quantumvestai-dev-api:8000/api/v1"
 # Setup router and templates
 router = APIRouter()
 templates = Jinja2Templates(directory=str(Path("/app/templates")))
+
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
 logger = logging.getLogger(__name__)
 
 @router.get("/profile", response_class=HTMLResponse)

--- a/ai-stock-platform/ui/controllers/stock_controller.py
+++ b/ai-stock-platform/ui/controllers/stock_controller.py
@@ -13,6 +13,11 @@ from pathlib import Path
 
 router = APIRouter()
 templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent.parent / "templates"))
+
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
 logger = logging.getLogger("quantumvestai.stock_controller")
 
 # Get API URL from environment or use default
@@ -89,7 +94,7 @@ async def stock_search(
                 result.setdefault('change', None)
                 result.setdefault('change_percent', None)
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "stocks/search.html",
             {
                 "request": request,
@@ -104,7 +109,7 @@ async def stock_search(
         )
     except Exception as e:
         logger.error(f"Stock search error: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "stocks/search.html",
             {
                 "request": request,
@@ -207,7 +212,7 @@ async def stock_detail(
             stock_data["sentiment"] = {"status": "unavailable", "reason": "demo_mode"}
             stock_data["in_watchlist"] = False
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "stocks/detail.html",
             {
                 "request": request, 
@@ -220,7 +225,7 @@ async def stock_detail(
         raise e
     except Exception as e:
         logger.error(f"Stock detail error for {ticker}: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {"request": request, "error": str(e), "user": None, "demo_mode": True},
             status_code=500

--- a/ai-stock-platform/ui/controllers/watchlist_controller.py
+++ b/ai-stock-platform/ui/controllers/watchlist_controller.py
@@ -13,6 +13,10 @@ from pathlib import Path
 
 router = APIRouter()
 templates = Jinja2Templates(directory=str(Path("/app/templates")))
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
 logger = logging.getLogger("quantumvestai.watchlist_controller")
 
 # Get API URL from environment or use default
@@ -44,7 +48,7 @@ async def view_watchlist(request: Request):
         )
     except Exception as e:
         logger.error(f"Watchlist error: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {"request": request, "error": str(e)},
             status_code=500

--- a/ai-stock-platform/ui/routes/admin.py
+++ b/ai-stock-platform/ui/routes/admin.py
@@ -16,6 +16,11 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 templates = Jinja2Templates(directory=str(Path("templates")))
 
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 router = APIRouter(tags=["admin"])
 
 @router.get("/admin")
@@ -59,7 +64,7 @@ async def admin_dashboard(request: Request, current_user: dict = Depends(admin_r
             }
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/dashboard/index.html", 
             {
                 "request": request, 
@@ -72,7 +77,7 @@ async def admin_dashboard(request: Request, current_user: dict = Depends(admin_r
     except Exception as e:
         logger.error(f"Error loading admin dashboard: {str(e)}")
         error_message = str(e)
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/dashboard/index.html", 
             {
                 "request": request, 
@@ -147,7 +152,7 @@ async def user_management(
             "has_next": page < total_pages
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/users.html", 
             {
                 "request": request, 
@@ -162,7 +167,7 @@ async def user_management(
     except Exception as e:
         logger.error(f"Error loading user management: {str(e)}")
         error_message = str(e)
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/users.html", 
             {
                 "request": request, 
@@ -205,7 +210,7 @@ async def user_detail(
             ]
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/user_detail.html", 
             {
                 "request": request, 
@@ -218,7 +223,7 @@ async def user_detail(
     except Exception as e:
         logger.error(f"Error loading user detail for {user_id}: {str(e)}")
         error_message = str(e)
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/user_detail.html", 
             {
                 "request": request, 
@@ -366,7 +371,7 @@ async def model_management(
             }
         ]
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/models.html", 
             {
                 "request": request, 
@@ -379,7 +384,7 @@ async def model_management(
     except Exception as e:
         logger.error(f"Error loading model management: {str(e)}")
         error_message = str(e)
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/models.html", 
             {
                 "request": request, 
@@ -449,7 +454,7 @@ async def api_status_page(
             {"timestamp": "2025-07-07 21:30:00", "level": "INFO", "service": "Auth", "message": "User authenticated successfully"}
         ]
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/api_status.html", 
             {
                 "request": request, 
@@ -464,7 +469,7 @@ async def api_status_page(
     except Exception as e:
         logger.error(f"Error loading API status: {str(e)}")
         error_message = str(e)
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/api_status.html", 
             {
                 "request": request, 
@@ -515,7 +520,7 @@ async def admin_settings_page(
             }
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/settings.html", 
             {
                 "request": request, 
@@ -528,7 +533,7 @@ async def admin_settings_page(
     except Exception as e:
         logger.error(f"Error loading admin settings: {str(e)}")
         error_message = str(e)
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/settings.html", 
             {
                 "request": request, 
@@ -653,7 +658,7 @@ async def features_management(
             }
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/features.html", 
             {
                 "request": request, 
@@ -666,7 +671,7 @@ async def features_management(
     except Exception as e:
         logger.error(f"Error loading features management: {str(e)}")
         error_message = str(e)
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "admin/features.html", 
             {
                 "request": request, 
@@ -685,5 +690,4 @@ async def admin_health_check(current_user: dict = Depends(admin_required)):
         "status": "healthy",
         "service": "admin",
         "timestamp": "2025-07-07T21:40:52Z",
-        "user": current_user["username"] if current_user else "unknown"
-    }
+        "user": current_user["username"] if current_user else "unknown"    }

--- a/ai-stock-platform/ui/routes/auth.py
+++ b/ai-stock-platform/ui/routes/auth.py
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).resolve().parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 # Demo user database
 DEMO_USERS = {
     "demo": {
@@ -69,7 +74,7 @@ async def login_page(request: Request, msg: str = None, next: str = None):
         if auth_cookie:
             return RedirectResponse(url="/dashboard", status_code=status.HTTP_302_FOUND)
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/login.html",
             {
                 "request": request,
@@ -160,7 +165,7 @@ async def login_post(
         
     except ValueError as e:
         logger.warning(f"Login validation failed: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/login.html",
             {
                 "request": request,
@@ -176,7 +181,7 @@ async def login_post(
     
     except Exception as e:
         logger.error(f"Login error: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/login.html",
             {
                 "request": request,
@@ -194,7 +199,7 @@ async def login_post(
 async def register_page(request: Request, msg: str = None):
     """Display registration page"""
     try:
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/register.html",
             {
                 "request": request,
@@ -265,7 +270,7 @@ async def register_post(
         
     except ValueError as e:
         logger.warning(f"Registration validation failed: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/register.html",
             {
                 "request": request,
@@ -282,7 +287,7 @@ async def register_post(
     
     except Exception as e:
         logger.error(f"Registration error: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/register.html",
             {
                 "request": request,
@@ -337,7 +342,7 @@ async def profile_page(request: Request):
         else:
             user_data = {"username": "demo", "role": "user", "full_name": "Demo User"}
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/profile.html",
             {
                 "request": request,
@@ -358,7 +363,7 @@ async def profile_page(request: Request):
 async def forgot_password_page(request: Request, msg: str = None):
     """Forgot password page"""
     try:
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/forgot_password.html",
             {
                 "request": request,
@@ -385,7 +390,7 @@ async def forgot_password_post(request: Request, email: str = Form(...)):
             raise ValueError("Please enter a valid email address")
         
         # In demo mode, just show success message
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/forgot_password.html",
             {
                 "request": request,
@@ -397,7 +402,7 @@ async def forgot_password_post(request: Request, email: str = Form(...)):
         )
         
     except ValueError as e:
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "auth/forgot_password.html",
             {
                 "request": request,

--- a/ai-stock-platform/ui/routes/dashboard.py
+++ b/ai-stock-platform/ui/routes/dashboard.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).resolve().parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 # Demo data for market summary
 DEMO_MARKET_DATA = {
     "indices": {
@@ -165,7 +170,7 @@ async def dashboard_page(request: Request):
             "cash_available": 15250.00
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "dashboard/index.html",
             {
                 "request": request,
@@ -182,7 +187,7 @@ async def dashboard_page(request: Request):
         
     except Exception as e:
         logger.error(f"Error loading dashboard: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "dashboard/index.html",
             {
                 "request": request,
@@ -241,7 +246,7 @@ async def portfolio_page(request: Request):
             ]
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "dashboard/portfolio.html",
             {
                 "request": request,
@@ -253,7 +258,7 @@ async def portfolio_page(request: Request):
         
     except Exception as e:
         logger.error(f"Error loading portfolio page: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,
@@ -291,7 +296,7 @@ async def analytics_page(request: Request):
             }
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "dashboard/analytics.html",
             {
                 "request": request,
@@ -303,7 +308,7 @@ async def analytics_page(request: Request):
         
     except Exception as e:
         logger.error(f"Error loading analytics page: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,

--- a/ai-stock-platform/ui/routes/features.py
+++ b/ai-stock-platform/ui/routes/features.py
@@ -16,6 +16,11 @@ logger = logging.getLogger(__name__)
 # Initialize templates
 templates = Jinja2Templates(directory="templates")
 
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 router = APIRouter(tags=["features"])
 
 @router.get("/features")
@@ -43,7 +48,7 @@ async def sentiment_analysis(
             # Fetch sentiment analysis data
             sentiment_data = await api_client.get_sentiment_analysis(ticker, period)
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "features/sentiment.html",
             {
                 "request": request,
@@ -56,7 +61,7 @@ async def sentiment_analysis(
         )
     except Exception as e:
         logger.error(f"Error loading sentiment analysis feature: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "features/sentiment.html",
             {
                 "request": request,
@@ -87,7 +92,7 @@ async def multi_factor_analysis(
             # Fetch multi-factor analysis data
             analysis_data = await api_client.get_multi_factor_analysis(ticker)
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "features/multi_factor.html",
             {
                 "request": request,
@@ -99,7 +104,7 @@ async def multi_factor_analysis(
         )
     except Exception as e:
         logger.error(f"Error loading multi-factor analysis feature: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "features/multi_factor.html",
             {
                 "request": request,
@@ -126,7 +131,7 @@ async def portfolio_optimization(
         # Fetch portfolio optimization data
         optimization_data = await api_client.get_portfolio_optimization(user_id=user.get("id") if user else None)
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "features/portfolio_optimization.html",
             {
                 "request": request,
@@ -137,7 +142,7 @@ async def portfolio_optimization(
         )
     except Exception as e:
         logger.error(f"Error loading portfolio optimization feature: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "features/portfolio_optimization.html",
             {
                 "request": request,
@@ -167,7 +172,7 @@ async def extended_predictions(
             # Fetch extended prediction data
             prediction_data = await api_client.get_extended_predictions(ticker, interval)
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "features/extended_predictions.html",
             {
                 "request": request,
@@ -180,7 +185,7 @@ async def extended_predictions(
         )
     except Exception as e:
         logger.error(f"Error loading extended predictions feature: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "features/extended_predictions.html",
             {
                 "request": request,
@@ -208,7 +213,7 @@ async def custom_indicators(
         # Fetch custom indicators data
         indicators_data = await api_client.get_custom_indicators(user_id=user.get("id") if user else None)
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "features/custom_indicators.html",
             {
                 "request": request,
@@ -222,7 +227,7 @@ async def custom_indicators(
         )
     except Exception as e:
         logger.error(f"Error loading custom indicators feature: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "features/custom_indicators.html",
             {
                 "request": request,

--- a/ai-stock-platform/ui/routes/forecast.py
+++ b/ai-stock-platform/ui/routes/forecast.py
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).resolve().parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 # Demo forecast data
 DEMO_PREDICTIONS = {
     "AAPL": {
@@ -124,7 +129,7 @@ async def forecast_home(request: Request):
         # Sort by confidence
         top_predictions.sort(key=lambda x: x["confidence"], reverse=True)
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "forecast.html",
             {
                 "request": request,
@@ -138,7 +143,7 @@ async def forecast_home(request: Request):
         
     except Exception as e:
         logger.error(f"Error loading forecast dashboard: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "forecast.html",
             {
                 "request": request,
@@ -202,7 +207,7 @@ async def stock_forecast(
             price = current_price * (0.95 + (i * 0.003) + (0.02 * (i % 7 - 3) / 10))
             historical_data.append({"date": date, "price": round(price, 2)})
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "forecast_detail.html",
             {
                 "request": request,
@@ -218,7 +223,7 @@ async def stock_forecast(
         
     except Exception as e:
         logger.error(f"Error loading stock forecast for {symbol}: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,
@@ -264,7 +269,7 @@ async def model_comparison(request: Request):
             }
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "model_comparison.html",
             {
                 "request": request,
@@ -276,7 +281,7 @@ async def model_comparison(request: Request):
         
     except Exception as e:
         logger.error(f"Error loading model comparison: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,

--- a/ai-stock-platform/ui/routes/home.py
+++ b/ai-stock-platform/ui/routes/home.py
@@ -6,6 +6,10 @@ from pathlib import Path
 router = APIRouter()
 templates = Jinja2Templates(directory=Path("templates"))
 
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 @router.get("/", response_class=HTMLResponse)
-async def home(request: Request):
-    return templates.TemplateResponse("home.html", {"request": request})
+async def home(request: Request):    return get_templates(request).TemplateResponse("home.html", {"request": request})

--- a/ai-stock-platform/ui/routes/market.py
+++ b/ai-stock-platform/ui/routes/market.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).resolve().parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 # Demo market data
 DEMO_MARKET_DATA = {
     "indices": {
@@ -171,7 +176,7 @@ async def market_overview(request: Request):
             }
         ]
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "market/overview.html",
             {
                 "request": request,
@@ -184,7 +189,7 @@ async def market_overview(request: Request):
         
     except Exception as e:
         logger.error(f"Error loading market overview: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "market/overview.html",
             {
                 "request": request,
@@ -253,7 +258,7 @@ async def ticker_details(
             "ma_50": stock_data["price"] * 0.96
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "market/ticker_detail.html",
             {
                 "request": request,
@@ -269,7 +274,7 @@ async def ticker_details(
         
     except Exception as e:
         logger.error(f"Error loading ticker details for {ticker}: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,
@@ -357,7 +362,7 @@ async def market_sentiment(
             "vix": 18.5
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "market/sentiment.html",
             {
                 "request": request,
@@ -370,7 +375,7 @@ async def market_sentiment(
         
     except Exception as e:
         logger.error(f"Error loading market sentiment: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,

--- a/ai-stock-platform/ui/routes/predictability.py
+++ b/ai-stock-platform/ui/routes/predictability.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).resolve().parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 # Demo predictability data
 DEMO_PREDICTABILITY_SCORES = {
     "AAPL": {
@@ -270,7 +275,7 @@ async def predictability_page(
             reverse=True
         )[:10]
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "predictability.html",
             {
                 "request": request,
@@ -288,7 +293,7 @@ async def predictability_page(
         
     except Exception as e:
         logger.error(f"Error loading predictability analysis: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "predictability.html",
             {
                 "request": request,
@@ -330,7 +335,7 @@ async def predictability_ranking_page(
         for i, stock in enumerate(ranked_stocks):
             stock["rank"] = i + 1
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "predictability_ranking.html",
             {
                 "request": request,
@@ -346,7 +351,7 @@ async def predictability_ranking_page(
         
     except Exception as e:
         logger.error(f"Error loading predictability ranking: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,
@@ -392,7 +397,7 @@ async def predictability_comparison_page(
         for i, stock in enumerate(comparison_data):
             stock["comparison_rank"] = i + 1
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "predictability_comparison.html",
             {
                 "request": request,
@@ -406,7 +411,7 @@ async def predictability_comparison_page(
         
     except Exception as e:
         logger.error(f"Error loading predictability comparison: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "predictability_comparison.html",
             {
                 "request": request,

--- a/ai-stock-platform/ui/routes/profile.py
+++ b/ai-stock-platform/ui/routes/profile.py
@@ -25,6 +25,11 @@ API_V1_URL = f"{API_URL}/api/v1"
 # Templates setup
 templates = Jinja2Templates(directory="templates")
 
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 # Router setup
 router = APIRouter(prefix="/profile", tags=["profile"])
 
@@ -91,7 +96,7 @@ async def profile_page(request: Request):
             }
         ]
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "profile.html",
             {
                 "request": request,
@@ -107,7 +112,7 @@ async def profile_page(request: Request):
         logger.error(f"Error loading profile page: {str(e)}")
         error_message = str(e)
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "profile.html",
             {
                 "request": request,
@@ -203,7 +208,7 @@ async def update_profile(
             }
         ]
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "profile.html",
             {
                 "request": request,
@@ -233,7 +238,7 @@ async def update_profile(
             "profile_image": current_user.get("profile_image", "/static/img/avatars/default.png")
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "profile.html",
             {
                 "request": request,
@@ -273,7 +278,7 @@ async def change_password(
                 "profile_image": current_user.get("profile_image", "/static/img/avatars/default.png")
             }
             
-            return templates.TemplateResponse(
+            return get_templates(request).TemplateResponse(
                 "profile.html",
                 {
                     "request": request,
@@ -323,7 +328,7 @@ async def change_password(
             }
         ]
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "profile.html",
             {
                 "request": request,
@@ -348,7 +353,7 @@ async def change_password(
             "profile_image": current_user.get("profile_image", "/static/img/avatars/default.png")
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "profile.html",
             {
                 "request": request,
@@ -375,7 +380,7 @@ async def change_password(
             "profile_image": current_user.get("profile_image", "/static/img/avatars/default.png")
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "profile.html",
             {
                 "request": request,

--- a/ai-stock-platform/ui/routes/settings.py
+++ b/ai-stock-platform/ui/routes/settings.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).resolve().parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 # Demo settings data (in-memory for demo)
 DEMO_USER_SETTINGS = {
     "general": {
@@ -74,7 +79,7 @@ async def settings_page(request: Request):
         
         logger.info("Loading settings page in demo mode")
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "settings.html",
             {
                 "request": request,
@@ -86,7 +91,7 @@ async def settings_page(request: Request):
         
     except Exception as e:
         logger.error(f"Error loading settings: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,

--- a/ai-stock-platform/ui/routes/settings_old.py
+++ b/ai-stock-platform/ui/routes/settings_old.py
@@ -21,6 +21,11 @@ API_URL = "http://quantumvestai-dev-api:8000/api/v1"
 # Templates setup
 templates = Jinja2Templates(directory="templates")
 
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 # Router setup
 router = APIRouter(prefix="/settings", tags=["settings"])
 
@@ -109,7 +114,7 @@ async def settings_page(request: Request):
             ]
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "settings.html",
             {
                 "request": request,
@@ -125,7 +130,7 @@ async def settings_page(request: Request):
         logger.error(f"Error loading settings page: {str(e)}")
         error_message = str(e)
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "settings.html",
             {
                 "request": request,
@@ -269,7 +274,7 @@ async def update_settings(
             ]
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "settings.html",
             {
                 "request": request,
@@ -324,7 +329,7 @@ async def update_settings(
             "timeframes": [{"value": "1d", "name": "1 Day"}]
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "settings.html",
             {
                 "request": request,

--- a/ai-stock-platform/ui/routes/utils.py
+++ b/ai-stock-platform/ui/routes/utils.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).resolve().parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 @router.get("/health")
 async def health_check():
     """Health check endpoint for utility service"""

--- a/ai-stock-platform/ui/routes/watchlist.py
+++ b/ai-stock-platform/ui/routes/watchlist.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).resolve().parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
+
+def get_templates(request: Request) -> Jinja2Templates:
+    """Return app-level templates if available."""
+    return getattr(request.app.state, "templates", templates)
+
 # Demo watchlist data (in-memory for demo)
 DEMO_WATCHLIST = [
     {
@@ -150,7 +155,7 @@ async def watchlist_page(request: Request, view: str = "grid"):
             "alerts_triggered": 2
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "watchlist.html",
             {
                 "request": request,
@@ -165,7 +170,7 @@ async def watchlist_page(request: Request, view: str = "grid"):
         
     except Exception as e:
         logger.error(f"Error loading watchlist: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "watchlist.html",
             {
                 "request": request,
@@ -396,7 +401,7 @@ async def portfolio_page(request: Request):
             }
         }
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "portfolio.html",
             {
                 "request": request,
@@ -409,7 +414,7 @@ async def portfolio_page(request: Request):
         
     except Exception as e:
         logger.error(f"Error loading portfolio page: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,
@@ -443,7 +448,7 @@ async def alerts_page(request: Request):
             }
         ]
         
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "alerts.html",
             {
                 "request": request,
@@ -455,12 +460,11 @@ async def alerts_page(request: Request):
         
     except Exception as e:
         logger.error(f"Error loading alerts page: {str(e)}")
-        return templates.TemplateResponse(
+        return get_templates(request).TemplateResponse(
             "error.html",
             {
                 "request": request,
                 "error": "Unable to load alerts data",
                 "page_title": "Alerts Error"
             },
-            status_code=500
-        )
+            status_code=500        )

--- a/ai-stock-platform/ui/static/js/quantum-i18n.js
+++ b/ai-stock-platform/ui/static/js/quantum-i18n.js
@@ -48,6 +48,9 @@ class QuantumI18n {
                 'nav.login': 'Login',
                 'nav.logout': 'Logout',
                 'nav.register': 'Register',
+                'nav.brand': 'QuantumVestAI',
+                'nav.forecast': 'Forecast',
+                'nav.profile': 'Profile',
 
                 // Dashboard
                 'dashboard.title': 'QuantumVestAI Dashboard',
@@ -136,6 +139,9 @@ class QuantumI18n {
                 'nav.login': 'Iniciar Sesión',
                 'nav.logout': 'Cerrar Sesión',
                 'nav.register': 'Registrarse',
+                'nav.brand': 'QuantumVestAI',
+                'nav.forecast': 'Pronóstico',
+                'nav.profile': 'Perfil',
 
                 // Dashboard
                 'dashboard.title': 'Panel de QuantumVestAI',
@@ -186,6 +192,9 @@ class QuantumI18n {
                 'nav.login': 'Connexion',
                 'nav.logout': 'Déconnexion',
                 'nav.register': 'Inscription',
+                'nav.brand': 'QuantumVestAI',
+                'nav.forecast': 'Prévisions',
+                'nav.profile': 'Profil',
 
                 // Dashboard
                 'dashboard.title': 'Tableau de Bord QuantumVestAI',
@@ -210,6 +219,9 @@ class QuantumI18n {
                 'nav.login': 'Anmelden',
                 'nav.logout': 'Abmelden',
                 'nav.register': 'Registrieren',
+                'nav.brand': 'QuantumVestAI',
+                'nav.forecast': 'Prognose',
+                'nav.profile': 'Profil',
 
                 // Dashboard
                 'dashboard.title': 'QuantumVestAI Dashboard',
@@ -234,6 +246,9 @@ class QuantumI18n {
                 'nav.login': '登录',
                 'nav.logout': '退出',
                 'nav.register': '注册',
+                'nav.brand': 'QuantumVestAI',
+                'nav.forecast': '预测',
+                'nav.profile': '个人资料',
 
                 // Dashboard
                 'dashboard.title': 'QuantumVestAI 仪表板',

--- a/ai-stock-platform/ui/templates/base.html
+++ b/ai-stock-platform/ui/templates/base.html
@@ -207,7 +207,7 @@
                             </a>
                         </li>
                         <li class="nav-item {% if '/forecast' in request.url.path %}active{% endif %}">
-                            <a href="/ticker-search" class="nav-link">
+                            <a href="/ticker-search" class="nav-link" data-i18n="nav.forecast">
                                 <i class="bi bi-graph-up"></i>
                                 <span class="nav-text">Forecast</span>
                             </a>
@@ -227,13 +227,13 @@
                         </li>
                         {% endif %}
                         <li class="nav-item {% if '/market' in request.url.path %}active{% endif %}">
-                            <a href="/market" class="nav-link">
+                            <a href="/market" class="nav-link" data-i18n="nav.market">
                                 <i class="bi bi-currency-exchange"></i>
                                 <span class="nav-text">Market</span>
                             </a>
                         </li>
                         <li class="nav-item {% if '/news' in request.url.path %}active{% endif %}">
-                            <a href="/news" class="nav-link">
+                            <a href="/news" class="nav-link" data-i18n="nav.news">
                                 <i class="bi bi-newspaper"></i>
                                 <span class="nav-text">News</span>
                             </a>
@@ -287,17 +287,17 @@
                                 <i class="bi bi-three-dots-vertical"></i>
                             </button>
                             <ul class="dropdown-menu dropdown-menu-end">
-                                <li><a class="dropdown-item" href="/profile">Profile</a></li>
-                                <li><a class="dropdown-item" href="/settings">Settings</a></li>
+                                <li><a class="dropdown-item" href="/profile" data-i18n="nav.profile">Profile</a></li>
+                                <li><a class="dropdown-item" href="/settings" data-i18n="nav.settings">Settings</a></li>
                                 <li><hr class="dropdown-divider"></li>
-                                <li><a class="dropdown-item" href="/logout">Logout</a></li>
+                                <li><a class="dropdown-item" href="/logout" data-i18n="nav.logout">Logout</a></li>
                             </ul>
                         </div>
                     </div>
                     {% else %}
                     <div class="auth-buttons">
-                        <a href="/login" class="btn btn-outline-primary btn-sm">Login</a>
-                        <a href="/register" class="btn btn-primary btn-sm">Register</a>
+                        <a href="/login" class="btn btn-outline-primary btn-sm" data-i18n="nav.login">Login</a>
+                        <a href="/register" class="btn btn-primary btn-sm" data-i18n="nav.register">Register</a>
                     </div>
                     {% endif %}
                 </div>


### PR DESCRIPTION
## Summary
- add `get_templates()` helpers so routes/controllers use app-level Jinja environment
- use `get_templates(request)` when rendering templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686d5ad063c0832a9fa84a0d83466bd5