### PR TITLE
Update docs for k8s svc access

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -16,7 +16,7 @@ The QuantumVestAI API provides comprehensive access to AI-powered stock market a
 
 - **Development**: `https://dev.quantumvestai.com`
 - **Production**: `https://api.quantumvestai.com`
-- **Local Development**: `http://localhost:5000`
+- **Internal Service**: `http://quantumvestai-dev-api:8000`
 
 ### Authentication
 
@@ -190,12 +190,12 @@ For additional support:
 
 ## Development
 
-### Local Testing
-To test the API locally:
+### Cluster Testing
+To test the API inside the Kubernetes cluster:
 
-1. Start the QuantumVestAI API server
-2. Use the local base URL: `http://localhost:5000`
-3. Access the interactive docs at: `http://localhost:5000/docs`
+1. Ensure the `quantumvestai-dev-api` service is running
+2. Use the service base URL: `http://quantumvestai-dev-api:8000`
+3. Access the interactive docs at: `http://quantumvestai-dev-api:8000/docs`
 
 ### Validation
 The OpenAPI specification has been validated for:

--- a/TWITTER_API_SETUP.md
+++ b/TWITTER_API_SETUP.md
@@ -105,17 +105,17 @@ To verify your Twitter API integration is working:
 
 1. **Health Check Endpoint**
    ```bash
-   curl http://localhost:5000/api/social/twitter/health
+   curl http://quantumvestai-dev-api:8000/api/social/twitter/health
    ```
 
 2. **Test Sentiment Analysis**
    ```bash
-   curl http://localhost:5000/api/social/twitter/sentiment/AAPL
+   curl http://quantumvestai-dev-api:8000/api/social/twitter/sentiment/AAPL
    ```
 
 3. **Test Trending Stocks**
    ```bash
-   curl http://localhost:5000/api/social/twitter/trending
+   curl http://quantumvestai-dev-api:8000/api/social/twitter/trending
    ```
 
 ## API Endpoints

--- a/ai-stock-platform/ui/.env.example
+++ b/ai-stock-platform/ui/.env.example
@@ -10,7 +10,7 @@ WORKERS=4
 LOG_LEVEL=debug
 
 # API Configuration
-API_BASE_URL=http://localhost:5000/api
+API_BASE_URL=http://quantumvestai-dev-api:8000/api
 API_TIMEOUT=10
 
 # HTTP Client Configuration
@@ -46,7 +46,7 @@ RATE_LIMIT_DEFAULT=100/minute
 RATE_LIMIT_AUTH=20/minute
 
 # CORS Settings
-CORS_ORIGINS=http://localhost:3000,http://localhost:8000
+CORS_ORIGINS=http://ui-service,http://quantumvestai-dev-api:8000
 CORS_ALLOW_CREDENTIALS=true
 
 # Caching

--- a/ai-stock-platform/ui/README.md
+++ b/ai-stock-platform/ui/README.md
@@ -86,7 +86,7 @@ This is a complete, production-ready web UI for the QuantumVestAI platform featu
    ```
 
 4. **Access the Application**:
-   - Open your browser to: http://localhost:3000
+   - Open your browser to: http://ui-service
    - Use demo accounts to login (see Demo Accounts section below)
 
 ## 👤 Demo Accounts

--- a/swagger.json
+++ b/swagger.json
@@ -23,8 +23,8 @@
       "description": "Production server"
     },
     {
-      "url": "http://localhost:5000",
-      "description": "Local development server"
+      "url": "http://quantumvestai-dev-api:8000",
+      "description": "Internal cluster service"
     }
   ],
   "security": [

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -39,8 +39,8 @@ servers:
     description: Development server
   - url: https://api.quantumvestai.com
     description: Production server
-  - url: http://localhost:5000
-    description: Local development server
+  - url: http://quantumvestai-dev-api:8000
+    description: Internal cluster service
 
 security:
   - bearerAuth: []


### PR DESCRIPTION
## Summary
- show internal service base URL in API docs
- point example `curl` commands at the API service
- reference `ui-service` in UI instructions
- adjust example env file for service URLs
- update Swagger specs for internal service address

## Testing
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875c12d12f0832abb37949df150b136