### PR TITLE
Fix import paths for API core modules

### DIFF
--- a/ai-stock-platform/api/__init__.py
+++ b/ai-stock-platform/api/__init__.py
@@ -5,18 +5,45 @@ Author: daparthi001
 """
 import logging
 import sys
+from pathlib import Path
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("quantumvestai_api")
 logger.info("Initializing API package")
 
+# Ensure this package path has priority in sys.path so that modules like
+# ``core`` resolve to ``api.core`` rather than the sibling package at the
+# repository root.
+_pkg_path = Path(__file__).resolve().parent
+if str(_pkg_path) not in sys.path:
+    sys.path.insert(0, str(_pkg_path))
+
+# Map the name ``core`` to this package's ``core`` module so imports of ``core``
+# resolve correctly even when a sibling ``ui.core`` package exists.
+import importlib
+sys.modules.setdefault('core', importlib.import_module('api.core'))
+
+# Remove local ``multipart`` stub if present so the real ``python-multipart``
+# package can be used by FastAPI/Starlette.
+sys.modules.pop('multipart', None)
+for p in list(sys.path):
+    if 'site-packages' in p:
+        sys.path.remove(p)
+        sys.path.insert(0, p)
+
 try:
     from .main import app
+    # Re-insert package path at the front in case submodules modified sys.path
+    if str(_pkg_path) in sys.path:
+        sys.path.remove(str(_pkg_path))
+    sys.path.insert(0, str(_pkg_path))
     logger.info(
         "Successfully imported app from api.main with %d routes", len(app.routes)
     )
 except Exception as e:  # pragma: no cover - optional dependency may be missing
     logger.error(f"Failed to import app from api.main: {e}")
-    app = None# Export the app variable
+    app = None
+
+# Export the app variable for external use
 __all__ = ["app"]

--- a/ai-stock-platform/core/__init__.py
+++ b/ai-stock-platform/core/__init__.py
@@ -1,14 +1,21 @@
-"""Compatibility module exposing UI core utilities."""
+"""Compatibility module redirecting to API core utilities."""
 
-from ui.core.http_client import (
-    HTTPClient,
-    HTTPClientConfig,
-    get_http_client,
-    safe_get_json,
-    safe_post_json,
-    cleanup_http_clients,
+from api.core import (
+    config,
+    logger,
+    middleware,
+    security,
+    utils,
 )
-from ui.core.config.settings import settings, Settings, get_settings
+from api.core.config.settings import settings, Settings, get_settings
+
+# Re-export commonly used components from api.core
+HTTPClient = utils.http_client.HTTPClient
+HTTPClientConfig = utils.http_client.HTTPClientConfig
+get_http_client = utils.http_client.get_http_client
+safe_get_json = utils.http_client.safe_get_json
+safe_post_json = utils.http_client.safe_post_json
+cleanup_http_clients = utils.http_client.cleanup_http_clients
 
 __all__ = [
     "HTTPClient",


### PR DESCRIPTION
## Summary
- map `core` imports to the API's core package
- ensure site-packages take priority and remove local multipart stub
- update compatibility layer so top-level `core` points to API utilities

## Testing
- `pytest tests/test_agents.py::test_agent_manager_async_predictions -q`

------
https://chatgpt.com/codex/tasks/task_e_686f3b7cf040832aa4f999e852cbe7bd