### PR TITLE
Add compatibility for core logger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Instructions for Codex Agents
+
+To run the application tests:
+1. Run `./setup_env.sh` to create a virtual environment and install dependencies.
+2. Activate the virtual environment with `source venv/bin/activate`.
+3. Execute `pytest -q` from the repository root.
+
+All pull requests should run these tests to ensure the application works as expected.

--- a/ai-stock-platform/api/core/logger/__init__.py
+++ b/ai-stock-platform/api/core/logger/__init__.py
@@ -11,7 +11,10 @@ from pathlib import Path
 from logging.handlers import RotatingFileHandler
 from typing import Optional
 
-from core.config.settings import settings
+# Use a relative import here so that this module can be loaded
+# during package initialisation before the `core` alias is
+# registered in ``api.__init__``.
+from ..config.settings import settings
 
 def setup_logger(
     name: str = "app",

--- a/ai-stock-platform/core/__init__.py
+++ b/ai-stock-platform/core/__init__.py
@@ -1,21 +1,29 @@
 """Compatibility module redirecting to API core utilities."""
 
-from api.core import (
-    config,
-    logger,
-    middleware,
-    security,
-    utils,
-)
+# Import the API configuration modules we rely on. Avoid importing optional
+# subpackages that would trigger database connections or other heavy side
+# effects during test collection.
+from api.core import config, logger
 from api.core.config.settings import settings, Settings, get_settings
 
+# Lightweight HTTP client utilities are provided by the UI core package.
+from ui.core import http_client as ui_http_client
+
+# Expose api.core submodules under the ``core`` namespace so imports like
+# ``core.logger`` resolve correctly even when this lightweight compatibility
+# package is imported first.
+import sys
+
+sys.modules.setdefault(__name__ + ".config", config)
+sys.modules.setdefault(__name__ + ".logger", logger)
+
 # Re-export commonly used components from api.core
-HTTPClient = utils.http_client.HTTPClient
-HTTPClientConfig = utils.http_client.HTTPClientConfig
-get_http_client = utils.http_client.get_http_client
-safe_get_json = utils.http_client.safe_get_json
-safe_post_json = utils.http_client.safe_post_json
-cleanup_http_clients = utils.http_client.cleanup_http_clients
+HTTPClient = ui_http_client.HTTPClient
+HTTPClientConfig = ui_http_client.HTTPClientConfig
+get_http_client = ui_http_client.get_http_client
+safe_get_json = ui_http_client.safe_get_json
+safe_post_json = ui_http_client.safe_post_json
+cleanup_http_clients = ui_http_client.cleanup_http_clients
 
 __all__ = [
     "HTTPClient",

--- a/ai-stock-platform/core/logger.py
+++ b/ai-stock-platform/core/logger.py
@@ -1,0 +1,3 @@
+from api.core.logger import logger, setup_logger
+
+__all__ = ["logger", "setup_logger"]


### PR DESCRIPTION
## Summary
- expose API logger under `core.logger`
- avoid importing heavy API submodules in lightweight `core` package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.middleware')*

------
https://chatgpt.com/codex/tasks/task_e_686fbde5fd8c832ab5367da8796d36ee