### PR TITLE
Fix DB table creation on API startup

### DIFF
--- a/ai-stock-platform/api/core/database.py
+++ b/ai-stock-platform/api/core/database.py
@@ -13,6 +13,8 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlalchemy.orm import sessionmaker
 
+from db.base import Base
+
 logger = logging.getLogger("api")
 
 
@@ -141,3 +143,14 @@ async def get_db_session():
     """Yield an async database session."""
     async with AsyncSessionLocal() as session:
         yield session
+
+
+async def create_db_and_tables() -> None:
+    """Create database tables if they do not exist."""
+    try:
+        async with async_engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        logger.info("Database tables created or verified")
+    except Exception as e:
+        logger.error(f"Failed to create tables: {e}")
+        raise

--- a/ai-stock-platform/api/main.py
+++ b/ai-stock-platform/api/main.py
@@ -500,6 +500,11 @@ async def startup_event():
     # Initialize database
     if initialize_database():
         logger.info("Database initialized successfully")
+        try:
+            from core.database import create_db_and_tables
+            await create_db_and_tables()
+        except Exception as e:
+            logger.error(f"Database table creation failed: {e}")
     else:
         logger.warning("Database initialization failed - running in degraded mode")
     

--- a/ai-stock-platform/ui/templates/auth/register.html
+++ b/ai-stock-platform/ui/templates/auth/register.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "auth_layout.html" %}
 
 {% block title %}Register | QuantumVestAI{% endblock %}
 


### PR DESCRIPTION
## Summary
- create helper to initialize DB tables if they don't exist
- call that helper from API startup
- show registration form using the auth layout

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: templates/static directories missing, some tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6871404b9f3c832aa5eaa92675e64d32