### PR TITLE
Fix indentation in websocket manager

### DIFF
--- a/ai-stock-platform/api/websocket/manager.py
+++ b/ai-stock-platform/api/websocket/manager.py
@@ -83,7 +83,7 @@ class ConnectionManager:
                     await self.handle_disconnection(websocket)
                     
     async def handle_disconnection(self, websocket: WebSocket):
-        # Clean up disconnected websocket
-        for client_id, connections in self.active_connections.copy().items():
-            if websocket in connections:                await self.disconnect(websocket, client_id)
+        """Remove a websocket from all tracking structures."""
+        for client_id, connections in self.active_connections.copy().items():            if websocket in connections:
+                await self.disconnect(websocket, client_id)
                 break


### PR DESCRIPTION
## Summary
- fix indentation error in `websocket/manager.py`

## Testing
- `pytest -q` *(fails: 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ec50d780c832aaff6dec0b6d150ef