### PR TITLE
Fix indentation in websocket manager

### DIFF
--- a/ai-stock-platform/api/websocket/__init__.py
+++ b/ai-stock-platform/api/websocket/__init__.py
@@ -3,21 +3,14 @@ WebSocket Package
 Created: 2025-05-20 04:36:10
 Author: daparthi001
 """
-from .manager import WebSocketManager
-from .connection import WebSocketConnection
-from .messages import WSMessage, WSResponse
-from .handlers import (
-    MarketDataHandler,
-    PortfolioHandler,
-    AlertHandler
-)
+"""Simplified exports for the local WebSocket utilities."""
+
+# Only the connection manager exists in this module hierarchy. The
+# previous implementation attempted to expose several classes that are not
+# actually present in the repository which caused import errors when the
+# package was initialised.
+
+from .manager import ConnectionManager
 
 __all__ = [
-    "WebSocketManager",
-    "WebSocketConnection",
-    "WSMessage",
-    "WSResponse",
-    "MarketDataHandler",
-    "PortfolioHandler",
-    "AlertHandler"
-]
+    "ConnectionManager",]

--- a/ai-stock-platform/api/websocket/manager.py
+++ b/ai-stock-platform/api/websocket/manager.py
@@ -83,7 +83,7 @@ class ConnectionManager:
                     await self.handle_disconnection(websocket)
                     
     async def handle_disconnection(self, websocket: WebSocket):
-        # Clean up disconnected websocket
-        for client_id, connections in self.active_connections.copy().items():
-            if websocket in connections:                await self.disconnect(websocket, client_id)
+        """Remove a websocket from all tracking structures."""
+        for client_id, connections in self.active_connections.copy().items():            if websocket in connections:
+                await self.disconnect(websocket, client_id)
                 break


### PR DESCRIPTION
## Summary
- fix indentation error in `websocket/manager.py`
- streamline `websocket/__init__` to avoid missing imports

## Testing
- `pytest -q` *(fails: 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ec50d780c832aaff6dec0b6d150ef