### PR TITLE
Fix API URL defaults

### DIFF
--- a/ai-stock-platform/ui/auth/dependencies.py
+++ b/ai-stock-platform/ui/auth/dependencies.py
@@ -27,7 +27,7 @@ JWT_ALGORITHM = "HS256"
 TOKEN_EXPIRE_MINUTES = int(os.getenv("TOKEN_EXPIRE_MINUTES", "60"))
 
 # API Configuration
-API_URL = os.getenv("API_URL", "http://quantumvestai-dev-api:8000/api/v1")
+API_URL = os.getenv("API_URL", "http://quantumvestai-dev-api:8000")
 
 # get_current_user function removed as per requirements
 

--- a/ai-stock-platform/ui/config/auth.dependencies.py
+++ b/ai-stock-platform/ui/config/auth.dependencies.py
@@ -17,7 +17,7 @@ JWT_ALGORITHM = "HS256"
 TOKEN_EXPIRE_MINUTES = int(os.getenv("TOKEN_EXPIRE_MINUTES", "60"))
 
 # API Configuration
-API_URL = os.getenv("API_URL", "http://quantumvestai-dev-api:8000/api/v1")
+API_URL = os.getenv("API_URL", "http://quantumvestai-dev-api:8000")
 
 
 # get_current_user function removed as per requirements

--- a/ai-stock-platform/ui/config/controllers.dashboard_controller.py
+++ b/ai-stock-platform/ui/config/controllers.dashboard_controller.py
@@ -14,7 +14,7 @@ import os
 from datetime import datetime, timedelta
 from metrics import http_requests_total, http_request_duration_seconds
 
-API_URL = "http://quantumvestai-dev-api:8000/api/v1"
+API_URL = "http://quantumvestai-dev-api:8000"
 # Set up logging
 logger = logging.getLogger(__name__)
 

--- a/ai-stock-platform/ui/controllers/auth_controller.py
+++ b/ai-stock-platform/ui/controllers/auth_controller.py
@@ -23,7 +23,7 @@ def get_templates(request: Request) -> Jinja2Templates:
     return getattr(request.app.state, "templates", templates)
 
 # Get API URL from environment or use default
-API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000/api/v1")
+API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000")
 API_V1_URL = f"{API_URL}/api/v1"
 
 def format_error_message(error_data):

--- a/ai-stock-platform/ui/controllers/dashboard_controller.py
+++ b/ai-stock-platform/ui/controllers/dashboard_controller.py
@@ -15,7 +15,7 @@ import json
 import os
 from datetime import datetime, timedelta
 
-API_URL = "http://quantumvestai-dev-api:8000/api/v1"
+API_URL = "http://quantumvestai-dev-api:8000"
 # Auth dependencies removed as per requirements
 
 # Define mock metrics classes that do nothing
@@ -156,7 +156,7 @@ async def dashboard(
         
         if dashboard_data is None:
             # Check if app.state has settings attribute
-            api_url_base = getattr(request.app.state, 'settings', {}).get('API_URL', os.getenv('API_URL', 'http://quantumvestai-dev-api:8000/api/v1'))
+            api_url_base = getattr(request.app.state, 'settings', {}).get('API_URL', os.getenv('API_URL', 'http://quantumvestai-dev-api:8000'))
             
             try:
                 # Get portfolio data from API using centralized HTTP client

--- a/ai-stock-platform/ui/controllers/feature_controller.py
+++ b/ai-stock-platform/ui/controllers/feature_controller.py
@@ -24,7 +24,7 @@ def get_templates(request: Request) -> Jinja2Templates:
     return getattr(request.app.state, "templates", templates)
 
 # Get API URL from environment or use default
-API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000/api/v1")
+API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000")
 API_V1_URL = f"{API_URL}/api/v1"
 
 @router.get("/advanced", response_class=HTMLResponse)

--- a/ai-stock-platform/ui/controllers/forecast_controller.py
+++ b/ai-stock-platform/ui/controllers/forecast_controller.py
@@ -23,7 +23,7 @@ def get_templates(request: Request) -> Jinja2Templates:
 logger = logging.getLogger(__name__)
 
 # Get API URL from environment
-API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000/api/v1")
+API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000")
 API_V1_URL = f"{API_URL}/api/v1"
 
 @router.get("/", response_class=HTMLResponse)

--- a/ai-stock-platform/ui/controllers/market_controller.py
+++ b/ai-stock-platform/ui/controllers/market_controller.py
@@ -13,7 +13,7 @@ import time
 import os
 from datetime import datetime, timedelta
 from core.http_client import safe_get_json
-API_URL = "http://quantumvestai-dev-api:8000/api/v1"
+API_URL = "http://quantumvestai-dev-api:8000"
 # Import dependencies with fallback
 try:
     from auth.dependencies import get_current_user, get_optional_current_user
@@ -95,7 +95,7 @@ async def market_overview(
     """
     try:
         # Get API URL from app state or environment
-        api_url_base = getattr(request.app.state, 'settings', {}).get('API_URL', os.getenv('API_URL', 'http://quantumvestai-dev-api:8000/api/v1'))
+        api_url_base = getattr(request.app.state, 'settings', {}).get('API_URL', os.getenv('API_URL', 'http://quantumvestai-dev-api:8000'))
         
         # Create cache key for demo mode
         cache_key = f"market_overview_demo"
@@ -201,7 +201,7 @@ async def stock_details(
     """
     try:
         # Get API URL from app state or environment
-        api_url_base = getattr(request.app.state, 'settings', {}).get('API_URL', os.getenv('API_URL', 'http://quantumvestai-dev-api:8000/api/v1'))
+        api_url_base = getattr(request.app.state, 'settings', {}).get('API_URL', os.getenv('API_URL', 'http://quantumvestai-dev-api:8000'))
         
         # Create cache key for demo mode
         cache_key = f"stock_details_{symbol.upper()}_demo"
@@ -317,7 +317,7 @@ async def search_stocks(
     """
     try:
         # Get API URL from app state or environment
-        api_url_base = getattr(request.app.state, 'settings', {}).get('API_URL', os.getenv('API_URL', 'http://quantumvestai-dev-api:8000/api/v1'))
+        api_url_base = getattr(request.app.state, 'settings', {}).get('API_URL', os.getenv('API_URL', 'http://quantumvestai-dev-api:8000'))
         
         # Create cache key for demo mode
         cache_key = f"stock_search_{query.lower()}_demo"

--- a/ai-stock-platform/ui/controllers/news_controller.py
+++ b/ai-stock-platform/ui/controllers/news_controller.py
@@ -23,7 +23,7 @@ def get_templates(request: Request) -> Jinja2Templates:
 logger = logging.getLogger("quantumvestai.news_controller")
 
 # Get API URL from environment or use default
-API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000/api/v1")
+API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000")
 API_V1_URL = f"{API_URL}/api/v1"
 
 # Demo news data

--- a/ai-stock-platform/ui/controllers/profile_controller.py
+++ b/ai-stock-platform/ui/controllers/profile_controller.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Optional
 from services.api_client import APIClient
 from core.config.settings import settings
-API_URL = "http://quantumvestai-dev-api:8000/api/v1"
+API_URL = "http://quantumvestai-dev-api:8000"
 
 # Setup router and templates
 router = APIRouter()

--- a/ai-stock-platform/ui/controllers/watchlist_controller.py
+++ b/ai-stock-platform/ui/controllers/watchlist_controller.py
@@ -20,7 +20,7 @@ def get_templates(request: Request) -> Jinja2Templates:
 logger = logging.getLogger("quantumvestai.watchlist_controller")
 
 # Get API URL from environment or use default
-API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000/api/v1")
+API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000")
 API_V1_URL = f"{API_URL}/api/v1"
 
 @router.get("/watchlist", response_class=HTMLResponse)

--- a/ai-stock-platform/ui/dependencies/__init__.py
+++ b/ai-stock-platform/ui/dependencies/__init__.py
@@ -1,6 +1,6 @@
 # This file makes the dependencies directory a proper Python package.
 # It allows for easier imports of dependency components throughout the application.
-API_URL = "http://quantumvestai-dev-api:8000/api/v1"
+API_URL = "http://quantumvestai-dev-api:8000"
 from ui.dependencies.common import (
     get_api_client,
     get_template_context,
@@ -8,5 +8,4 @@ from ui.dependencies.common import (
     common_query_params
 )
 
-# This allows importing these dependencies directly from the package
-# For example: from ui.dependencies import get_api_client, pagination_params
+# This allows importing these dependencies directly from the package# For example: from ui.dependencies import get_api_client, pagination_params

--- a/ai-stock-platform/ui/dependencies/common.py
+++ b/ai-stock-platform/ui/dependencies/common.py
@@ -6,7 +6,7 @@ from core.config.constants import (
     DEFAULT_PAGE_SIZE,
     MAX_PAGE_SIZE
 )
-API_URL = "http://quantumvestai-dev-api:8000/api/v1"
+API_URL = "http://quantumvestai-dev-api:8000"
 async def get_api_client(request: Request) -> APIClient:
     """
     Dependency to get API client without authentication (demo mode)

--- a/ai-stock-platform/ui/docker-compose.yml
+++ b/ai-stock-platform/ui/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       - PORT=3000
       - DEBUG=true
-      - API_BASE_URL=http://quantumvestai-dev-api:8000/api/v1
+      - API_BASE_URL=http://quantumvestai-dev-api:8000
       - ENVIRONMENT=development
     volumes:
       - ./ui:/app/ui

--- a/ai-stock-platform/ui/routes/api_proxy.py
+++ b/ai-stock-platform/ui/routes/api_proxy.py
@@ -14,7 +14,7 @@ router = APIRouter(prefix="/api/v1", tags=["api"])
 logger = logging.getLogger("quantumvestai.api_proxy")
 
 # Get API URL from environment or use default
-API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000/api/v1")
+API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000")
 API_V1_URL = f"{API_URL}/api/v1"
 
 @router.get("/ticker-search")

--- a/ai-stock-platform/ui/routes/direct_routes.py
+++ b/ai-stock-platform/ui/routes/direct_routes.py
@@ -21,7 +21,7 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 # Get API URL from environment or use default
-API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000/api/v1")
+API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000")
 API_V1_URL = f"{API_URL}/api/v1"
 
 @router.post("/login")

--- a/ai-stock-platform/ui/routes/profile.py
+++ b/ai-stock-platform/ui/routes/profile.py
@@ -19,7 +19,7 @@ from datetime import datetime
 logger = logging.getLogger(__name__)
 
 # API Configuration
-API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000/api/v1")
+API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000")
 API_V1_URL = f"{API_URL}/api/v1"
 
 # Templates setup

--- a/ai-stock-platform/ui/routes/settings_old.py
+++ b/ai-stock-platform/ui/routes/settings_old.py
@@ -16,7 +16,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # API Configuration
-API_URL = "http://quantumvestai-dev-api:8000/api/v1"
+API_URL = "http://quantumvestai-dev-api:8000"
 
 # Templates setup
 templates = Jinja2Templates(directory="templates")

--- a/ai-stock-platform/ui/routes/utils_old.py
+++ b/ai-stock-platform/ui/routes/utils_old.py
@@ -3,7 +3,7 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 from typing import Optional, List, Dict, Any
 from ui.services.yahoo_finance import YahooFinanceService
-API_URL = "http://quantumvestai-dev-api:8000/api/v1"
+API_URL = "http://quantumvestai-dev-api:8000"
 
 # Router setup for utility endpoints
 router = APIRouter(prefix="/utils", tags=["utilities"])

--- a/ai-stock-platform/ui/templates/auth/dependencies.py
+++ b/ai-stock-platform/ui/templates/auth/dependencies.py
@@ -19,7 +19,7 @@ JWT_ALGORITHM = "HS256"
 TOKEN_EXPIRE_MINUTES = int(os.getenv("TOKEN_EXPIRE_MINUTES", "60"))
 
 # API Configuration
-API_URL = os.getenv("API_URL", "http://quantumvestai-dev-api:8000/api/v1")
+API_URL = os.getenv("API_URL", "http://quantumvestai-dev-api:8000")
 
 
 # get_current_user function removed as per requirements

--- a/ai-stock-platform/ui/templates/controllers/dashboard_controller.py
+++ b/ai-stock-platform/ui/templates/controllers/dashboard_controller.py
@@ -13,7 +13,7 @@ import json
 import os
 from datetime import datetime, timedelta
 from metrics import http_requests_total, http_request_duration_seconds
-API_URL = "http://quantumvestai-dev-api:8000/api/v1"
+API_URL = "http://quantumvestai-dev-api:8000"
 # Set up logging
 logger = logging.getLogger(__name__)
 

--- a/ai-stock-platform/ui/ui/routes/auth.py
+++ b/ai-stock-platform/ui/ui/routes/auth.py
@@ -6,6 +6,5 @@ New code should import directly from routes.auth.
 """
 
 # Import directly from the real routes package
-API_URL = "http://quantumvestai-dev-api:8000/api/v1"
-from ...routes.auth import router
-__all__ = ['router']
+API_URL = "http://quantumvestai-dev-api:8000"
+from ...routes.auth import router__all__ = ['router']


### PR DESCRIPTION
## Summary
- fix API_BASE_URL in docker-compose to avoid duplicate prefixes
- normalize API_URL defaults in UI dependencies and controllers

## Testing
- `pytest -q tests/test_basic.py tests/test_config.py tests/test_ensemble.py` *(fails: ModuleNotFoundError, pydantic ValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_686eed7e8e58832a8305ed9ad7431f5b