### PR TITLE
Fix alembic package import loop

### DIFF
--- a/ai-stock-platform/api/alembic/__init__.py
+++ b/ai-stock-platform/api/alembic/__init__.py
@@ -1,14 +1,17 @@
 """Alembic database migration components."""
 
-# This lightweight package primarily houses the migration scripts under
-# ``alembic/versions``.  The real Alembic library provides the ``alembic``
-# package with modules like ``alembic.config`` and ``alembic.script`` which our
-# tests expect to import.  If the library isn't installed, importing this
-# package should fail so that ``pytest.importorskip("alembic")`` correctly skips
-# migration tests instead of raising obscure errors during import later on.
-try:  # Attempt to import the real library components
-    from importlib import import_module
+# This lightweight package primarily stores the application's migration
+# scripts under ``alembic/versions``.  When running the application we expect
+# the real Alembic library to be installed so helper modules like
+# ``alembic.config`` and ``alembic.script`` are available.  Because this
+# directory shares the package name, importing ``alembic`` would normally
+# resolve to this folder only.  To allow Python to also find the installed
+# library, we extend ``__path__`` into a namespace package.
 
-    import_module("alembic.config")  # type: ignore[unused-ignore]
-except Exception as exc:  # pragma: no cover - import side effects
-    raise ImportError("The Alembic library is required to run migrations") from exc
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)  # type: ignore[misc]
+
+# When the real Alembic library is installed, Python will discover its modules
+# via the extended search path above.  If it's missing, importing things like
+# ``alembic.config`` will fail normally.


### PR DESCRIPTION
## Summary
- simplify local alembic `__init__` so it only extends the namespace

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 11 failed, 24 passed, 5 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871d25704ec832a9ee91a6e8aa909c4