### PR TITLE
Enable model predictions in UI

### DIFF
--- a/ai-stock-platform/ui/src/components/StockDetails.tsx
+++ b/ai-stock-platform/ui/src/components/StockDetails.tsx
@@ -7,6 +7,7 @@ import { Container, Row, Col, Card, Button, Spinner, Alert, Badge, Tab, Tabs } f
 import { useParams, Link } from 'react-router-dom';
 import { ROUTES } from '../config/constants';
 import apiService, { Stock } from '../services/api-service';
+import { mlService, PredictionResult } from '../services/ml-service';
 
 const StockDetails: React.FC = () => {
   const { symbol } = useParams<{ symbol: string }>();
@@ -14,6 +15,7 @@ const StockDetails: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<string>('overview');
+  const [prediction, setPrediction] = useState<PredictionResult | null>(null);
 
   useEffect(() => {
     if (symbol) {
@@ -27,6 +29,8 @@ const StockDetails: React.FC = () => {
       setError(null);
       const data = await apiService.getStockDetails(symbol);
       setStock(data);
+      setPrediction(null);
+      await fetchPrediction(symbol);
     } catch (err) {
       console.error('Error fetching stock details:', err);
       setError('Failed to load stock details. Please try again.');
@@ -45,6 +49,15 @@ const StockDetails: React.FC = () => {
       });
     } finally {
       setLoading(false);
+    }
+  };
+
+  const fetchPrediction = async (sym: string) => {
+    try {
+      const result = await mlService.getPrediction(sym, 'next_day');
+      setPrediction(result);
+    } catch (err) {
+      console.error('Error fetching prediction:', err);
     }
   };
 
@@ -119,13 +132,24 @@ const StockDetails: React.FC = () => {
               <h6>52 Week Range</h6>
               <div>{formatCurrency(stock['52_week_low'] || 0)} - {formatCurrency(stock['52_week_high'] || 0)}</div>
             </Col>
-            <Col md={3} className="text-center">
-              <h6>Market Cap</h6>
-              <div>{stock.market_cap}</div>
+          <Col md={3} className="text-center">
+            <h6>Market Cap</h6>
+            <div>{stock.market_cap}</div>
+          </Col>
+        </Row>
+        {prediction && (
+          <Row className="mt-3">
+            <Col className="text-center">
+              <h6>Next Day Prediction</h6>
+              <h4>{formatCurrency(prediction.predicted_price)}</h4>
+              <div className="text-muted small">
+                Model: {prediction.model_version} | Confidence: {(prediction.confidence * 100).toFixed(1)}%
+              </div>
             </Col>
           </Row>
-        </Card.Body>
-      </Card>
+        )}
+      </Card.Body>
+    </Card>
 
       {/* Detailed Information Tabs */}
       <Tabs

--- a/ai-stock-platform/ui/src/components/StockFlowVisualization.tsx
+++ b/ai-stock-platform/ui/src/components/StockFlowVisualization.tsx
@@ -23,6 +23,7 @@ import {
 } from 'chart.js';
 import { motion, AnimatePresence } from 'framer-motion';
 import wsService from '../services/websocket.service';
+import { mlService } from '../services/ml-service';
 
 // Register ChartJS components
 ChartJS.register(
@@ -69,6 +70,7 @@ const StockFlowVisualization: React.FC<FlowVisualizationProps> = ({
   const [selectedTimeframe, setSelectedTimeframe] = useState<'1m' | '5m' | '15m' | '1h' | '1d'>('5m');
   const [loading, setLoading] = useState(true);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [modelPredictions, setModelPredictions] = useState<Record<string, number>>({});
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -106,19 +108,40 @@ const StockFlowVisualization: React.FC<FlowVisualizationProps> = ({
         flow,
         timestamp: new Date().toISOString(),
         sector: ['Technology', 'Healthcare', 'Finance', 'Energy'][Math.floor(Math.random() * 4)],
-        prediction: showPredictions ? basePrice + change + (Math.random() - 0.5) * 20 : undefined
+        prediction: showPredictions ? modelPredictions[symbol] ?? basePrice + change : undefined
       };
     });
+  }, [stocks, showPredictions, modelPredictions]);
+
+  const fetchPredictions = useCallback(async () => {
+    if (!showPredictions) {
+      setModelPredictions({});
+      return;
+    }
+    try {
+      const results = await Promise.all(
+        stocks.map(s => mlService.getPrediction(s, 'next_day').catch(() => null))
+      );
+      const map: Record<string, number> = {};
+      results.forEach(res => {
+        if (res) {
+          map[res.symbol] = res.predicted_price;
+        }
+      });
+      setModelPredictions(map);
+    } catch (err) {
+      console.error('Error fetching predictions', err);
+    }
   }, [stocks, showPredictions]);
 
-  const updateFlowData = useCallback(() => {
+  const updateFlowData = useCallback(async () => {
     setLoading(true);
-    // Simulate API call delay
+    await fetchPredictions();
     setTimeout(() => {
       setFlowData(generateMockFlowData());
       setLoading(false);
     }, 500);
-  }, [generateMockFlowData]);
+  }, [generateMockFlowData, fetchPredictions]);
 
   const togglePlayPause = () => {
     setIsPlaying(!isPlaying);


### PR DESCRIPTION
## Summary
- fetch prediction data in stock details view and display next-day forecast
- integrate ML predictions into stock flow visualization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: db.models.forecast)*

------
https://chatgpt.com/codex/tasks/task_e_686ef6763b10832abda52a308d7bd13f