### PR TITLE
Refactor security module imports

### DIFF
--- a/ai-stock-platform/api/core/security.py
+++ b/ai-stock-platform/api/core/security.py
@@ -14,6 +14,7 @@ from typing import Optional, Dict, Any
 
 from core.config import settings
 from db.session import get_db
+from db.models.user import User
 from core.exceptions import AuthenticationError
 
 # Password context for hashing
@@ -54,7 +55,6 @@ async def get_current_user(
     db: Session = Depends(get_db)
 ):
     """Get current user from token."""
-    from db.models.user import User  # Import here to avoid circular imports
     
     try:
         payload = jwt.decode(


### PR DESCRIPTION
## Summary
- import `User` at module level in `security.py`
- remove local import in `get_current_user`

## Testing
- `pytest -q` *(fails: ImportError: No module named 'core.exceptions')*

------
https://chatgpt.com/codex/tasks/task_e_68700f45b5ec832aa19cf423f9c4ca32