### PR TITLE
Add CI workflow for running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Run Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          ./setup_env.sh
+
+      - name: Run tests
+        run: |
+          source venv/bin/activate
+          pytest -q
+        env:
+          ALPHA_VANTAGE_API_KEY: demo


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to automatically run project tests

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871aea74f70832a86332c37a622d525