### PR TITLE
Fix absolute import for authentication modules

### DIFF
--- a/ai-stock-platform/api/api_safe_setup_Version2.py
+++ b/ai-stock-platform/api/api_safe_setup_Version2.py
@@ -73,7 +73,8 @@ from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
-from ...db.session import get_db
+# Updated import to absolute path to avoid relative import issues
+from db.session import get_db
 from ...schemas.token import TokenData
 from ...schemas.user import User
 

--- a/ai-stock-platform/api/core/security/auth.py
+++ b/ai-stock-platform/api/core/security/auth.py
@@ -8,7 +8,8 @@ from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
-from ...db.session import get_db
+# Updated import to use absolute path to avoid relative import issues
+from db.session import get_db
 from ...schemas.token import TokenData
 from ...schemas.user import User
 


### PR DESCRIPTION
## Summary
- use absolute import path for db.session to prevent `ImportError: attempted relative import beyond top-level package`

## Testing
- `pytest ai-stock-platform/api/tests/integration/test_order_flow.py -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686e085cf804832aaf6b8cc9c8ac6acb