### PR TITLE
Add helper script to run API container

### DIFF
--- a/ai-stock-platform/api/run_api_container.sh
+++ b/ai-stock-platform/api/run_api_container.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Run the QuantumVestAI API container with Docker Compose
+# This script builds and starts the API along with its dependencies
+# to help debug container build issues.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Choose docker compose command
+if command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE="docker-compose"
+else
+    COMPOSE="docker compose"
+fi
+
+$COMPOSE -f docker-compose.yml up --build


### PR DESCRIPTION
## Summary
- add `run_api_container.sh` to easily build and launch the API container with Docker Compose

## Testing
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872ed6ae6a8832a8313812697b74a66