### PR TITLE
Fix order model and test indentation

### DIFF
--- a/ai-stock-platform/api/main.py
+++ b/ai-stock-platform/api/main.py
@@ -512,6 +512,7 @@ async def startup_event():
 
 
 # Check if this script is executed directly
-if __name__ == "__main__":    import uvicorn
+if __name__ == "__main__":
+    import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)
 

--- a/ai-stock-platform/api/models/orders.py
+++ b/ai-stock-platform/api/models/orders.py
@@ -62,6 +62,7 @@ class Order(Base):
         self.time_in_force = time_in_force
         self.price = price
         self.stop_price = stop_price
-        self.status = status        self.created_at = created_at or datetime.utcnow()        self.updated_at = self.created_at
-        self.executed_price: Optional[float] = None
-        self.executed_quantity: Optional[float] = None
+        self.status = status
+        self.created_at = created_at or datetime.utcnow()
+        self.updated_at = self.created_at
+        self.executed_price: Optional[float] = None        self.executed_quantity: Optional[float] = None

--- a/ai-stock-platform/api/tests/test_trending_stocks.py
+++ b/ai-stock-platform/api/tests/test_trending_stocks.py
@@ -196,5 +196,5 @@ if __name__ == "__main__":
         await test_data_consistency()
     
     asyncio.run(run_async_tests())
-        print("All tests passed! ✅")
+    print("All tests passed! ✅")
 


### PR DESCRIPTION
## Summary
- fix newline and indentation in order model
- correct indentation in trending stocks tests
- adjust uvicorn startup indentation

## Testing
- `pytest -q` *(fails: async plugin missing and other validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e03e43e70832ab44d89e058e9e728