### PR TITLE
Fix missing full name field in registration page

### DIFF
--- a/ai-stock-platform/ui/templates/auth/register.html
+++ b/ai-stock-platform/ui/templates/auth/register.html
@@ -45,6 +45,11 @@
                 <label for="email">Email Address</label>
                 <input type="email" id="email" name="email" class="form-control" value="{{ email|default('') }}" required>
             </div>
+
+            <div class="form-group">
+                <label for="full_name">Full Name</label>
+                <input type="text" id="full_name" name="full_name" class="form-control" value="{{ full_name|default('') }}" required>
+            </div>
             
             <div class="form-group">
                 <label for="password">Password</label>


### PR DESCRIPTION
## Summary
- add missing `full_name` input to registration template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several modules)*

------
https://chatgpt.com/codex/tasks/task_e_686f38cf0c8c832aac3c691745220f08