### PR TITLE
Fix optional DB init and replace bcrypt

### DIFF
--- a/ai-stock-platform/api/api_safe_setup_Version2.py
+++ b/ai-stock-platform/api/api_safe_setup_Version2.py
@@ -78,7 +78,7 @@ from db.session import get_db
 from schemas.token import TokenData
 from chemas.user import User
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
@@ -177,7 +177,7 @@ sqlalchemy==2.0.23
 pydantic==2.5.2
 pydantic-settings==2.1.0
 python-jose[cryptography]==3.3.0
-passlib[bcrypt]==1.7.4
+passlib==1.7.4
 python-multipart==0.0.6
 email-validator==2.1.0.post1
 psycopg2-binary==2.9.9

--- a/ai-stock-platform/api/config/requirements.txt
+++ b/ai-stock-platform/api/config/requirements.txt
@@ -7,7 +7,7 @@ pydantic==2.0.2
 pydantic-settings==2.0.1
 psycopg2-binary==2.9.6
 python-jose[cryptography]==3.3.0
-passlib[bcrypt]==1.7.4
+passlib==1.7.4
 python-multipart==0.0.6
 email-validator==2.0.0
 httpx==0.24.1

--- a/ai-stock-platform/api/core/security.py
+++ b/ai-stock-platform/api/core/security.py
@@ -18,7 +18,7 @@ from db.models.user import User
 from core.exceptions import AuthenticationError
 
 # Password context for hashing
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 
 # OAuth2 scheme for token
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f"{settings.API_PREFIX}/auth/token")

--- a/ai-stock-platform/api/core/security/auth.py
+++ b/ai-stock-platform/api/core/security/auth.py
@@ -13,7 +13,7 @@ from db.session import get_db
 from db.models.user import User as DBUser
 from .tokens import TokenHandler
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 

--- a/ai-stock-platform/api/core/security/utils.py
+++ b/ai-stock-platform/api/core/security/utils.py
@@ -10,7 +10,7 @@ from passlib.context import CryptContext
 from db.models.user import User
 from core.config import settings
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 
 class SecurityUtils:
     """Security utility functions"""

--- a/ai-stock-platform/api/core/utils/password_utils.py
+++ b/ai-stock-platform/api/core/utils/password_utils.py
@@ -5,12 +5,12 @@ Author: daparthi001
 """
 from passlib.context import CryptContext
 
-# Configure password hashing
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+# Configure password hashing. Use pbkdf2_sha256 to avoid bcrypt dependency issues
+pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 
 def get_password_hash(password: str) -> str:
     """
-    Generate password hash using bcrypt
+    Generate password hash using pbkdf2_sha256
     
     Args:
         password: Plain text password

--- a/ai-stock-platform/api/db_init/01_seed_data.py
+++ b/ai-stock-platform/api/db_init/01_seed_data.py
@@ -17,7 +17,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Set up password hashing
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 
 # Import models
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/ai-stock-platform/api/db_init/03_create_admin.py
+++ b/ai-stock-platform/api/db_init/03_create_admin.py
@@ -16,7 +16,7 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(level
 logger = logging.getLogger('db-init')
 
 # Password hashing
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 
 def create_admin_user():
     """Create admin user in the database."""

--- a/ai-stock-platform/api/main.py
+++ b/ai-stock-platform/api/main.py
@@ -500,11 +500,15 @@ async def startup_event():
     # Initialize database
     if initialize_database():
         logger.info("Database initialized successfully")
-        try:
-            from core.database import create_db_and_tables
-            await create_db_and_tables()
-        except Exception as e:
-            logger.error(f"Database table creation failed: {e}")
+        run_migrations = os.environ.get("RUN_DB_MIGRATIONS", "0").lower() in ("1", "true", "yes")
+        if run_migrations:
+            try:
+                from core.database import create_db_and_tables
+                await create_db_and_tables()
+            except Exception as e:
+                logger.error(f"Database table creation failed: {e}")
+        else:
+            logger.info("Skipping automatic table creation - RUN_DB_MIGRATIONS not enabled")
     else:
         logger.warning("Database initialization failed - running in degraded mode")
     

--- a/ai-stock-platform/api/pyproject.toml
+++ b/ai-stock-platform/api/pyproject.toml
@@ -11,7 +11,7 @@ uvicorn = "^0.21.1"
 sqlalchemy = "^2.0.9"
 alembic = "^1.10.3"
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}
-passlib = {extras = ["bcrypt"], version = "^1.7.4"}
+passlib = "^1.7.4"
 python-multipart = "^0.0.6"
 python-dotenv = "^1.0.0"
 pydantic = {version = "^2.0.0", extras = ["email"]}

--- a/ai-stock-platform/api/requirements.txt
+++ b/ai-stock-platform/api/requirements.txt
@@ -4,7 +4,7 @@ sqlalchemy==2.0.23
 pydantic==2.5.2
 pydantic-settings==2.1.0
 python-jose[cryptography]==3.3.0
-passlib[bcrypt]==1.7.4
+passlib==1.7.4
 python-multipart==0.0.6
 email-validator==2.1.0.post1
 psycopg2-binary==2.9.9

--- a/ai-stock-platform/ui/requirements.txt
+++ b/ai-stock-platform/ui/requirements.txt
@@ -35,8 +35,7 @@ seaborn==0.13.0
 
 # Authentication and security
 python-jose[cryptography]==3.3.0
-passlib[bcrypt]==1.7.4
-bcrypt==3.2.0
+passlib==1.7.4
 python-dotenv==1.0.0
 pydantic==2.5.2
 pydantic-settings==2.1.0

--- a/ai-stock-platform/ui/setup.py
+++ b/ai-stock-platform/ui/setup.py
@@ -18,7 +18,7 @@ setup(
         "httpx>=0.19.0",
         "pydantic>=1.8.0",
         "python-jose[cryptography]>=3.3.0",
-        "passlib[bcrypt]>=1.7.4",
+        "passlib>=1.7.4",
         "yfinance>=0.1.70",
         "pandas>=1.3.0",
         "numpy>=1.21.0",


### PR DESCRIPTION
## Summary
- prevent table creation on every startup unless `RUN_DB_MIGRATIONS` is set
- switch password hashing to `pbkdf2_sha256`
- drop `bcrypt` extras from requirements

## Testing
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871572db0cc832a9c046e3da397dff5