### PR TITLE
Fix fallback for Alpha Vantage key

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Activate it with `source venv/bin/activate`.
 To fetch real-time stock market data you must set the `ALPHA_VANTAGE_API_KEY`
 environment variable. Sign up for a free key at
 [Alpha Vantage](https://www.alphavantage.co/support/#api-key) and export it
-before starting the API server:
+before starting the API server. If the variable is not set the application will
+fall back to the public **demo** key which has strict rate limits:
 ```bash
 export ALPHA_VANTAGE_API_KEY=your_key_here
 ```

--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -12,6 +12,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Dict, List, Any, Optional
 import os
+from core.config import settings
 
 # Try to import aiohttp, fallback to None if not available
 try:
@@ -27,9 +28,12 @@ class TrendingStocksService:
     """Service for managing trending stocks data with real-time updates and caching."""
     
     def __init__(self):
-        self.api_key = os.getenv("ALPHA_VANTAGE_API_KEY")
+        # Use configured API key or fallback to the default demo key
+        self.api_key = os.getenv("ALPHA_VANTAGE_API_KEY", settings.ALPHA_VANTAGE_API_KEY)
         if not self.api_key:
-            raise RuntimeError("ALPHA_VANTAGE_API_KEY must be set for real-time data access")
+            raise RuntimeError(
+                "ALPHA_VANTAGE_API_KEY must be set for real-time data access"
+            )
         self.base_url = "https://www.alphavantage.co/query"
         self.cache_ttl = int(os.getenv("CACHE_TTL_TRENDING_STOCKS", "300"))  # 5 minutes
         self._cache: Dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- pull Alpha Vantage API key from `settings` so a default demo key is used when no environment variable is present
- document fallback to demo key in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_686f18b6a298832a978ecefc007481f2