### PR TITLE
Add async DB utility and update CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Run Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          ./setup_env.sh
+
+      - name: Run tests
+        run: |
+          source venv/bin/activate
+          pytest -q
+        env:
+          ALPHA_VANTAGE_API_KEY: demo
+          TEST_DATABASE_URL: sqlite:///:memory:

--- a/ai-stock-platform/api/db/session.py
+++ b/ai-stock-platform/api/db/session.py
@@ -7,7 +7,7 @@ Updated: 2025-06-14 23:14:45 by daparthi001
 import logging
 import time
 import os
-from typing import Generator, Dict, Any
+from typing import Generator, Dict, Any, AsyncGenerator
 from sqlalchemy import create_engine, event, text
 from sqlalchemy.orm import sessionmaker, Session
 from db.base import Base
@@ -155,6 +155,15 @@ except Exception as e:
 
 def get_db() -> Generator:
     """Get database session"""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+async def get_db_async() -> AsyncGenerator[Session, None]:
+    """Asynchronous wrapper for ``get_db`` to support ``async for`` usage in tests."""
     db = SessionLocal()
     try:
         yield db

--- a/ai-stock-platform/api/tests/test_db_connection.py
+++ b/ai-stock-platform/api/tests/test_db_connection.py
@@ -13,7 +13,7 @@ import logging
 from typing import Generator, Optional
 from datetime import datetime
 
-from db.session import Base, get_db
+from db.session import Base, get_db, get_db_async
 from core.config import settings
 from core.logger import setup_logger
 
@@ -213,7 +213,7 @@ class TestDatabaseConnection:
         """Test async database operations."""
         try:
             # Get async session
-            async for db in get_db():
+            async for db in get_db_async():
                 # Execute simple query
                 result = await db.execute(text("SELECT 1"))
                 assert await result.scalar() == 1


### PR DESCRIPTION
## Summary
- add `get_db_async` helper and use it in async tests
- ensure CI uses sqlite in-memory database

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871aea74f70832a86332c37a622d525