### PR TITLE
Fix registration error by defining User alerts relationship

### DIFF
--- a/ai-stock-platform/api/db/models/user.py
+++ b/ai-stock-platform/api/db/models/user.py
@@ -55,10 +55,11 @@ class User(Base, TimestampMixin):
         secondary=user_watchlist,
         back_populates="watched_by",
     )
-    watchlist = relationship(
-        "Stock",
-        secondary=user_watchlist,
-        back_populates="watched_by",
+
+    alerts = relationship(
+        "Alert",
+        back_populates="user",
+        cascade="all, delete-orphan",
     )
 
     def set_password(self, password: str) -> None:


### PR DESCRIPTION
## Summary
- define `alerts` relationship on the User model

## Testing
- `pytest -q` *(fails: ERROR ai-stock-platform/api/tools/test_db_connection.py, ERROR ai-stock-platform/ui/tests/test_routes/test_auth.py)*

------
https://chatgpt.com/codex/tasks/task_e_6870a2000988832ab5255404377d718f