### PR TITLE
Add websocket unit tests

### DIFF
--- a/ai-stock-platform/api/tests/test_websocket_broadcast.py
+++ b/ai-stock-platform/api/tests/test_websocket_broadcast.py
@@ -1,0 +1,33 @@
+"""Tests for WebSocket broadcasting via ConnectionManager."""
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fastapi.testclient import TestClient
+from main import app, ws_manager
+
+
+def test_websocket_broadcasts_updates():
+    client = TestClient(app)
+    with client.websocket_connect("/ws/test-client") as ws:
+        ws.send_json({"type": "subscribe", "data": {"symbol": "AAPL"}})
+        resp = ws.receive_json()
+        assert resp["type"] == "subscribed"
+        assert resp["topic"] == "AAPL"
+
+        asyncio.get_event_loop().run_until_complete(
+            ws_manager.broadcast_stock_update("AAPL", {"price": 123.45})
+        )
+        update = ws.receive_json()
+        assert update["type"] == "price_update"
+        assert update["data"]["symbol"] == "AAPL"
+        assert update["data"]["price"] == 123.45
+
+        asyncio.get_event_loop().run_until_complete(
+            ws_manager.broadcast_event("top_movers", [{"symbol": "AAPL"}])
+        )
+        event = ws.receive_json()
+        assert event["type"] == "top_movers"
+        assert event["data"][0]["symbol"] == "AAPL"

--- a/ai-stock-platform/ui/tests/realtime.test.ts
+++ b/ai-stock-platform/ui/tests/realtime.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+const RealtimeService = require('../static/js/realtime.js')
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  url: string
+  readyState: number
+  onopen: ((ev?: any) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onclose: ((ev: { code: number }) => void) | null = null
+  onerror: ((ev: any) => void) | null = null
+  sent: string[] = []
+  constructor(url: string) {
+    this.url = url
+    this.readyState = MockWebSocket.OPEN
+    MockWebSocket.instances.push(this)
+  }
+  send(data: string) {
+    this.sent.push(data)
+  }
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+    if (this.onclose) this.onclose({ code: 1006 })
+  }
+}
+MockWebSocket.OPEN = 1
+MockWebSocket.CLOSED = 3
+
+describe('RealtimeService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // @ts-ignore
+    global.WebSocket = MockWebSocket
+    MockWebSocket.instances = []
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    // @ts-ignore
+    delete global.WebSocket
+  })
+
+  it('reconnects when connection drops', () => {
+    const service = new RealtimeService('token', { maxReconnectAttempts: 1, reconnectDelay: 100 })
+    service.connect()
+    const first = MockWebSocket.instances[0]
+    first.onopen && first.onopen()
+    first.onclose && first.onclose({ code: 1006 })
+    expect(MockWebSocket.instances.length).toBe(1)
+    vi.advanceTimersByTime(100)
+    expect(MockWebSocket.instances.length).toBe(2)
+  })
+
+  it('ignores malformed JSON messages', () => {
+    const service = new RealtimeService('token')
+    const cb = vi.fn()
+    service.subscribe('price_update', cb)
+    service.connect()
+    const socket = MockWebSocket.instances[0]
+    socket.onopen && socket.onopen()
+    socket.onmessage && socket.onmessage({ data: '{ bad json' })
+    expect(cb).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add vitest suite to verify RealtimeService reconnects and ignores malformed data
- add API test ensuring broadcast messages reach subscribed websocket clients

## Testing
- `pytest -q ai-stock-platform/api/tests/test_websocket_broadcast.py ai-stock-platform/ui/tests/realtime.test.ts` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686ded1b45a8832aa44440b4e9b1aeb6