### PR TITLE
Add troubleshooting utilities and config fixes

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+# Example environment variables for QuantumVestAI

--- a/ai-stock-platform/ui/controllers/stock_controller.py
+++ b/ai-stock-platform/ui/controllers/stock_controller.py
@@ -5,6 +5,11 @@ Author: daparthi001
 """
 import logging
 import os
+
+# Default model to use for forecasts. Can be overridden via the
+# MODEL_ENSEMBLE environment variable which is mounted through the
+# application's ConfigMap in Kubernetes.
+MODEL_ENSEMBLE = os.getenv("MODEL_ENSEMBLE", "ADVANCED")
 from pathlib import Path
 
 import aiohttp

--- a/config.py
+++ b/config.py
@@ -1,0 +1,12 @@
+import os
+
+# Simple configuration accessor
+MODEL_ENSEMBLE = os.getenv("MODEL_ENSEMBLE", "ADVANCED")
+
+def get_db_url():
+    host = os.getenv("DB_HOST", "localhost")
+    port = os.getenv("DB_PORT", "5432")
+    name = os.getenv("DB_NAME", "quantumvestaidb")
+    user = os.getenv("DB_USER", "dbadmin")
+    password = os.getenv("DB_PASSWORD", "")
+    return f"postgresql://{user}:{password}@{host}:{port}/{name}"

--- a/config_fix.py
+++ b/config_fix.py
@@ -1,0 +1,8 @@
+import os
+
+# Ensure MODEL_ENSEMBLE is defined with a sensible default
+if "MODEL_ENSEMBLE" not in os.environ:
+    os.environ["MODEL_ENSEMBLE"] = "ADVANCED"
+    print("MODEL_ENSEMBLE not set. Defaulting to 'ADVANCED'")
+else:
+    print(f"MODEL_ENSEMBLE set to {os.environ['MODEL_ENSEMBLE']}")

--- a/db_migration.py
+++ b/db_migration.py
@@ -1,0 +1,36 @@
+import logging
+import os
+import sys
+import psycopg2
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger("db_migration")
+
+# Connection details from environment or default values
+DB_HOST = os.getenv("POSTGRES_SERVER", os.getenv("DB_HOST", "localhost"))
+DB_PORT = os.getenv("POSTGRES_PORT", os.getenv("DB_PORT", "5432"))
+DB_NAME = os.getenv("POSTGRES_DB", os.getenv("DB_NAME", "postgres"))
+DB_USER = os.getenv("POSTGRES_USER", os.getenv("DB_USER", "postgres"))
+DB_PASSWORD = os.getenv("POSTGRES_PASSWORD", os.getenv("DB_PASSWORD", ""))
+
+conn_str = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+
+logger.info("Connecting to %s", conn_str)
+try:
+    conn = psycopg2.connect(conn_str)
+except Exception as exc:
+    logger.error("Failed to connect: %s", exc)
+    sys.exit(1)
+
+with conn:
+    with conn.cursor() as cur:
+        cur.execute("""SELECT column_name FROM information_schema.columns
+                        WHERE table_name='users' AND column_name='hashed_password'""")
+        if cur.fetchone():
+            logger.info("Column 'hashed_password' already exists")
+        else:
+            logger.info("Adding missing 'hashed_password' column")
+            cur.execute("ALTER TABLE users ADD COLUMN hashed_password VARCHAR(255)")
+            logger.info("Column added successfully")
+
+logger.info("Migration complete")

--- a/k8s-configmap.yaml
+++ b/k8s-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: quantumvestai-config
+  namespace: dev
+data:
+  MODEL_ENSEMBLE: "ADVANCED"

--- a/stock_controller_fix.py
+++ b/stock_controller_fix.py
@@ -1,0 +1,19 @@
+"""Apply hotfix to stock_controller."""
+import fileinput
+import sys
+
+TARGET_FILE = "ai-stock-platform/ui/controllers/stock_controller.py"
+
+for line in fileinput.input(TARGET_FILE, inplace=True):
+    if line.strip().startswith("import os"):
+        print(line, end="")
+        print(
+            "# Default model to use for forecasts. Can be overridden via the"
+            "\n# MODEL_ENSEMBLE environment variable which is mounted through the"
+            "\n# application's ConfigMap in Kubernetes."
+            "\nMODEL_ENSEMBLE = os.getenv('MODEL_ENSEMBLE', 'ADVANCED')"
+        )
+    elif "Query(MODEL_ENSEMBLE)" in line and "MODEL_ENSEMBLE" not in line.split():
+        print(line.replace("Query(MODEL_ENSEMBLE)", "Query(MODEL_ENSEMBLE)"), end="")
+    else:
+        print(line, end="")


### PR DESCRIPTION
## Summary
- hotfix `stock_controller` to read MODEL_ENSEMBLE from env
- add example `.env` and config helper
- include simple migration and config fix scripts
- create Kubernetes ConfigMap example
- add script to patch stock controller if needed

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: test_auth login, database connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_687441eb8008832abdfcf584db2fc6cb