### PR TITLE
Fix default DB URL in migrator

### DIFF
--- a/ai-stock-platform/api/scripts/database_migrator.py
+++ b/ai-stock-platform/api/scripts/database_migrator.py
@@ -13,7 +13,17 @@ logger = logging.getLogger(__name__)
 
 class DatabaseMigrator:
     def __init__(self, db_url=None):
-        self.db_url = db_url or os.getenv('DATABASE_URL', 'postgresql://user:pass@localhost/quantumvestai')
+        """Initialize the migrator with a database URL.
+
+        Falls back to a local PostgreSQL instance if ``DATABASE_URL`` is not
+        provided. The default connection string matches the development
+        settings used throughout the project.
+        """
+
+        default_url = (
+            "postgresql://postgres:postgres@localhost:5432/quantumvestai"
+        )
+        self.db_url = db_url or os.getenv("DATABASE_URL", default_url)
         self.connection = None
 
     async def connect(self):


### PR DESCRIPTION
## Summary
- fix database URL in `DatabaseMigrator`

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687466a2bcb4832a9b3730274a43d564