### PR TITLE
Add model training scheduler

### DIFF
--- a/ai-stock-platform/api/ml/__init__.py
+++ b/ai-stock-platform/api/ml/__init__.py
@@ -17,6 +17,7 @@ except Exception:  # pragma: no cover - optional heavy deps
     PortfolioOptimizationModel = None
 from .ensemble_model import EnsemblePredictor, linear_regression_predict
 from .agent_system import AIAgent, AgentManager
+from .model_scheduler import start_model_training_scheduler
 
 __all__ = [
     "PricePredictionModel",
@@ -27,4 +28,5 @@ __all__ = [
     "linear_regression_predict",
     "AIAgent",
     "AgentManager",
+    "start_model_training_scheduler",
 ]

--- a/ai-stock-platform/api/ml/model_scheduler.py
+++ b/ai-stock-platform/api/ml/model_scheduler.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Simple scheduler to retrain ML models periodically."""
+
+import logging
+from datetime import datetime
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+logger = logging.getLogger("model_scheduler")
+
+
+def train_models_job() -> None:
+    """Job that retrains all models."""
+    logger.info("Starting scheduled model training...")
+    from .train_models import ModelTrainer
+    trainer = ModelTrainer()
+    try:
+        trainer.train_all_models()
+        logger.info("Model training completed")
+    except Exception as exc:
+        logger.exception("Model training failed: %s", exc)
+
+
+def start_model_training_scheduler() -> BackgroundScheduler:
+    """Start the background scheduler for model training.
+
+    Returns the scheduler instance so callers can manage its lifecycle.
+    """
+    scheduler = BackgroundScheduler()
+    # Run every day at 02:00 UTC
+    scheduler.add_job(
+        train_models_job,
+        CronTrigger(hour=2, minute=0),
+        id="daily_model_training",
+        replace_existing=True,
+    )
+    scheduler.start()
+    logger.info("Model training scheduler started at %s", datetime.utcnow())
+    return scheduler
+
+
+if __name__ == "__main__":
+    sched = start_model_training_scheduler()
+    try:
+        while True:
+            # Keep the main thread alive to allow scheduler to run
+            sched.print_jobs()
+            import time
+            time.sleep(60)
+    except (KeyboardInterrupt, SystemExit):
+        sched.shutdown()

--- a/ai-stock-platform/api/requirements.txt
+++ b/ai-stock-platform/api/requirements.txt
@@ -18,4 +18,5 @@ aiohttp==3.9.5
 tweepy==4.14.0
 textblob==0.17.1
 nltk==3.8.1
+apscheduler==3.11.0
 aiosqlite==0.19.0

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+ROOT = os.path.join(os.path.dirname(__file__), "..", "ai-stock-platform")
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "api"))
+
+from api.ml.model_scheduler import start_model_training_scheduler
+
+
+def test_scheduler_adds_job():
+    scheduler = start_model_training_scheduler()
+    try:
+        jobs = scheduler.get_jobs()
+        assert any(job.id == "daily_model_training" for job in jobs)
+    finally:
+        scheduler.shutdown()


### PR DESCRIPTION
## Summary
- create APScheduler-based job for daily model training
- expose scheduler from `api.ml`
- include APScheduler in requirements
- test that scheduler registers job

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow', database connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872f46d8f20832a9ede63bb6d7a099e