### PR TITLE
Add missing async DB table creator

### DIFF
--- a/ai-stock-platform/api/core/database.py
+++ b/ai-stock-platform/api/core/database.py
@@ -165,3 +165,10 @@ async def get_db_session():
     async with AsyncSessionLocal() as session:
         yield session
 
+
+async def create_db_and_tables() -> None:
+    """Create all database tables using the async engine."""
+    async with async_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+


### PR DESCRIPTION
## Summary
- fix import error for create_db_and_tables by implementing the function in `core/database.py`
- run project tests (they fail)

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6873c6fd7f14832a8e407e0c1bfc46df