### PR TITLE
Fix CORS_ORIGINS env parsing

### DIFF
--- a/ai-stock-platform/ui/config/settings.py
+++ b/ai-stock-platform/ui/config/settings.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
     )
     
     # CORS settings
-    CORS_ORIGINS: List[str] = Field(
+    CORS_ORIGINS: List[str] | str = Field(
         default=["http://localhost:3000", "https://app.quantumvestai.com"],
         env='CORS_ORIGINS'
     )
@@ -36,12 +36,18 @@ class Settings(BaseSettings):
     @field_validator("CORS_ORIGINS", mode="before")
     @classmethod
     def parse_cors_origins(cls, v):
-        """Allow comma separated or JSON list and handle empty values."""
+        """Allow comma-separated or JSON list and handle empty values."""
         if isinstance(v, str):
             if not v:
                 return []
-            if not v.startswith("["):
-                return [orig.strip() for orig in v.split(",") if orig.strip()]
+            if v.startswith("["):
+                try:
+                    import json
+                    parsed = json.loads(v)
+                    return [orig.strip() for orig in parsed if orig.strip()]
+                except Exception:
+                    return [orig.strip() for orig in v.strip("[]").split(",") if orig.strip()]
+            return [orig.strip() for orig in v.split(",") if orig.strip()]
         return v
 
     CORS_ALLOW_CREDENTIALS: bool = Field(default=True, env='CORS_ALLOW_CREDENTIALS')


### PR DESCRIPTION
## Summary
- loosen type of `CORS_ORIGINS` in UI settings to allow string or list
- improve validator to gracefully parse comma separated values or JSON lists

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687561053e54832aac459103d961fc3c