### PR TITLE
Fix missing password column regression

### DIFF
--- a/ai-stock-platform/api/db/models/user.py
+++ b/ai-stock-platform/api/db/models/user.py
@@ -27,11 +27,11 @@ class User(Base, TimestampMixin):
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String, unique=True, index=True, nullable=False)
     username = Column(String, unique=True, index=True, nullable=False)
-    # Some early migrations named the column ``hashed_password`` while later
-    # ones used ``password_hash``.  To work with databases created by either
-    # migration history we store the value under ``hashed_password`` and expose
-    # ``password_hash`` as a backward-compatible synonym.
-    hashed_password = Column(String, nullable=False)
+    # Most database schemas historically used the ``password_hash`` column
+    # name. Map that column to the ``hashed_password`` attribute so existing
+    # code continues to work without requiring a migration.
+    hashed_password = Column("password_hash", String, nullable=False)
+    # Some legacy code still references ``password_hash`` directly.
     password_hash = synonym("hashed_password")
     full_name = Column(String)
     is_active = Column(Boolean, default=True)


### PR DESCRIPTION
## Summary
- map `hashed_password` attribute to the legacy `password_hash` column to support existing databases

## Testing
- `pytest -q` *(fails: RuntimeError/KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68727bf3aeb4832aac46eb5a6b19d8eb