### PR TITLE
Fix API URL building in client

### DIFF
--- a/ai-stock-platform/ui/services/api_client.py
+++ b/ai-stock-platform/ui/services/api_client.py
@@ -6,6 +6,7 @@ Author: daparthi001
 import json
 import logging
 from typing import Any, Dict, Optional, Union
+from urllib.parse import urljoin
 
 import requests
 from core.config.settings import settings
@@ -53,11 +54,10 @@ class APIClient:
         return f"/api/v1/{endpoint}"
     
     def build_url(self, endpoint: str) -> str:
-        """Build full URL for an endpoint"""
-        # Ensure endpoint starts with /
-        if not endpoint.startswith("/"):
-            endpoint = f"/{endpoint}"
-        return f"{self.base_url}{endpoint}"
+        """Build full URL for an endpoint, handling base paths gracefully."""
+        normalized = self._normalize_endpoint(endpoint)
+        base = self.base_url.rstrip("/")
+        return urljoin(base, normalized)
         
     def _handle_response(self, response: requests.Response) -> Dict[str, Any]:
         """Handle API response and errors"""
@@ -87,7 +87,7 @@ class APIClient:
     def get(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Make a GET request to the API"""
         normalized_endpoint = self._normalize_endpoint(endpoint)
-        url = f"{self.base_url}{normalized_endpoint}"
+        url = self.build_url(endpoint)
         
         self.logger.debug(f"Making GET request to {url}")
         try:
@@ -106,8 +106,8 @@ class APIClient:
     def post(self, endpoint: str, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Make a POST request to the API"""
         normalized_endpoint = self._normalize_endpoint(endpoint)
-        url = f"{self.base_url}{normalized_endpoint}"
-        
+        url = self.build_url(endpoint)
+
         self.logger.debug(f"Making POST request to {url}")
         try:
             response = requests.post(
@@ -130,7 +130,7 @@ class APIClient:
     def post_form(self, endpoint: str, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Make a POST request with form-encoded data."""
         normalized_endpoint = self._normalize_endpoint(endpoint)
-        url = f"{self.base_url}{normalized_endpoint}"
+        url = self.build_url(endpoint)
 
         headers = self._get_headers()
         headers["Content-Type"] = "application/x-www-form-urlencoded"
@@ -157,7 +157,7 @@ class APIClient:
     def put(self, endpoint: str, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Make a PUT request to the API"""
         normalized_endpoint = self._normalize_endpoint(endpoint)
-        url = f"{self.base_url}{normalized_endpoint}"
+        url = self.build_url(endpoint)
         
         self.logger.debug(f"Making PUT request to {url}")
         try:
@@ -176,7 +176,7 @@ class APIClient:
     def delete(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Make a DELETE request to the API"""
         normalized_endpoint = self._normalize_endpoint(endpoint)
-        url = f"{self.base_url}{normalized_endpoint}"
+        url = self.build_url(endpoint)
         
         self.logger.debug(f"Making DELETE request to {url}")
         try:

--- a/ai-stock-platform/ui/tests/test_services/test_api_client.py
+++ b/ai-stock-platform/ui/tests/test_services/test_api_client.py
@@ -46,7 +46,7 @@ def test_api_client_get(mock_get):
     
     # Check request was made correctly
     mock_get.assert_called_once_with(
-        f"{settings.API_BASE_URL}/test-endpoint",
+        f"{settings.API_BASE_URL.rstrip('/')}/api/v1/test-endpoint",
         headers=client.headers,
         params=None,
         timeout=10
@@ -69,7 +69,7 @@ def test_api_client_get_with_params(mock_get):
     
     # Check params were passed correctly
     mock_get.assert_called_once_with(
-        f"{settings.API_BASE_URL}/test-endpoint",
+        f"{settings.API_BASE_URL.rstrip('/')}/api/v1/test-endpoint",
         headers=client.headers,
         params={"key": "value"},
         timeout=10
@@ -117,7 +117,7 @@ def test_api_client_post(mock_post):
     
     # Check request was made correctly
     mock_post.assert_called_once_with(
-        f"{settings.API_BASE_URL}/test-endpoint",
+        f"{settings.API_BASE_URL.rstrip('/')}/api/v1/test-endpoint",
         headers=client.headers,
         data=json.dumps(data),
         timeout=10
@@ -141,7 +141,7 @@ def test_api_client_put(mock_put):
     
     # Check request was made correctly
     mock_put.assert_called_once_with(
-        f"{settings.API_BASE_URL}/test-endpoint/123",
+        f"{settings.API_BASE_URL.rstrip('/')}/api/v1/test-endpoint/123",
         headers=client.headers,
         data=json.dumps(data),
         timeout=10
@@ -163,7 +163,7 @@ def test_api_client_delete(mock_delete):
     
     # Check request was made correctly
     mock_delete.assert_called_once_with(
-        f"{settings.API_BASE_URL}/test-endpoint/123",
+        f"{settings.API_BASE_URL.rstrip('/')}/api/v1/test-endpoint/123",
         headers=client.headers,
         timeout=10
     )
@@ -177,15 +177,15 @@ def test_api_client_build_url():
     
     # Test with leading slash
     url = client.build_url("/endpoint")
-    assert url == f"{settings.API_BASE_URL}/endpoint"
+    assert url == f"{settings.API_BASE_URL.rstrip('/')}/api/v1/endpoint"
     
     # Test without leading slash
     url = client.build_url("endpoint")
-    assert url == f"{settings.API_BASE_URL}/endpoint"
+    assert url == f"{settings.API_BASE_URL.rstrip('/')}/api/v1/endpoint"
     
     # Test with query parameters already in path
     url = client.build_url("/endpoint?param=value")
-    assert url == f"{settings.API_BASE_URL}/endpoint?param=value"
+    assert url == f"{settings.API_BASE_URL.rstrip('/')}/api/v1/endpoint?param=value"
 
 @patch("requests.post")
 def test_api_client_authenticate(mock_post):
@@ -204,10 +204,10 @@ def test_api_client_authenticate(mock_post):
     
     # Check auth request was made correctly
     mock_post.assert_called_once_with(
-        f"{settings.API_BASE_URL}/auth/login",
+        f"{settings.API_BASE_URL.rstrip('/')}/api/v1/auth/login",
         headers=client.headers,
         data=json.dumps({
-            "username": "testuser", 
+            "username": "testuser",
             "password": "password"
         }),
         timeout=10


### PR DESCRIPTION
## Summary
- improve API URL construction so base URL may include `/api`
- update tests for new URL logic

## Testing
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875be047610832aa877e0d62afd94bb