### PR TITLE
Fix alembic import namespace issue

### DIFF
--- a/ai-stock-platform/api/alembic/__init__.py
+++ b/ai-stock-platform/api/alembic/__init__.py
@@ -1,11 +1,17 @@
 """Alembic database migration components."""
 
-# This lightweight package primarily houses the migration scripts under
-# ``alembic/versions``.  The real Alembic library provides the ``alembic``
-# package with modules like ``alembic.config`` and ``alembic.script`` which our
-# tests expect to import.  If the library isn't installed, importing this
-# package should fail so that ``pytest.importorskip("alembic")`` correctly skips
-# migration tests instead of raising obscure errors during import later on.
+# This lightweight package primarily stores the application's migration
+# scripts under ``alembic/versions``.  When running the application we expect
+# the real Alembic library to be installed so we can import helper modules like
+# ``alembic.config`` and ``alembic.script``.  Since this directory shares the
+# same name as the real package, importing ``alembic`` would normally resolve to
+# this folder only.  To allow Python to also find the installed library we
+# extend ``__path__`` into a namespace package before attempting the import.
+
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)  # type: ignore[misc]
+
 try:  # Attempt to import the real library components
     from importlib import import_module
 


### PR DESCRIPTION
## Summary
- fix alembic namespace so installed package is found

## Testing
- `./setup_env.sh`
- `pytest -q tests/test_basic.py tests/test_agents.py`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6871d25704ec832a9ee91a6e8aa909c4