### PR TITLE
Fix portfolio service imports and typing

### DIFF
--- a/ai-stock-platform/ui/src/services/portfolio.service.ts
+++ b/ai-stock-platform/ui/src/services/portfolio.service.ts
@@ -4,7 +4,7 @@
  * Author: daparthi001
  */
 import { api } from './api';
-import { wsService } from './websocket';
+import wsService, { WebSocketMessage } from './websocket.service';
 import authService from './auth.service';
 import { Position, Transaction, PortfolioSummary } from '../types/portfolio';
 import { Subject } from 'rxjs';
@@ -36,7 +36,7 @@ export const portfolioService = {
             wsService.subscribe('PORTFOLIO_UPDATES');
         }
         
-        wsService.onMessage().subscribe((message) => {
+        wsService.onMessage().subscribe((message: WebSocketMessage) => {
             if (message.type === 'PORTFOLIO_UPDATE') {
                 subject.next(message.data);
                 callback(message.data);
@@ -46,5 +46,4 @@ export const portfolioService = {
         return subject;
     }
 };
-
 export default portfolioService;


### PR DESCRIPTION
## Summary
- correct websocket import path in portfolio service
- add WebSocketMessage typing for messages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686dedcf920c832aacd99482d49fb538