### PR TITLE
Fix stock_controller import error

### DIFF
--- a/ai-stock-platform/ui/controllers/stock_controller.py
+++ b/ai-stock-platform/ui/controllers/stock_controller.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import aiohttp
 from fastapi import APIRouter, Form, HTTPException, Query, Request
+from config.constants import MODEL_ENSEMBLE
 
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates


### PR DESCRIPTION
## Summary
- import MODEL_ENSEMBLE constant into `stock_controller`

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: database connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_687460f08618832a99d580734964bc77