### PR TITLE
Add basic AI agent manager

### DIFF
--- a/ai-stock-platform/api/ml/__init__.py
+++ b/ai-stock-platform/api/ml/__init__.py
@@ -20,6 +20,7 @@ from .evaluation import (
     BacktestEngine,
 )
 from .ensemble_model import EnsemblePredictor, linear_regression_predict
+from .agent_system import AIAgent, AgentManager
 
 __all__ = [
     "PricePredictionModel",
@@ -33,4 +34,6 @@ __all__ = [
     "PerformanceMetrics",    "BacktestEngine",
     "EnsemblePredictor",
     "linear_regression_predict",
+    "AIAgent",
+    "AgentManager",
 ]

--- a/ai-stock-platform/api/ml/agent_system.py
+++ b/ai-stock-platform/api/ml/agent_system.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List
+
+import pandas as pd
+import asyncio
+
+@dataclass
+class AIAgent:
+    """Simple prediction agent wrapping a model function."""
+
+    name: str
+    model_fn: Callable[[str, pd.DataFrame, int], pd.DataFrame]
+
+    async def predict(
+        self, ticker: str, historical_data: pd.DataFrame, days_ahead: int = 5
+    ) -> pd.DataFrame:
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, self.model_fn, ticker, historical_data, days_ahead
+        )
+
+
+class AgentManager:
+    """Manage multiple :class:`AIAgent` instances and run them concurrently."""
+
+    def __init__(self) -> None:
+        self.agents: List[AIAgent] = []
+
+    def register(self, agent: AIAgent) -> None:
+        self.agents.append(agent)
+
+    async def run_predictions(
+        self, ticker: str, historical_data: pd.DataFrame, days_ahead: int = 5
+    ) -> List[pd.DataFrame]:
+        tasks = [
+            asyncio.create_task(agent.predict(ticker, historical_data, days_ahead))
+            for agent in self.agents
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        return [r for r in results if not isinstance(r, Exception)]

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import asyncio
+import pandas as pd
+
+ROOT = os.path.join(os.path.dirname(__file__), "..", "ai-stock-platform")
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "api"))
+
+from api.ml.agent_system import AIAgent, AgentManager
+
+
+def test_agent_manager_async_predictions():
+    dates = pd.date_range(end="2024-01-10", periods=10)
+    df = pd.DataFrame({"adjusted_close": range(10)}, index=dates)
+
+    def model_one(ticker, hist, days_ahead):
+        future = pd.date_range(start=hist.index[-1], periods=days_ahead + 1)[1:]
+        return pd.DataFrame({"date": future, "predicted_close": [1] * days_ahead}).set_index("date")
+
+    def model_two(ticker, hist, days_ahead):
+        future = pd.date_range(start=hist.index[-1], periods=days_ahead + 1)[1:]
+        return pd.DataFrame({"date": future, "predicted_close": [2] * days_ahead}).set_index("date")
+
+    manager = AgentManager()
+    manager.register(AIAgent("one", model_one))
+    manager.register(AIAgent("two", model_two))
+
+    results = asyncio.run(manager.run_predictions("TEST", df, days_ahead=2))
+    assert len(results) == 2
+    assert list(results[0]["predicted_close"]) == [1, 1]
+    assert list(results[1]["predicted_close"]) == [2, 2]


### PR DESCRIPTION
## Summary
- implement AIAgent and AgentManager to run prediction models concurrently
- expose the new classes from `ml/__init__.py`
- add unit test for AgentManager

## Testing
- `pytest -q` *(fails: ImportError: No module named 'db.models.forecast')*

------
https://chatgpt.com/codex/tasks/task_e_686ef8401730832a9b6b6f5986869fc6