### PR TITLE
Fix password column compatibility

### DIFF
--- a/ai-stock-platform/api/core/database.py
+++ b/ai-stock-platform/api/core/database.py
@@ -11,8 +11,6 @@ from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from core.config import get_settings
 from pathlib import Path
 
-from alembic import command
-from alembic.config import Config
 from sqlalchemy.orm import sessionmaker
 
 settings = get_settings()

--- a/ai-stock-platform/api/db/models/user.py
+++ b/ai-stock-platform/api/db/models/user.py
@@ -27,11 +27,30 @@ class User(Base, TimestampMixin):
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String, unique=True, index=True, nullable=False)
     username = Column(String, unique=True, index=True, nullable=False)
-    # Some early migrations named the column ``hashed_password`` while later
-    # ones used ``password_hash``.  To work with databases created by either
-    # migration history we store the value under ``hashed_password`` and expose
-    # ``password_hash`` as a backward-compatible synonym.
-    hashed_password = Column(String, nullable=False)
+    # Historically this field has been named either ``hashed_password`` or
+    # ``password_hash`` depending on the migration path used when the database
+    # was created.  To transparently support both schemas we detect which column
+    # is present at import time and map the ``hashed_password`` attribute to that
+    # column.  ``password_hash`` is kept as a backward compatible synonym.
+
+    _pwd_column_name = "hashed_password"
+    try:  # Introspect the DB to determine which column actually exists
+        from sqlalchemy import create_engine, inspect
+        from core.config import get_settings
+
+        settings = get_settings()
+        engine = create_engine(settings.SQLALCHEMY_DATABASE_URI)
+        insp = inspect(engine)
+        cols = [c["name"] for c in insp.get_columns("users")]
+        engine.dispose()
+        if "password_hash" in cols and "hashed_password" not in cols:
+            _pwd_column_name = "password_hash"
+    except Exception:
+        # If inspection fails (e.g., during tests with no DB) default to the
+        # original ``hashed_password`` column name.
+        pass
+
+    hashed_password = Column(_pwd_column_name, String, nullable=False)
     password_hash = synonym("hashed_password")
     full_name = Column(String)
     is_active = Column(Boolean, default=True)

--- a/ai-stock-platform/api/scripts/list_db_tables.py
+++ b/ai-stock-platform/api/scripts/list_db_tables.py
@@ -1,0 +1,32 @@
+"""List database tables using the application's SQLAlchemy engine."""
+
+import logging
+import sys
+from pathlib import Path
+from sqlalchemy import inspect
+
+# Ensure the parent directory (which contains the `db` package) is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from db.session import engine
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def main() -> None:
+    """Print all table names in the connected database."""
+    try:
+        inspector = inspect(engine)
+        tables = inspector.get_table_names()
+        if not tables:
+            print("No tables found.")
+        else:
+            print("Available tables:")
+            for table in tables:
+                print(f"- {table}")
+    except Exception as e:
+        logger.error("Failed to list tables: %s", e)
+        raise
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- handle legacy `password_hash` column when creating `User` models

## Testing
- `pytest -q` *(fails: 11 failed, 24 passed, 5 skipped, 5 errors in 219.35s)*

------
https://chatgpt.com/codex/tasks/task_e_68727bf3aeb4832aac46eb5a6b19d8eb