### PR TITLE
Add ensemble prediction module

### DIFF
--- a/ai-stock-platform/api/ml/__init__.py
+++ b/ai-stock-platform/api/ml/__init__.py
@@ -7,18 +7,19 @@ from .models import (
     PricePredictionModel,
     SentimentAnalysisModel,
     TrendAnalysisModel,
-    PortfolioOptimizationModel
+    PortfolioOptimizationModel,
 )
 from .preprocessing import (
     DataPreprocessor,
     FeatureEngineering,
-    DataNormalization
+    DataNormalization,
 )
 from .evaluation import (
     ModelEvaluator,
     PerformanceMetrics,
-    BacktestEngine
+    BacktestEngine,
 )
+from .ensemble_model import EnsemblePredictor, linear_regression_predict
 
 __all__ = [
     "PricePredictionModel",
@@ -29,6 +30,7 @@ __all__ = [
     "FeatureEngineering",
     "DataNormalization",
     "ModelEvaluator",
-    "PerformanceMetrics",
-    "BacktestEngine"
+    "PerformanceMetrics",    "BacktestEngine",
+    "EnsemblePredictor",
+    "linear_regression_predict",
 ]

--- a/ai-stock-platform/api/ml/ensemble_model.py
+++ b/ai-stock-platform/api/ml/ensemble_model.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pandas as pd
+from typing import Callable, List
+
+class EnsemblePredictor:
+    """Combine multiple prediction models by averaging their outputs."""
+
+    def __init__(self):
+        self._models: List[Callable[[str, pd.DataFrame, int], pd.DataFrame]] = []
+
+    def add_model(self, model_fn: Callable[[str, pd.DataFrame, int], pd.DataFrame]):
+        """Register a prediction function.
+        The function must accept (ticker, historical_data, days_ahead)
+        and return a DataFrame with a 'predicted_close' column indexed by date.
+        """
+        self._models.append(model_fn)
+
+    def predict(self, ticker: str, historical_data: pd.DataFrame, days_ahead: int = 5) -> pd.DataFrame:
+        if not self._models:
+            raise ValueError("No prediction models registered")
+
+        predictions = []
+        for model_fn in self._models:
+            try:
+                df = model_fn(ticker, historical_data, days_ahead)
+                predictions.append(df['predicted_close'].values)
+            except Exception:
+                # Skip models that fail
+                continue
+
+        if not predictions:
+            raise ValueError("All prediction models failed")
+
+        avg_prediction = np.mean(predictions, axis=0)
+        dates = pd.date_range(start=historical_data.index[-1], periods=days_ahead+1)[1:]
+        return pd.DataFrame({'date': dates, 'predicted_close': avg_prediction}).set_index('date')
+
+
+def linear_regression_predict(ticker: str, historical_data: pd.DataFrame, days_ahead: int = 5) -> pd.DataFrame:
+    """Simple linear regression predictor used as a fallback model."""
+    from sklearn.linear_model import LinearRegression
+
+    df = historical_data.dropna()
+    if len(df) < 2:
+        raise ValueError("Not enough data for regression")
+
+    X = np.arange(len(df)).reshape(-1, 1)
+    y = df['adjusted_close'].values
+    model = LinearRegression().fit(X, y)
+
+    future_index = np.arange(len(df), len(df) + days_ahead).reshape(-1, 1)
+    preds = model.predict(future_index)
+    dates = pd.date_range(start=df.index[-1], periods=days_ahead+1)[1:]
+    return pd.DataFrame({'date': dates, 'predicted_close': preds}).set_index('date')

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,0 +1,24 @@
+def test_ensemble_average():
+    import pandas as pd
+    from ai_stock_platform.api.ml.ensemble_model import EnsemblePredictor
+
+    # Dummy historical data
+    dates = pd.date_range(end='2024-01-10', periods=10)
+    df = pd.DataFrame({'adjusted_close': range(10)}, index=dates)
+
+    # Dummy model returning constant + 1 predictions
+    def model_one(ticker, hist, days_ahead):
+        future_dates = pd.date_range(start=hist.index[-1], periods=days_ahead+1)[1:]
+        return pd.DataFrame({'date': future_dates, 'predicted_close': [1]*days_ahead}).set_index('date')
+
+    # Dummy model returning constant + 3 predictions
+    def model_two(ticker, hist, days_ahead):
+        future_dates = pd.date_range(start=hist.index[-1], periods=days_ahead+1)[1:]
+        return pd.DataFrame({'date': future_dates, 'predicted_close': [3]*days_ahead}).set_index('date')
+
+    ens = EnsemblePredictor()
+    ens.add_model(model_one)
+    ens.add_model(model_two)
+
+    result = ens.predict('TEST', df, days_ahead=2)
+    assert list(result['predicted_close']) == [2.0, 2.0]


### PR DESCRIPTION
## Summary
- add ensemble model for combining predictions
- expose ensemble in ML package
- test ensemble averaging logic

## Testing
- `pytest -q` *(fails: SyntaxError in repo tests)*

------
https://chatgpt.com/codex/tasks/task_e_686e03b3bf60832aa3e71dc30b060471