### PR TITLE
Adjust DB module to use env vars

### DIFF
--- a/ai-stock-platform/api/core/database.py
+++ b/ai-stock-platform/api/core/database.py
@@ -5,15 +5,10 @@ Author: AI Assistant
 """
 import logging
 import os
-from typing import Optional
 from contextlib import contextmanager
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
-from core.config import get_settings
-from pathlib import Path
-
 from sqlalchemy.orm import sessionmaker
 
-settings = get_settings()
 
 from db.base import Base
 
@@ -145,8 +140,20 @@ def _convert_to_async(db_url: str) -> str:
         return db_url.replace("sqlite:///", "sqlite+aiosqlite:///")
     return db_url
 
-DATABASE_URL = os.environ.get(
-    "ASYNC_DATABASE_URL", _convert_to_async(settings.SQLALCHEMY_DATABASE_URI)
+# Build database URL from environment variables
+db_user = os.environ.get("DB_USER", "dbadmin")
+db_password = os.environ.get("DB_PASSWORD", "")
+db_host = os.environ.get("DB_HOST", "localhost")
+db_port = os.environ.get("DB_PORT", "5432")
+db_name = os.environ.get("DB_NAME", "quantumvestai")
+
+default_sync_url = os.environ.get(
+    "DATABASE_URL",
+    f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}",
+)
+
+DATABASE_URL = _convert_to_async(
+    os.environ.get("ASYNC_DATABASE_URL", default_sync_url)
 )
 async_engine = create_async_engine(DATABASE_URL, future=True)
 AsyncSessionLocal = sessionmaker(

--- a/ai-stock-platform/api/db/session.py
+++ b/ai-stock-platform/api/db/session.py
@@ -8,6 +8,7 @@ import logging
 import time
 import os
 from typing import Generator, Dict, Any, AsyncGenerator
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import create_engine, event, text
 from sqlalchemy.orm import sessionmaker, Session
 from db.base import Base
@@ -160,4 +161,12 @@ def get_db() -> Generator:
         yield db
     finally:
         db.close()
+
+
+async def get_db_async() -> AsyncGenerator[AsyncSession, None]:
+    """Yield an async database session using core.database utilities."""
+    from core.database import get_db_session
+
+    async for session in get_db_session():
+        yield session
 


### PR DESCRIPTION
## Summary
- read database details directly from environment variables
- expose async DB session helper

## Testing
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872e452796c832a927e9feb1bbd0c40