### PR TITLE
Fix user model duplication and imports

### DIFF
--- a/ai-stock-platform/api/alembic/db/models/user.py
+++ b/ai-stock-platform/api/alembic/db/models/user.py
@@ -1,63 +1,7 @@
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey, Table
-from sqlalchemy.orm import relationship
-from datetime import datetime
-import uuid
+"""Compatibility wrapper for Alembic migrations."""
 
-from db.base import Base
-
-# Association table for user watchlists
-user_watchlist = Table(
-    'user_watchlist',
-    Base.metadata,
-    Column('user_id', Integer, ForeignKey('users.id', ondelete='CASCADE')),
-    Column('stock_id', Integer, ForeignKey('stocks.id', ondelete='CASCADE')),
-    Column('notes', String),
-    Column('created_at', DateTime, default=datetime.utcnow)
-)
-
-class User(Base):
-    """User model for authentication and profile data."""
-    __tablename__ = "users"
-    
-    id = Column(Integer, primary_key=True, index=True)
-    username = Column(String, unique=True, index=True)
-    email = Column(String, unique=True, index=True)
-    hashed_password = Column(String)
-    full_name = Column(String, nullable=True)
-    
-    # Profile fields
-    avatar_url = Column(String, nullable=True)
-    bio = Column(String, nullable=True)
-    phone = Column(String, nullable=True)
-    timezone = Column(String, default="UTC")
-    
-    # Account status
-    is_active = Column(Boolean, default=True)
-    is_verified = Column(Boolean, default=False)
-    is_admin = Column(Boolean, default=False)
-    role = Column(String, default="free")  # free, basic, premium, admin
-    
-    # Subscription info
-    subscription_plan = Column(String, nullable=True)
-    subscription_status = Column(String, nullable=True)  # active, cancelled, expired
-    subscription_expiry = Column(DateTime, nullable=True)
-    
-    # Timestamps
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
-    last_login = Column(DateTime, nullable=True)
-    
-    # Verification and security
-    verification_token = Column(String, nullable=True)
-    password_reset_token = Column(String, nullable=True)
-    password_reset_expires = Column(DateTime, nullable=True)
-    
-    # API access
-    api_key = Column(String, default=lambda: str(uuid.uuid4()))
-    
-    # Relationships
-    watchlist = relationship("Stock", secondary=user_watchlist, back_populates="watched_by")
-    alerts = relationship("Alert", back_populates="user")
-    
-    def __repr__(self):
-        return f"<User {self.username}>"
+# Re-export the main application ``User`` model so that existing migration
+# scripts referencing ``alembic.db.models.user`` continue to function without
+# defining a duplicate table.
+from db.models.user import User  # noqa: F401
+__all__ = ["User"]

--- a/ai-stock-platform/api/core/config/__init__.py
+++ b/ai-stock-platform/api/core/config/__init__.py
@@ -1,7 +1,16 @@
 """
 Application configuration.
 """
-from pydantic_settings import BaseSettings
+try:
+    from pydantic_settings import BaseSettings, SettingsConfigDict
+except Exception:  # noqa: BLE001 - fallback for environments without pydantic_settings
+    from pydantic import BaseModel
+
+    class BaseSettings(BaseModel):
+        class Config:
+            extra = "ignore"
+
+    SettingsConfigDict = dict
 import os
 from functools import lru_cache
 

--- a/ai-stock-platform/api/core/security/auth.py
+++ b/ai-stock-platform/api/core/security/auth.py
@@ -1,23 +1,64 @@
-"""
-Authentication functionality.
-"""
+"""Authentication utilities and helpers."""
+
 from datetime import datetime, timedelta
 from typing import Optional
+
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
-from jose import JWTError, jwt
+from jose import JWTError
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
-# Updated import to use absolute path to avoid relative import issues
+
 from db.session import get_db
-from schemas.token import TokenData
-from schemas.user import User
+from db.models.user import User as DBUser
+from .tokens import TokenHandler
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
+
 def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a plaintext password against its hash."""
     return pwd_context.verify(plain_password, hashed_password)
 
+
 def get_password_hash(password: str) -> str:
+    """Hash a password for storage."""
     return pwd_context.hash(password)
+
+
+def get_user(db: Session, username: str) -> Optional[DBUser]:
+    """Retrieve a user by username."""
+    return db.query(DBUser).filter(DBUser.username == username).first()
+
+
+async def authenticate_user(db: Session, username: str, password: str) -> Optional[DBUser]:
+    """Authenticate a user using the database."""
+    user = get_user(db, username)
+    if not user or not verify_password(password, user.hashed_password):
+        return None
+    return user
+
+
+async def get_current_user(
+    db: Session = Depends(get_db),
+    token: str = Depends(oauth2_scheme),
+) -> DBUser:
+    """Retrieve the current user based on the provided JWT token."""
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = TokenHandler.decode_token(token)
+        username = payload.get("sub") or payload.get("username")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+
+    user = get_user(db, username)
+    if user is None:
+        raise credentials_exception
+    return user

--- a/ai-stock-platform/api/core/security/tokens.py
+++ b/ai-stock-platform/api/core/security/tokens.py
@@ -7,12 +7,14 @@ from typing import Optional
 from jose import jwt
 from pydantic import BaseModel
 
-from ..config import settings
+from ..config import get_settings
+
+config = get_settings()
 
 class TokenHandler:
-    SECRET_KEY = settings.SECRET_KEY
-    ALGORITHM = settings.ALGORITHM
-    ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
+    SECRET_KEY = config.SECRET_KEY
+    ALGORITHM = config.ALGORITHM
+    ACCESS_TOKEN_EXPIRE_MINUTES = config.ACCESS_TOKEN_EXPIRE_MINUTES
 
     @classmethod
     def create_access_token(cls, data: dict, expires_delta: Optional[timedelta] = None) -> str:
@@ -29,3 +31,13 @@ class TokenHandler:
     @classmethod
     def decode_token(cls, token: str) -> Optional[BaseModel]:
         return jwt.decode(token, cls.SECRET_KEY, algorithms=[cls.ALGORITHM])
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    """Convenience wrapper to create an access token using :class:`TokenHandler`."""
+    return TokenHandler.create_access_token(data, expires_delta)
+
+
+def decode_token(token: str) -> Optional[BaseModel]:
+    """Convenience wrapper to decode a JWT token."""
+    return TokenHandler.decode_token(token)

--- a/ai-stock-platform/api/models/user.py
+++ b/ai-stock-platform/api/models/user.py
@@ -4,33 +4,8 @@ Created: 2025-05-19 03:27:22
 Updated: 2025-05-21 15:48:25
 Author: daparthi001
 """
-from sqlalchemy import Column, Integer, String, Boolean, Float
-from sqlalchemy.orm import relationship
-from db.base_class import Base
-from db.base import TimestampMixin
-from core.security import get_password_hash
+"""Backward compatibility wrapper for the :mod:`db.models.user` model."""
 
-class User(Base, TimestampMixin):
-    """User model for authentication and profile"""
-    __tablename__ = "users"
-
-    # Authentication fields
-    id = Column(Integer, primary_key=True, index=True)
-    email = Column(String, unique=True, index=True, nullable=False)
-    username = Column(String, unique=True, index=True, nullable=False)
-    hashed_password = Column(String, nullable=False)
-    full_name = Column(String)
-    is_active = Column(Boolean, default=True)
-    is_superuser = Column(Boolean, default=False)
-
-    # Relationships
-    positions = relationship("Position", back_populates="user", cascade="all, delete-orphan")
-    transactions = relationship("Transaction", back_populates="user", cascade="all, delete-orphan")
-    watchlists = relationship("WatchList", back_populates="user", cascade="all, delete-orphan")
-
-    def set_password(self, password: str) -> None:
-        """Set encrypted password"""
-        self.hashed_password = get_password_hash(password)
-
-    def __repr__(self) -> str:
-        return f"<User {self.username}>"
+# Export the User model used across the API
+from db.models.user import User
+__all__ = ["User"]

--- a/ai-stock-platform/api/routers/auth.py
+++ b/ai-stock-platform/api/routers/auth.py
@@ -17,7 +17,8 @@ from api.core.auth.dependencies import get_current_user, get_current_active_user
 from api.core.database import get_db_session
 from api.core.config import settings
 from api.models.response import StandardResponse
-from api.models.user import User
+# Use the SQLAlchemy model from the consolidated db.models package
+from db.models.user import User
 from api.schemas.auth import Token, UserResponse
 
 # Create router WITHOUT a prefix (prefix will be added in main.py)

--- a/ai-stock-platform/api/routers/websocket.py
+++ b/ai-stock-platform/api/routers/websocket.py
@@ -10,7 +10,9 @@ from datetime import datetime
 
 from core.security import get_current_user
 from db.models.user import User
-from api.websocket.manager import ConnectionManager
+# Import the local websocket manager using a relative import to avoid package
+# resolution issues when the application is executed as a module
+from ..websocket.manager import ConnectionManager
 
 logger = logging.getLogger("api")
 

--- a/ai-stock-platform/api/schemas/__init__.py
+++ b/ai-stock-platform/api/schemas/__init__.py
@@ -1,14 +1,13 @@
 """
 Schemas package initialization.
 """
-from .user import User, UserCreate, UserBase
+from .user import User, UserCreate, UserBase, UserUpdate, UserProfile
 from .token import Token, TokenData
 from .stock import *
-from .prediction import *
 from .watchlist import *
 from .whitepaper import *
 
 __all__ = [
-    "User", "UserCreate", "UserBase",
+    "User", "UserCreate", "UserBase", "UserUpdate", "UserProfile",
     "Token", "TokenData"
 ]

--- a/ai-stock-platform/api/schemas/token.py
+++ b/ai-stock-platform/api/schemas/token.py
@@ -1,0 +1,9 @@
+from typing import Optional
+from pydantic import BaseModel
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+class TokenData(BaseModel):
+    username: Optional[str] = None

--- a/ai-stock-platform/api/schemas/user.py
+++ b/ai-stock-platform/api/schemas/user.py
@@ -1,0 +1,30 @@
+from typing import Optional
+from pydantic import BaseModel, EmailStr
+
+class UserBase(BaseModel):
+    """Base user fields shared across schemas."""
+    username: str
+    email: EmailStr
+    full_name: Optional[str] = None
+    is_active: Optional[bool] = True
+
+    class Config:
+        orm_mode = True
+
+class UserCreate(UserBase):
+    """Schema for user creation."""
+    password: str
+
+class UserUpdate(BaseModel):
+    """Schema for updating user information."""
+    username: Optional[str] = None
+    email: Optional[EmailStr] = None
+    full_name: Optional[str] = None
+    is_active: Optional[bool] = None
+
+class UserProfile(UserBase):
+    """Public user profile schema."""
+    id: int
+
+# Backwards compatible alias used in some modules
+User = UserProfile

--- a/ai-stock-platform/ui/main.py
+++ b/ai-stock-platform/ui/main.py
@@ -117,33 +117,6 @@ API_URL = os.environ.get("API_URL", "http://localhost:8000")
 API_V1_URL = f"{API_URL}/api/v1"
 
 # Enhanced template filters and utilities setup
-try:
-    # Import and register comprehensive template filters
-    from utils.template_filters import register_filters, validate_template_filters, get_template_filter_status
-    
-    # Register all template filters
-    filter_registration_success = register_filters(app)
-    
-    if filter_registration_success:
-        logger.info("✓ Comprehensive template filters registered successfully")
-        
-        # Validate that critical filters are working
-        validation_success = validate_template_filters(app)
-        if validation_success:
-            logger.info("✓ Template filter validation passed")
-        else:
-            logger.warning("⚠ Template filter validation failed, but registration succeeded")
-    else:
-        logger.error("✗ Template filter registration failed, adding fallback filters")
-        # Add minimal fallback filters if comprehensive registration fails
-        _add_fallback_filters(templates)
-
-except ImportError as e:
-    logger.error(f"Could not import template filters module: {e}")
-    _add_fallback_filters(templates)
-except Exception as e:
-    logger.error(f"Error setting up template filters: {e}")
-    _add_fallback_filters(templates)
 
 def _add_fallback_filters(templates):
     """Add minimal fallback filters if comprehensive system fails"""
@@ -247,6 +220,35 @@ def _add_fallback_filters(templates):
     templates.env.filters["format_number"] = format_number
     
     logger.info("✓ Fallback template filters registered")
+
+
+try:
+    # Import and register comprehensive template filters
+    from utils.template_filters import register_filters, validate_template_filters, get_template_filter_status
+
+    # Register all template filters
+    filter_registration_success = register_filters(app)
+
+    if filter_registration_success:
+        logger.info("✓ Comprehensive template filters registered successfully")
+
+        # Validate that critical filters are working
+        validation_success = validate_template_filters(app)
+        if validation_success:
+            logger.info("✓ Template filter validation passed")
+        else:
+            logger.warning("⚠ Template filter validation failed, but registration succeeded")
+    else:
+        logger.error("✗ Template filter registration failed, adding fallback filters")
+        # Add minimal fallback filters if comprehensive registration fails
+        _add_fallback_filters(templates)
+
+except ImportError as e:
+    logger.error(f"Could not import template filters module: {e}")
+    _add_fallback_filters(templates)
+except Exception as e:
+    logger.error(f"Error setting up template filters: {e}")
+    _add_fallback_filters(templates)
 
 # Add globals for template context
 templates.env.globals["now"] = datetime.utcnow

--- a/ai-stock-platform/ui/routes/__init__.py
+++ b/ai-stock-platform/ui/routes/__init__.py
@@ -4,47 +4,47 @@
 
 # Import and expose all routers for easier imports elsewhere
 try:
-    from routes.auth import router as auth_router
+    from .auth import router as auth_router
 except ImportError:
     auth_router = None
 
 try:
-    from routes.dashboard import router as dashboard_router
+    from .dashboard import router as dashboard_router
 except ImportError:
     dashboard_router = None
 
 try:
-    from routes.forecast import router as forecast_router
+    from .forecast import router as forecast_router
 except ImportError:
     forecast_router = None
 
 try:
-    from routes.market import router as market_router
+    from .market import router as market_router
 except ImportError:
     market_router = None
 
 try:
-    from routes.watchlist import router as watchlist_router
+    from .watchlist import router as watchlist_router
 except ImportError:
     watchlist_router = None
 
 try:
-    from routes.predictability import router as predictability_router
+    from .predictability import router as predictability_router
 except ImportError:
     predictability_router = None
 
 try:
-    from routes.settings import router as settings_router
+    from .settings import router as settings_router
 except ImportError:
     settings_router = None
 
 try:
-    from routes.api_proxy import router as api_proxy_router
+    from .api_proxy import router as api_proxy_router
 except ImportError:
     api_proxy_router = None
 
 try:
-    from routes.utils import router as utils_router
+    from .utils import router as utils_router
 except ImportError:
     utils_router = None
 
@@ -60,5 +60,4 @@ all_routers = [
         settings_router,
         api_proxy_router,
         utils_router
-    ] if router is not None
-]
+    ] if router is not None]

--- a/ai-stock-platform/ui/services/cache_service.py
+++ b/ai-stock-platform/ui/services/cache_service.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 from typing import Any, Callable, Dict, Optional, List
 
-from services.api_client import APIClient
+from .api_client import APIClient
 
 # Cache with a 5-minute TTL and max of 1000 items
 cache = TTLCache(maxsize=1000, ttl=300)

--- a/ai-stock-platform/ui/tests/conftest.py
+++ b/ai-stock-platform/ui/tests/conftest.py
@@ -4,10 +4,11 @@ Pytest configuration and fixtures for QuantumVestAI UI tests.
 import os
 import sys
 import pytest
-ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 sys.path.append(ROOT)
 sys.path.append(os.path.join(ROOT, "ai-stock-platform"))
 sys.path.append(os.path.join(ROOT, "ai-stock-platform", "api"))
+sys.path.append(os.path.join(ROOT, "ai-stock-platform", "ui"))
 pytest.importorskip("httpx")
 from fastapi import FastAPI
 from fastapi.testclient import TestClient

--- a/ai-stock-platform/ui/ui/routes/__init__.py
+++ b/ai-stock-platform/ui/ui/routes/__init__.py
@@ -1,16 +1,10 @@
+"""Compatibility layer for legacy imports.
+
+This module re-exports objects from :mod:`ui.routes` so that code importing
+``ui.routes.*`` continues to function.
 """
-UI Routes Module - Import Compatibility Layer
-
-This module provides backward compatibility for code importing from ui.routes.
-New code should import directly from routes.
-"""
-
-# Import all routes directly to make them available through ui.routes
-from routes.auth import *
-from routes.admin import *
-from routes.forecast import *
-from routes.predictability import *
-from routes.watchlist import *
-    pass
-
-__all__ = []
+from ...routes.auth import *  # noqa: F401,F403
+from ...routes.admin import *  # noqa: F401,F403
+from ...routes.forecast import *  # noqa: F401,F403
+from ...routes.predictability import *  # noqa: F401,F403
+from ...routes.watchlist import *  # noqa: F401,F403

--- a/ai-stock-platform/ui/ui/routes/auth.py
+++ b/ai-stock-platform/ui/ui/routes/auth.py
@@ -5,8 +5,7 @@ This module provides backward compatibility for code importing from ui.routes.au
 New code should import directly from routes.auth.
 """
 
-# Import directly from the module to avoid circular imports
+# Import directly from the real routes package
 API_URL = "http://quantumvestai-dev-api:8000/api/v1"
-from routes.auth import router
-
+from ...routes.auth import router
 __all__ = ['router']

--- a/pydantic_settings/__init__.py
+++ b/pydantic_settings/__init__.py
@@ -1,6 +1,14 @@
-from pydantic import BaseSettings
+"""Minimal stub for the :mod:`pydantic_settings` package used in tests."""
 
-# Simple stub of pydantic-settings for tests
-SettingsConfigDict = dict
+try:  # pragma: no cover - prefer the real package if available
+    from pydantic_settings import BaseSettings, SettingsConfigDict  # type: ignore
+except Exception:  # pragma: no cover - fallback implementation
+    from pydantic import BaseModel
+
+    class BaseSettings(BaseModel):
+        class Config:
+            extra = "ignore"
+
+    SettingsConfigDict = dict
 
 __all__ = ["BaseSettings", "SettingsConfigDict"]


### PR DESCRIPTION
## Summary
- avoid duplicate table definitions by re-exporting the User model for alembic and API packages
- fix websocket router import path
- reference db user model directly in auth router
- implement robust fallback in `pydantic_settings` stub

## Testing
- `pytest -q` *(fails: InvalidRequestError: Table 'users' is already defined)*

------
https://chatgpt.com/codex/tasks/task_e_686e0f336ebc832ab8847dde617bfabc