### PR TITLE
Add environment setup helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,12 @@ This document provides a comprehensive list of API and UI endpoints for the Quan
 - **GET** `/api/v1/data/industries/performance` - Get industry performance
 
 ---
-
 Feel free to reach out for further assistance or to report issues!
+## Environment Setup
+To create a virtual environment and install dependencies, run:
+```bash
+./setup_env.sh
+```
+Activate it with `source venv/bin/activate`.
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+-r ai-stock-platform/api/requirements.txt
+-r ai-stock-platform/ui/requirements.txt

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Simple environment setup script for QuantumVestAI
+set -e
+
+# Create virtual environment if not present
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+
+# Activate the virtual environment
+source venv/bin/activate
+
+# Upgrade pip
+pip install --upgrade pip
+
+# Install all dependencies
+pip install -r requirements.txt
+
+echo "Environment setup complete. Activate with 'source venv/bin/activate'"


### PR DESCRIPTION
## Summary
- add unified `requirements.txt`
- add `setup_env.sh` script for setting up a virtual environment
- document environment setup steps in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_686defa870d8832aa36b332d61dca019