### PR TITLE
Fix fallback database initialization

### DIFF
--- a/ai-stock-platform/api/db/models/stock.py
+++ b/ai-stock-platform/api/db/models/stock.py
@@ -68,6 +68,18 @@ class Stock(Base, TimestampMixin):
         back_populates="stock",
         cascade="all, delete-orphan"
     )
+
+    # Portfolio relationships
+    positions: Mapped[List["Position"]] = relationship(
+        "Position",
+        back_populates="stock",
+        cascade="all, delete-orphan",
+    )
+    transactions: Mapped[List["Transaction"]] = relationship(
+        "Transaction",
+        back_populates="stock",
+        cascade="all, delete-orphan",
+    )
     
     def __repr__(self) -> str:
         return f"<Stock {self.ticker}>"

--- a/ai-stock-platform/api/db/session.py
+++ b/ai-stock-platform/api/db/session.py
@@ -139,6 +139,14 @@ except Exception as e:
     engine = create_engine("sqlite:///fallback.db")
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     logger.warning("Using fallback SQLite database due to connection error")
+    # Automatically create tables for the fallback database so basic
+    # authentication and other features continue working when PostgreSQL
+    # is unavailable.
+    try:
+        Base.metadata.create_all(bind=engine)
+        logger.info("Initialized fallback SQLite database")
+    except Exception as init_err:
+        logger.error("Failed to initialize fallback database: %s", str(init_err))
 
 def get_db() -> Generator:
     """Get database session"""


### PR DESCRIPTION
## Summary
- ensure SQLite fallback creates all tables
- run project tests

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: database connection tests)*

------
https://chatgpt.com/codex/tasks/task_e_68713143856c832ab57270042cecd4b9