### PR TITLE
Fix import issue in portfolio service

### DIFF
--- a/ai-stock-platform/ui/src/services/portfolio.service.ts
+++ b/ai-stock-platform/ui/src/services/portfolio.service.ts
@@ -4,7 +4,7 @@
  * Author: daparthi001
  */
 import { api } from './api';
-import wsService, { WebSocketMessage } from './websocket.service';
+import wsService from './websocket.service';
 import authService from './auth.service';
 import { Position, Transaction, PortfolioSummary } from '../types/portfolio';
 import { Subject } from 'rxjs';


### PR DESCRIPTION
## Summary
- remove unused `WebSocketMessage` import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686df1a44a44832ab037613cdf5fc802