### PR TITLE
Add aliases for core modules

### DIFF
--- a/ai-stock-platform/core/__init__.py
+++ b/ai-stock-platform/core/__init__.py
@@ -2,20 +2,22 @@
 
 from api.core import (
     config,
-    logger,
     middleware,
     security,
     utils,
 )
 from api.core.config.settings import settings, Settings, get_settings
+from api.core.logger import logger, setup_logger
+from .http_client import (
+    HTTPClient,
+    HTTPClientConfig,
+    get_http_client,
+    safe_get_json,
+    safe_post_json,
+    cleanup_http_clients,
+)
 
-# Re-export commonly used components from api.core
-HTTPClient = utils.http_client.HTTPClient
-HTTPClientConfig = utils.http_client.HTTPClientConfig
-get_http_client = utils.http_client.get_http_client
-safe_get_json = utils.http_client.safe_get_json
-safe_post_json = utils.http_client.safe_post_json
-cleanup_http_clients = utils.http_client.cleanup_http_clients
+
 
 __all__ = [
     "HTTPClient",
@@ -27,4 +29,6 @@ __all__ = [
     "settings",
     "Settings",
     "get_settings",
+    "logger",
+    "setup_logger",
 ]

--- a/ai-stock-platform/core/logger.py
+++ b/ai-stock-platform/core/logger.py
@@ -1,0 +1,3 @@
+from api.core.logger import logger, setup_logger
+
+__all__ = ["logger", "setup_logger"]

--- a/ai-stock-platform/core/utils/__init__.py
+++ b/ai-stock-platform/core/utils/__init__.py
@@ -1,0 +1,3 @@
+from api.core.utils import *
+
+__all__ = ["get_password_hash", "verify_password"]

--- a/ai-stock-platform/core/utils/password_utils.py
+++ b/ai-stock-platform/core/utils/password_utils.py
@@ -1,0 +1,1 @@
+from api.core.utils.password_utils import *


### PR DESCRIPTION
## Summary
- alias `core.logger` to `api.core.logger`
- re-export http client utilities directly in `core.__init__`
- map `core.utils` to `api.core.utils`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'routes.auth')*

------
https://chatgpt.com/codex/tasks/task_e_686f4c797b14832a9837059d1022e076