### PR TITLE
Fix auth page timestamp rendering

### DIFF
--- a/ai-stock-platform/ui/templates/auth/login.html
+++ b/ai-stock-platform/ui/templates/auth/login.html
@@ -147,7 +147,7 @@
             <p class="tagline">Quantum-powered investment analytics</p>
             <!-- Remove or safely handle datetime reference -->
             {% if now is defined %}
-            <p class="timestamp" style="font-size: 10px; opacity: 0.5;">{{ now.strftime('%Y-%m-%d') }}</p>
+            <p class="timestamp" style="font-size: 10px; opacity: 0.5;">{{ now().strftime('%Y-%m-%d') }}</p>
             {% endif %}
         </div>
         

--- a/ai-stock-platform/ui/templates/auth/password_reset.html
+++ b/ai-stock-platform/ui/templates/auth/password_reset.html
@@ -10,7 +10,7 @@
         
         <!-- Add date reference safely -->
         {% if now is defined %}
-        <p class="auth-timestamp" style="font-size: 10px; opacity: 0.5;">{{ now.strftime('%Y-%m-%d') }}</p>
+        <p class="auth-timestamp" style="font-size: 10px; opacity: 0.5;">{{ now().strftime('%Y-%m-%d') }}</p>
         {% endif %}
 
         {% if msg %}

--- a/ai-stock-platform/ui/templates/auth/register.html
+++ b/ai-stock-platform/ui/templates/auth/register.html
@@ -10,7 +10,7 @@
         
         <!-- Add date reference safely -->
         {% if now is defined %}
-        <p class="auth-timestamp" style="font-size: 10px; opacity: 0.5;">{{ now.strftime('%Y-%m-%d') }}</p>
+        <p class="auth-timestamp" style="font-size: 10px; opacity: 0.5;">{{ now().strftime('%Y-%m-%d') }}</p>
         {% endif %}
 
         <!-- Error display with basic formatting -->


### PR DESCRIPTION
## Summary
- fix incorrect usage of `now` helper in auth templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.middleware')*

------
https://chatgpt.com/codex/tasks/task_e_686f185afaf8832aa833f833875e7334