### PR TITLE
Add missing UI env vars

### DIFF
--- a/ai-stock-platform/ui/config/settings.py
+++ b/ai-stock-platform/ui/config/settings.py
@@ -106,6 +106,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
         case_sensitive=True,
+        extra="ignore",
     )
 
 # Instantiate settings

--- a/ci-cd/k8s/ui-deployment.yaml
+++ b/ci-cd/k8s/ui-deployment.yaml
@@ -111,6 +111,29 @@ spec:
           value: "3000"
         - name: HOST
           value: "0.0.0.0"
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: ui-secrets
+              key: JWT_SECRET_KEY
+        - name: APP_VERSION
+          value: "v1.5.2"
+        - name: API_BASE_URL
+          value: "http://quantumvestai-dev-api.dev.svc.cluster.local:8000/api"
+        - name: ENV
+          value: "production"
+        - name: ENVIRONMENT
+          value: "development"
+        - name: DEBUG
+          value: "false"
+        - name: WORKERS
+          value: "4"
+        - name: LOG_LEVEL
+          value: "info"
+        - name: CORS_ORIGINS
+          value: "*"
+        - name: CORS_ALLOW_CREDENTIALS
+          value: "true"
         
         # Use startup script from container
         command: ["/bin/bash", "-c"]


### PR DESCRIPTION
## Summary
- update `ui-deployment.yaml` with environment variables used by the UI to avoid runtime errors
- allow unknown env vars in `ui/config/settings.py`

## Testing
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*


------
https://chatgpt.com/codex/tasks/task_e_687565d7379c832a9a0b1ccf99fc3666