### PR TITLE
Remove binary placeholders, use remote images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # QuantumVestAI Application Endpoints Documentation
 
 This document provides a comprehensive list of API and UI endpoints for the QuantumVestAI application.
+For screenshots and icons used in the interface, see [UI Visuals](docs/UI_IMAGES.md).
 
 ---
 

--- a/docs/UI_IMAGES.md
+++ b/docs/UI_IMAGES.md
@@ -1,0 +1,28 @@
+# QuantumVestAI UI Visuals
+
+This document showcases key images used throughout the QuantumVestAI user interface.
+
+## Logos
+
+![Main Logo](../ai-stock-platform/ui/static/img/logo.svg)
+![Collapsed Logo](../ai-stock-platform/ui/static/img/logo-collapsed.svg)
+
+## Icons
+
+| Feature | Icon |
+|---------|------|
+| Dashboard | ![Dashboard Icon](../ai-stock-platform/ui/static/img/icons/dashboard.svg) |
+| Market | ![Market Icon](../ai-stock-platform/ui/static/img/icons/market.svg) |
+| News | ![News Icon](../ai-stock-platform/ui/static/img/icons/news.svg) |
+| Predictability | ![Predictability Icon](../ai-stock-platform/ui/static/img/icons/predictability.svg) |
+| Watchlist | ![Watchlist Icon](../ai-stock-platform/ui/static/img/icons/watchlist.svg) |
+| User | ![User Icon](../ai-stock-platform/ui/static/img/icons/user.svg) |
+
+## Placeholder Images
+
+These images appear if remote images fail to load, reducing flicker. Since this
+repository avoids storing binary assets, the placeholders are served from the
+web using publicly available image services.
+
+![Stock Placeholder](https://via.placeholder.com/300x200.png?text=Stock)
+![News Placeholder](https://via.placeholder.com/300x200.png?text=News)


### PR DESCRIPTION
## Summary
- remove placeholder jpg/png images from repo
- update `docs/UI_IMAGES.md` to use remote image links
- keep link in `README` to the new visuals doc

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f0354d3c8832a8451292c5e63d948