### PR TITLE
Handle CORS_ORIGINS env var

### DIFF
--- a/ai-stock-platform/ui/config/settings.py
+++ b/ai-stock-platform/ui/config/settings.py
@@ -32,6 +32,17 @@ class Settings(BaseSettings):
         default=["http://localhost:3000", "https://app.quantumvestai.com"],
         env='CORS_ORIGINS'
     )
+
+    @validator("CORS_ORIGINS", pre=True)
+    def parse_cors_origins(cls, v):
+        """Allow comma separated or JSON list and handle empty values."""
+        if isinstance(v, str):
+            if not v:
+                return []
+            if not v.startswith("["):
+                return [orig.strip() for orig in v.split(",") if orig.strip()]
+        return v
+
     CORS_ALLOW_CREDENTIALS: bool = Field(default=True, env='CORS_ALLOW_CREDENTIALS')
     CORS_ALLOW_METHODS: List[str] = Field(
         default=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ import sys
 ROOT = os.path.join(os.path.dirname(__file__), "..", "ai-stock-platform")
 sys.path.append(ROOT)
 sys.path.append(os.path.join(ROOT, "api"))
+sys.path.append(os.path.join(ROOT, "ui"))
 import pytest
 from api.core.config import Settings, validate_settings
 
@@ -67,3 +68,11 @@ def test_environment_validation():
     # Test production environment
     settings = Settings(ENVIRONMENT="production")
     assert settings.DEBUG is False
+
+
+def test_ui_cors_origins_empty_string():
+    """Ensure UI settings handle empty CORS_ORIGINS"""
+    from ui.config.settings import Settings as UISettings
+
+    settings = UISettings(CORS_ORIGINS="")
+    assert settings.CORS_ORIGINS == []


### PR DESCRIPTION
## Summary
- add validator for `CORS_ORIGINS` in UI settings
- extend config tests for UI settings

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: test_auth, test_db_connection, test_trending_stocks)*

------
https://chatgpt.com/codex/tasks/task_e_68752ec803c0832aa7b18a060cf6a265