### PR TITLE
Fix demo defaults in UI

### DIFF
--- a/ai-stock-platform/ui/main.py
+++ b/ai-stock-platform/ui/main.py
@@ -300,20 +300,29 @@ class AuthUtils:
     @staticmethod
     def get_user_info(request: Request) -> dict:
         """Get user information from request"""
-        if AuthUtils.is_authenticated(request):
-            return {
-                "username": "demo",
-                "email": "demo@quantumvestai.com",
-                "role": "user",
-                "is_authenticated": True,
-                "features_enabled": {
-                    "advanced_analytics": True,
-                    "real_time_data": True,
-                    "portfolio_management": True,
-                    "ai_predictions": True
+        if not AuthUtils.is_authenticated(request):
+            return {"is_authenticated": False}
+
+        # Try to parse user information from the cookie set at login
+        user_cookie = request.cookies.get("user_info")
+        if user_cookie:
+            parts = user_cookie.split("|")
+            if len(parts) >= 3:
+                username, role, full_name = parts[0], parts[1], parts[2]
+                return {
+                    "username": username,
+                    "full_name": full_name,
+                    "role": role,
+                    "is_authenticated": True,
                 }
-            }
-        return {"is_authenticated": False}
+
+        # Fallback to demo user if cookie format unexpected
+        return {
+            "username": "demo",
+            "email": "demo@quantumvestai.com",
+            "role": "user",
+            "is_authenticated": True,
+        }
 
 # Enhanced route handlers
 @app.get("/", response_class=HTMLResponse)

--- a/ai-stock-platform/ui/static/js/quantum-community.js
+++ b/ai-stock-platform/ui/static/js/quantum-community.js
@@ -1229,8 +1229,8 @@ class QuantumCommunity {
 
     // Utility methods
     getCurrentUserId() {
-        // Get from session/localStorage or return demo user
-        return localStorage.getItem('quantum-user-id') || 'demo-user';
+        // Get from session/localStorage; return null if not set
+        return localStorage.getItem('quantum-user-id');
     }
 
     getUserLevel() {

--- a/ai-stock-platform/ui/utils/template_context.py
+++ b/ai-stock-platform/ui/utils/template_context.py
@@ -54,7 +54,8 @@ class TemplateContextProcessor:
             
             # Feature flags
             "debug_mode": os.environ.get("DEBUG", "false").lower() == "true",
-            "demo_mode": os.environ.get("DEMO_MODE", "true").lower() == "true",
+            # Demo mode is disabled by default. Enable by setting DEMO_MODE=true
+            "demo_mode": os.environ.get("DEMO_MODE", "false").lower() == "true",
             
             # Time helpers
             "timestamp": datetime.utcnow().isoformat(),


### PR DESCRIPTION
## Summary
- stop defaulting demo mode to true in template context
- parse user_info cookie instead of returning demo user for any authentication
- avoid hardcoding demo user ID in community script

## Testing
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6874395699fc832a85344caeb390769b