### PR TITLE
Fix UI import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,14 @@ To create a virtual environment and install dependencies, run:
 ```
 Activate it with `source venv/bin/activate`.
 
+## External API Key
+To fetch real-time stock market data you must set the `ALPHA_VANTAGE_API_KEY`
+environment variable. Sign up for a free key at
+[Alpha Vantage](https://www.alphavantage.co/support/#api-key) and export it
+before starting the API server:
+```bash
+export ALPHA_VANTAGE_API_KEY=your_key_here
+```
+Without this key the trending stock endpoints will not return current data.
+
 

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+import sys
+
+_pkg_path = Path(__file__).resolve().parent.parent / 'ai-stock-platform' / 'ui'
+__path__ = [str(_pkg_path)]
+if str(_pkg_path) not in sys.path:
+    sys.path.insert(0, str(_pkg_path))


### PR DESCRIPTION
## Summary
- document how to set `ALPHA_VANTAGE_API_KEY` for real-time quotes
- add `ui` package wrapper so tests can import UI modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.middleware')*

------
https://chatgpt.com/codex/tasks/task_e_686ee82d7f7c832aadb327a87143ddc0