### PR TITLE
Add Kubernetes SECRET_KEY support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,5 +139,17 @@ For local development you can initialize a PostgreSQL database by running:
 If the tables are missing at startup, the API will attempt to create them
 automatically.
 
+### Docker Environment Files
+Both the API and UI containers load environment variables from files matching
+their runtime environment. When the container starts it looks for a file named
+`.env.<environment>` inside the respective directory and applies those values.
+Set `API_ENV` for the API image or `ENV` for the UI image to select which file
+should be used (for example `API_ENV=production`).
+
+Sensitive values like `SECRET_KEY` should not be stored in these files for
+production deployments. Instead, create a Kubernetes `Secret` and mount it as an
+environment variable or file. Both the API and UI startup scripts will read a
+`SECRET_KEY_FILE` path if provided to load the key securely.
+
 
 \n

--- a/ai-stock-platform/api/.env.production
+++ b/ai-stock-platform/api/.env.production
@@ -1,0 +1,25 @@
+# Production Environment Configuration
+APP_NAME=QuantumVestAI
+VERSION=1.0.0
+DEBUG=false
+ENVIRONMENT=production
+
+# Server
+PORT=8000
+WORKERS=4
+RELOAD=false
+
+# Database
+POSTGRES_SERVER=db
+POSTGRES_USER=quantumvest
+POSTGRES_PASSWORD=secureprod
+POSTGRES_DB=quantumvestai
+POSTGRES_PORT=5432
+
+# Security
+# SECRET_KEY will be provided at runtime via Kubernetes Secret
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+REFRESH_TOKEN_EXPIRE_DAYS=7
+
+# Logging
+LOG_LEVEL=INFO

--- a/ai-stock-platform/api/docker-entrypoint.sh
+++ b/ai-stock-platform/api/docker-entrypoint.sh
@@ -11,6 +11,25 @@ echo "Environment: $API_ENV"
 echo "User: $(whoami)"
 echo "Python: $(python --version)"
 
+# Load environment-specific configuration if present
+ENV_FILE="/app/.env.${API_ENV}"
+if [ -f "$ENV_FILE" ]; then
+    echo "Loading environment variables from $ENV_FILE"
+    cp "$ENV_FILE" /app/.env
+    set -a
+    source /app/.env
+    set +a
+
+# If SECRET_KEY_FILE is specified, load secret key from that file
+if [ -n "$SECRET_KEY_FILE" ] && [ -f "$SECRET_KEY_FILE" ]; then
+    echo "Loading SECRET_KEY from $SECRET_KEY_FILE"
+    export SECRET_KEY="$(cat "$SECRET_KEY_FILE")"
+fi
+
+else
+    echo "No environment file found for $API_ENV"
+fi
+
 # Create required directories
 mkdir -p /app/api /app/logs
 

--- a/ai-stock-platform/ui/.env.production
+++ b/ai-stock-platform/ui/.env.production
@@ -1,0 +1,16 @@
+# QuantumVestAI UI Production Configuration
+ENV=production
+DEBUG=false
+# SECRET_KEY is injected via Kubernetes Secret
+PORT=3000
+HOST=0.0.0.0
+WORKERS=4
+LOG_LEVEL=info
+
+# API Configuration
+API_BASE_URL=http://localhost:8000/api
+API_TIMEOUT=10
+
+# CORS Settings
+CORS_ORIGINS=http://localhost:3000,http://localhost:8000
+CORS_ALLOW_CREDENTIALS=true

--- a/ai-stock-platform/ui/scripts/start.sh
+++ b/ai-stock-platform/ui/scripts/start.sh
@@ -7,12 +7,27 @@ set -e
 
 echo "Starting QuantumVestAI UI application..."
 
+# Determine environment and load matching .env file
+ENV=${ENV:-production}
+ENV_FILE=".env.${ENV}"
+if [ -f "$ENV_FILE" ]; then
+    echo "Using environment file $ENV_FILE"
+    cp "$ENV_FILE" .env
+fi
+
 # Load environment variables if .env file exists
 if [ -f .env ]; then
     echo "Loading environment variables from .env file"
     set -a
     source .env
+
     set +a
+fi
+
+# Load SECRET_KEY from mounted file if provided
+if [ -n "$SECRET_KEY_FILE" ] && [ -f "$SECRET_KEY_FILE" ]; then
+    echo "Loading SECRET_KEY from $SECRET_KEY_FILE"
+    export SECRET_KEY="$(cat "$SECRET_KEY_FILE")"
 fi
 
 # Set default values with proper validation


### PR DESCRIPTION
## Summary
- document using Kubernetes secrets to provide `SECRET_KEY`
- remove hardcoded `SECRET_KEY` from production env files
- load key from optional `SECRET_KEY_FILE` in startup scripts

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68749b3d0268832a9ea756796b20ebdf