### PR TITLE
Fix Dockerfile entrypoint permissions

### DIFF
--- a/ai-stock-platform/api/Dockerfile
+++ b/ai-stock-platform/api/Dockerfile
@@ -42,7 +42,7 @@ HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
 EXPOSE ${PORT}
 
 # Copy entrypoint script
-COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+COPY --chown=appuser:appuser docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh
 
 # Use entrypoint to run migrations before starting


### PR DESCRIPTION
## Summary
- fix permission issue when copying entrypoint script in Dockerfile

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68745a86a3b8832a86fa291554f24273