### PR TITLE
Fix missing full name field in registration page

### DIFF
--- a/ai-stock-platform/ui/static/js/auth/register.js
+++ b/ai-stock-platform/ui/static/js/auth/register.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
             
             try {
                 // Submit the form using fetch
-                const response = await fetch('/auth/register', {
+                const response = await fetch('/register', {
                     method: 'POST',
                     body: formData
                 });

--- a/ai-stock-platform/ui/templates/auth/register.html
+++ b/ai-stock-platform/ui/templates/auth/register.html
@@ -34,7 +34,7 @@
         <div id="error-container" class="alert alert-danger" style="display:none;"></div>
         {% endif %}
 
-        <form id="registration-form" action="/auth/register" method="POST">
+        <form id="registration-form" action="/register" method="POST">
             <div class="form-group">
                 <label for="username">Username</label>
                 <input type="text" id="username" name="username" class="form-control" value="{{ username|default('') }}" required>
@@ -44,6 +44,11 @@
             <div class="form-group">
                 <label for="email">Email Address</label>
                 <input type="email" id="email" name="email" class="form-control" value="{{ email|default('') }}" required>
+            </div>
+
+            <div class="form-group">
+                <label for="full_name">Full Name</label>
+                <input type="text" id="full_name" name="full_name" class="form-control" value="{{ full_name|default('') }}" required>
             </div>
             
             <div class="form-group">


### PR DESCRIPTION
## Summary
- add missing `full_name` input to registration template
- point registration form and JS to `/register`

## Testing
- `python ai-stock-platform/ui/test_fixes.py` *(passes)*
- `pytest -q` *(fails: ModuleNotFoundError for several modules)*

------
https://chatgpt.com/codex/tasks/task_e_686f38cf0c8c832aac3c691745220f08