### PR TITLE
Improve migration logging when DB unavailable

### DIFF
--- a/ai-stock-platform/api/scripts/database_migrator.py
+++ b/ai-stock-platform/api/scripts/database_migrator.py
@@ -129,7 +129,23 @@ class DatabaseMigrator:
         await self.connection.execute(create_table_query)
         logger.info("Migration log table created")
 
-    async def log_migration(self, migration_name: str, success: bool = True, error_message: str | None = None):
+    async def log_migration(
+        self,
+        migration_name: str,
+        success: bool = True,
+        error_message: str | None = None,
+    ) -> None:
+        """Record the result of a migration run.
+
+        If no database connection is available, the log entry is skipped to
+        avoid further errors when the connection attempt itself fails.
+        """
+        if not self.connection:
+            logger.warning(
+                "Skipping migration log because no database connection is available"
+            )
+            return
+
         query = """
         INSERT INTO migration_log (migration_name, success, error_message)
         VALUES ($1, $2, $3);


### PR DESCRIPTION
## Summary
- skip writing migration logs when no DB connection available

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687461bcde94832a9fbd0e2bca89bd65