### PR TITLE
Improve DB setup instructions and auto-create tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,28 @@ export ALPHA_VANTAGE_API_KEY=your_key_here
 ```
 Without this key the trending stock endpoints will not return current data.
 
+## Database Setup
 
+The API uses asynchronous SQLAlchemy connections. Before running the server you must
+configure two environment variables:
+
+```bash
+export ASYNC_DATABASE_URL=postgresql+asyncpg://user:password@localhost/dbname
+export RUN_DB_MIGRATIONS=true
+```
+
+`ASYNC_DATABASE_URL` provides the connection string for the async engine. If it is
+not set the server falls back to a local SQLite file (`test.db`). `RUN_DB_MIGRATIONS`
+controls whether the application automatically creates tables on startup.
+
+For local development you can initialize a PostgreSQL database by running:
+
+```bash
+./ai-stock-platform/api/scripts/init_local_db.sh
+```
+
+If the tables are missing at startup, the API will attempt to create them
+automatically.
+
+
+\n

--- a/ai-stock-platform/api/main.py
+++ b/ai-stock-platform/api/main.py
@@ -501,14 +501,19 @@ async def startup_event():
     if initialize_database():
         logger.info("Database initialized successfully")
         run_migrations = os.environ.get("RUN_DB_MIGRATIONS", "0").lower() in ("1", "true", "yes")
-        if run_migrations:
-            try:
-                from core.database import create_db_and_tables
+        try:
+            from sqlalchemy import inspect
+            from core.database import async_engine, create_db_and_tables
+
+            async with async_engine.begin() as conn:
+                has_users = await conn.run_sync(lambda sconn: inspect(sconn).has_table("users"))
+
+            if run_migrations or not has_users:
                 await create_db_and_tables()
-            except Exception as e:
-                logger.error(f"Database table creation failed: {e}")
-        else:
-            logger.info("Skipping automatic table creation - RUN_DB_MIGRATIONS not enabled")
+            else:
+                logger.info("Database tables already exist; skipping creation")
+        except Exception as e:
+            logger.error(f"Database table creation failed: {e}")
     else:
         logger.warning("Database initialization failed - running in degraded mode")
     


### PR DESCRIPTION
## Summary
- add environment variable info to README
- automatically create DB tables if missing

## Testing
- `./setup_env.sh`
- `source venv/bin/activate && pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68717fde5e54832aa4dadb6a19a3526b