### PR TITLE
Add websocket subscription manager and broadcasting task

### DIFF
--- a/ai-stock-platform/api/main.py
+++ b/ai-stock-platform/api/main.py
@@ -11,6 +11,7 @@ import logging
 from datetime import datetime
 import json
 import uuid
+import asyncio
 
 from fastapi import FastAPI, Request, HTTPException, status, Depends, Response
 from fastapi.responses import JSONResponse
@@ -25,6 +26,7 @@ from core.responses import create_success_response, create_error_response
 from core.validation import validate_user_login, validate_stock_symbol_param, validate_pagination_params
 from core.database import initialize_database, get_database_health, check_database_connection
 from core.exceptions import ValidationError, AuthenticationError, NotFoundError
+from routers.websocket import router as websocket_router, manager as websocket_manager
 
 # Configure logging
 logging.basicConfig(
@@ -54,6 +56,8 @@ app = FastAPI(
 
 # Will be initialized in startup event
 trending_stocks_service = None
+ws_manager = websocket_manager
+broadcast_task = None
 
 # Configure CORS
 app = configure_cors(app)
@@ -61,6 +65,9 @@ app = configure_cors(app)
 # Add enhanced middleware
 app.add_middleware(ErrorHandlerMiddleware)
 app.add_middleware(RateLimitMiddleware)
+
+# Include WebSocket routes
+app.include_router(websocket_router)
 
 # Request logging middleware
 @app.middleware("http")
@@ -440,11 +447,27 @@ async def get_stock(request: Request, symbol: str):
         raise NotFoundError(f"Stock with symbol {validated_symbol} not found")
 
 
+async def trending_stock_broadcaster() -> None:
+    """Background task that pushes trending stock updates to websocket clients."""
+    while True:
+        try:
+            if trending_stocks_service:
+                result = await trending_stocks_service.get_trending_stocks()
+                stocks = result.get("stocks", []) if isinstance(result, dict) else []
+                for stock in stocks:
+                    await ws_manager.broadcast_stock_update(stock.get("symbol", ""), stock)
+                await ws_manager.broadcast_event("top_movers", stocks)
+                await ws_manager.broadcast_event("market_overview", stocks)
+        except Exception as e:
+            logger.error(f"Error broadcasting trending stocks: {e}")
+        await asyncio.sleep(30)
+
+
 # --- STARTUP EVENT ---
 @app.on_event("startup")
 async def startup_event():
     """Enhanced startup event with database initialization"""
-    global trending_stocks_service
+    global trending_stocks_service, broadcast_task
     
     logger.info(f"Starting QuantumVestAI API v{API_VERSION}")
     logger.info(f"Environment: {API_ENV}")
@@ -462,13 +485,15 @@ async def startup_event():
             logger.info("Service validation passed - trending_stocks_service is available")
         else:
             logger.error("Service validation failed - trending_stocks_service is None")
-            
+
     except Exception as e:
         logger.error(f"Failed to initialize trending stocks service: {e}")
         import traceback
         logger.error(traceback.format_exc())
         # Set to None to ensure consistent state
         trending_stocks_service = None
+
+    broadcast_task = asyncio.create_task(trending_stock_broadcaster())
     
     # Initialize database
     if initialize_database():
@@ -488,5 +513,4 @@ async def startup_event():
 
 # Check if this script is executed directly
 if __name__ == "__main__":
-    import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    import uvicorn    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/ai-stock-platform/api/routers/websocket.py
+++ b/ai-stock-platform/api/routers/websocket.py
@@ -3,45 +3,18 @@ WebSocket Router Implementation
 Created: 2025-05-19 03:43:23
 Author: daparthi001
 """
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends
-from typing import Dict, Set, Optional
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from typing import Optional
 import logging
-import json
 from datetime import datetime
 
 from core.security import get_current_user
 from db.models.user import User
-from services.stock_service import StockService
-from core.config import settings
+from api.websocket.manager import ConnectionManager
 
 logger = logging.getLogger("api")
 
 router = APIRouter()
-
-# Store active connections
-class ConnectionManager:
-    def __init__(self):
-        self.active_connections: Dict[str, Set[WebSocket]] = {}
-    
-    async def connect(self, websocket: WebSocket, client_id: str):
-        await websocket.accept()
-        if client_id not in self.active_connections:
-            self.active_connections[client_id] = set()
-        self.active_connections[client_id].add(websocket)
-    
-    async def disconnect(self, websocket: WebSocket, client_id: str):
-        if client_id in self.active_connections:
-            self.active_connections[client_id].remove(websocket)
-            if not self.active_connections[client_id]:
-                del self.active_connections[client_id]
-    
-    async def broadcast(self, client_id: str, message: dict):
-        if client_id in self.active_connections:
-            for connection in self.active_connections[client_id]:
-                try:
-                    await connection.send_json(message)
-                except Exception as e:
-                    logger.error(f"Error broadcasting to client {client_id}: {str(e)}")
 
 manager = ConnectionManager()
 
@@ -110,17 +83,16 @@ async def websocket_endpoint(
 async def handle_subscription(websocket: WebSocket, data: dict, user: Optional[User]):
     """Handle subscription requests"""
     try:
-        # Validate subscription request
-        if "topic" not in data:
+        payload = data.get("data", data)
+        topic = payload.get("type") or payload.get("symbol") or payload.get("topic")
+        if not topic:
             await websocket.send_json({
                 "error": "Missing topic in subscription request",
                 "timestamp": datetime.utcnow().isoformat()
             })
             return
-        
-        # Add subscription logic here
-        # Example: Subscribe to stock updates
-        topic = data["topic"]
+
+        await manager.subscribe(websocket, topic)
         await websocket.send_json({
             "type": "subscribed",
             "topic": topic,
@@ -137,16 +109,16 @@ async def handle_subscription(websocket: WebSocket, data: dict, user: Optional[U
 async def handle_unsubscription(websocket: WebSocket, data: dict, user: Optional[User]):
     """Handle unsubscription requests"""
     try:
-        # Validate unsubscription request
-        if "topic" not in data:
+        payload = data.get("data", data)
+        topic = payload.get("type") or payload.get("symbol") or payload.get("topic")
+        if not topic:
             await websocket.send_json({
                 "error": "Missing topic in unsubscription request",
                 "timestamp": datetime.utcnow().isoformat()
             })
             return
-        
-        # Add unsubscription logic here
-        topic = data["topic"]
+
+        await manager.unsubscribe(websocket, topic)
         await websocket.send_json({
             "type": "unsubscribed",
             "topic": topic,
@@ -157,5 +129,4 @@ async def handle_unsubscription(websocket: WebSocket, data: dict, user: Optional
         logger.error(f"Unsubscription error: {str(e)}")
         await websocket.send_json({
             "error": "Unsubscription failed",
-            "timestamp": datetime.utcnow().isoformat()
-        })
+            "timestamp": datetime.utcnow().isoformat()        })

--- a/ai-stock-platform/api/websocket/manager.py
+++ b/ai-stock-platform/api/websocket/manager.py
@@ -4,7 +4,7 @@ Created: 2025-05-19 04:08:26
 Author: daparthi001
 """
 from fastapi import WebSocket
-from typing import Dict, Set
+from typing import Dict, Set, Any
 import asyncio
 import json
 import logging
@@ -60,8 +60,22 @@ class ConnectionManager:
                     **data
                 }
             }
-            
+
             for websocket in self.symbol_subscribers[symbol].copy():
+                try:
+                    await websocket.send_json(message)
+                except Exception as e:
+                    logger.error(f"Error sending message to client: {e}")
+                    await self.handle_disconnection(websocket)
+
+    async def broadcast_event(self, event_type: str, data: Any):
+        if event_type in self.symbol_subscribers:
+            message = {
+                "type": event_type,
+                "data": data,
+            }
+
+            for websocket in self.symbol_subscribers[event_type].copy():
                 try:
                     await websocket.send_json(message)
                 except Exception as e:
@@ -72,5 +86,4 @@ class ConnectionManager:
         # Clean up disconnected websocket
         for client_id, connections in self.active_connections.copy().items():
             if websocket in connections:
-                await self.disconnect(websocket, client_id)
-                break
+                await self.disconnect(websocket, client_id)                break


### PR DESCRIPTION
## Summary
- connect router to websocket manager
- implement subscribe/unsubscribe logic
- support generic event broadcasting
- start background task to push trending stock updates
- expose websocket routes from main app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686dea64059c832a8b2b74860f8229e9