### PR TITLE
Handle CORS_ORIGINS env var

### DIFF
--- a/ai-stock-platform/ui/config/settings.py
+++ b/ai-stock-platform/ui/config/settings.py
@@ -8,9 +8,9 @@ import logging
 from typing import List, Optional, Union
 from urllib.parse import quote
 
-from pydantic import AnyHttpUrl, Field, SecretStr, validator
+from pydantic import AnyHttpUrl, Field, SecretStr, field_validator
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -32,6 +32,18 @@ class Settings(BaseSettings):
         default=["http://localhost:3000", "https://app.quantumvestai.com"],
         env='CORS_ORIGINS'
     )
+
+    @field_validator("CORS_ORIGINS", mode="before")
+    @classmethod
+    def parse_cors_origins(cls, v):
+        """Allow comma separated or JSON list and handle empty values."""
+        if isinstance(v, str):
+            if not v:
+                return []
+            if not v.startswith("["):
+                return [orig.strip() for orig in v.split(",") if orig.strip()]
+        return v
+
     CORS_ALLOW_CREDENTIALS: bool = Field(default=True, env='CORS_ALLOW_CREDENTIALS')
     CORS_ALLOW_METHODS: List[str] = Field(
         default=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
@@ -65,7 +77,8 @@ class Settings(BaseSettings):
     JWT_ALGORITHM: str = Field(default="HS256", env='JWT_ALGORITHM')
     ACCESS_TOKEN_EXPIRE_MINUTES: int = Field(default=30, env='ACCESS_TOKEN_EXPIRE_MINUTES')
 
-    @validator("LOG_LEVEL")
+    @field_validator("LOG_LEVEL")
+    @classmethod
     def validate_log_level(cls, v):
         valid_levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
         v = v.upper()
@@ -84,9 +97,10 @@ class Settings(BaseSettings):
         encoded_password = quote(password)
         return f"postgresql://{user}:{encoded_password}@{host}:{port}/{name}"
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = True
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=True,
+    )
 
 # Instantiate settings
 settings = Settings()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ import sys
 ROOT = os.path.join(os.path.dirname(__file__), "..", "ai-stock-platform")
 sys.path.append(ROOT)
 sys.path.append(os.path.join(ROOT, "api"))
+sys.path.append(os.path.join(ROOT, "ui"))
 import pytest
 from api.core.config import Settings, validate_settings
 
@@ -67,3 +68,11 @@ def test_environment_validation():
     # Test production environment
     settings = Settings(ENVIRONMENT="production")
     assert settings.DEBUG is False
+
+
+def test_ui_cors_origins_empty_string():
+    """Ensure UI settings handle empty CORS_ORIGINS"""
+    from ui.config.settings import Settings as UISettings
+
+    settings = UISettings(CORS_ORIGINS="")
+    assert settings.CORS_ORIGINS == []


### PR DESCRIPTION
## Summary
- add validator for `CORS_ORIGINS` in UI settings
- extend config tests for UI settings
- modernize UI settings to use `field_validator`

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: test_auth, test_db_connection, test_trending_stocks)*

------
https://chatgpt.com/codex/tasks/task_e_68752ec803c0832aa7b18a060cf6a265