### PR TITLE
Fix homepage demo login

### DIFF
--- a/ai-stock-platform/ui/routes/dashboard.py
+++ b/ai-stock-platform/ui/routes/dashboard.py
@@ -36,19 +36,8 @@ async def dashboard_page(request: Request):
     try:
         logger.info("Loading dashboard page in demo mode")
         
-        # Get user info from request (demo mode)
-        user = {
-            "username": "demo",
-            "email": "demo@quantumvestai.com", 
-            "is_authenticated": True,
-            "account_type": "Premium Demo",
-            "features_enabled": {
-                "advanced_analytics": True,
-                "real_time_data": True,
-                "portfolio_management": True,
-                "ai_predictions": True
-            }
-        }
+        # Do not assume a logged-in demo user
+        user = None
         
         # Demo watchlist removed
         watchlist_items = []


### PR DESCRIPTION
## Summary
- remove hardcoded demo user from dashboard so homepage doesn't show as logged in

## Testing
- `pytest -q` *(fails: test_auth, test_db_connection, test_trending_stocks)*

------
https://chatgpt.com/codex/tasks/task_e_6875c20113f8832ab93a17b2101fcf05