### PR TITLE
Fix login API interactions

### DIFF
--- a/ai-stock-platform/main.py
+++ b/ai-stock-platform/main.py
@@ -332,8 +332,8 @@ async def direct_login_post(
         
         # Call API login endpoint
         response = requests.post(
-            f"{API_V1_URL}/auth/login", 
-            json=login_data,
+            f"{API_V1_URL}/auth/login",
+            data=login_data,
             timeout=5
         )
         

--- a/ai-stock-platform/ui/controllers/auth_controller.py
+++ b/ai-stock-platform/ui/controllers/auth_controller.py
@@ -90,10 +90,12 @@ async def login_post(
     templates = get_templates(request)
     
     try:
-        # TODO: Add main API login logic here
-        # For now, initialize variables to prevent undefined errors
-        access_token = None
-        response = None
+        api = APIClient()
+        api_resp = api.post_form(
+            "/auth/login",
+            data={"username": username, "password": password},
+        )
+        access_token = api_resp.get("data", {}).get("access_token")
         
         # If no format worked or no token received
         if not access_token:

--- a/ai-stock-platform/ui/routes/direct_routes.py
+++ b/ai-stock-platform/ui/routes/direct_routes.py
@@ -33,10 +33,15 @@ async def direct_login_post(
 ):
     """Direct login handler that forwards to API and handles the response"""
     logger.info(f"Direct login route hit for: {username}")
-    
-                continue
-        
-        if api_response and api_response.status_code == 200:
+
+    try:
+        api_response = requests.post(
+            f"{API_V1_URL}/auth/login",
+            data={"username": username, "password": password},
+            timeout=5,
+        )
+
+        if api_response.status_code == 200:
             # Login successful
             token_data = api_response.json()
             logger.info(f"Login successful for {username}")
@@ -58,7 +63,7 @@ async def direct_login_post(
             return redirect_response
         else:
             # Login failed
-                error_message = "Login failed"
+            error_message = "Login failed"
             
             # Fall back to emergency login
             logger.warning(f"API login failed for {username}: {error_message}")


### PR DESCRIPTION
## Summary
- send form data for login in main
- use form request in direct login route
- implement API call in auth controller login

## Testing
- `pytest -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6872f9497228832aa5e4000cb537e6f8