### PR TITLE
Implement database table creation

### DIFF
--- a/ai-stock-platform/api/core/database.py
+++ b/ai-stock-platform/api/core/database.py
@@ -165,3 +165,14 @@ async def get_db_session():
     async with AsyncSessionLocal() as session:
         yield session
 
+
+async def create_db_and_tables() -> None:
+    """Create all database tables using the async engine."""
+    try:
+        async with async_engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        logger.info("Database tables created successfully")
+    except Exception as e:  # pragma: no cover - log runtime errors
+        logger.error("Failed to create database tables: %s", str(e))
+        raise
+


### PR DESCRIPTION
## Summary
- add async create_db_and_tables helper

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873c73ec880832aae7314ff874db3db