### PR TITLE
Update Dockerfile defaults for DB connection

### DIFF
--- a/ai-stock-platform/api/Dockerfile
+++ b/ai-stock-platform/api/Dockerfile
@@ -29,7 +29,15 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     TZ=UTC \
     API_ENV="development" \
     PROJECT_NAME="QuantumVestAI API" \
-    VERSION="1.0.1"
+    VERSION="1.0.1" \
+    POSTGRES_SERVER=localhost \
+    POSTGRES_USER=postgres \
+    POSTGRES_PASSWORD=postgres \
+    POSTGRES_DB=quantumvestai \
+    POSTGRES_PORT=5432
+
+# Provide default connection string so database_migrator.py can run
+ENV DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_SERVER}:${POSTGRES_PORT}/${POSTGRES_DB}"
 
 # Healthcheck - Test the /api/v1/health endpoint specifically
 # Set up a non-root user


### PR DESCRIPTION
## Summary
- default PostgreSQL variables in API Dockerfile
- expose DATABASE_URL for migration script

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: KeyboardInterrupt, 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6874686907c4832a914fa9734c1a4a15