### PR TITLE
Fix WebSocket subscriptions in portfolio service

### DIFF
--- a/ai-stock-platform/ui/src/services/portfolio.service.ts
+++ b/ai-stock-platform/ui/src/services/portfolio.service.ts
@@ -32,18 +32,13 @@ export const portfolioService = {
         
         const token = authService.getToken();
         if (token) {
-            wsService.connect(token);
-            wsService.subscribe('PORTFOLIO_UPDATES');
+            wsService.subscribe('PORTFOLIO_UPDATES', (data: any) => {
+                subject.next(data);
+                callback(data);
+            });
         }
-        
-        wsService.onMessage().subscribe((message: WebSocketMessage) => {
-            if (message.type === 'PORTFOLIO_UPDATE') {
-                subject.next(message.data);
-                callback(message.data);
-            }
-        });
+
 
         return subject;
     }
-};
-export default portfolioService;
+};export default portfolioService;


### PR DESCRIPTION
## Summary
- adjust WebSocket usage in `portfolio.service.ts`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686def70c0b4832aa9283d5280e0230a