### PR TITLE
Fix settings import for API services

### DIFF
--- a/ai-stock-platform/api/services/stock_service.py
+++ b/ai-stock-platform/api/services/stock_service.py
@@ -9,7 +9,10 @@ import asyncio
 from typing import Optional, List, Dict, Any
 from sqlalchemy.orm import Session
 from models.stock import Stock, WatchList
-from core.config import settings
+# Import settings explicitly from the configuration module to avoid
+# accidentally importing the module itself when the `core.config`
+# package is present in the Python path.
+from core.config.settings import settings
 import logging
 
 logger = logging.getLogger(__name__)

--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -12,7 +12,9 @@ import logging
 from datetime import datetime, timedelta
 from typing import Dict, List, Any, Optional
 import os
-from core.config import settings
+# Explicitly import the settings instance to avoid ambiguity with the
+# `core.config` package which also contains a `settings` submodule.
+from core.config.settings import settings
 
 # Try to import aiohttp, fallback to None if not available
 try:


### PR DESCRIPTION
## Summary
- fix settings import in `stock_service` and `trending_stocks_service`
  to avoid pulling in the wrong module which lacked `ALPHA_VANTAGE_API_KEY`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.middleware')*

------
https://chatgpt.com/codex/tasks/task_e_686f3c9f0104832aaf0d89f8678d83e8