### PR TITLE
Add hero illustration to home page

### DIFF
--- a/ai-stock-platform/ui/static/img/hero-investment.svg
+++ b/ai-stock-platform/ui/static/img/hero-investment.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" aria-hidden="true">
+  <defs>
+    <linearGradient id="heroGradient" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#4facfe"/>
+      <stop offset="100%" stop-color="#00f2fe"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="400" fill="url(#heroGradient)" rx="20"/>
+  <polyline points="60,340 200,220 270,260 400,140 540,200" fill="none" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="520,220 540,200 540,240" fill="none" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/ai-stock-platform/ui/templates/home.html
+++ b/ai-stock-platform/ui/templates/home.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
 
+{% block head_extra %}
+<style>
+    .hero-image { max-width: 100%; height: auto; }
+</style>
+{% endblock %}
+
 {% block title %}QuantumVestAI - Stock Market Forecasting and Analytics{% endblock %}
 
 {% block content %}
@@ -14,7 +20,8 @@
             </div>
         </div>
         <div class="col-lg-6">
-            <div class="hero-chart">
+            <div class="hero-chart text-center">
+                <img src="{{ get_asset_url('img/hero-investment.svg') }}" alt="Confident investing" class="hero-image mb-3">
                 <canvas id="heroChart"></canvas>
             </div>
         </div>

--- a/docs/UI_IMAGES.md
+++ b/docs/UI_IMAGES.md
@@ -26,3 +26,9 @@ web using publicly available image services.
 
 ![Stock Placeholder](https://via.placeholder.com/300x200.png?text=Stock)
 ![News Placeholder](https://via.placeholder.com/300x200.png?text=News)
+
+## Hero Illustration
+
+The home page features a simple vector image representing market growth. This SVG is stored in the repository to avoid large binary assets.
+
+![Hero Illustration](../ai-stock-platform/ui/static/img/hero-investment.svg)


### PR DESCRIPTION
## Summary
- add new hero-investment illustration SVG
- document hero image in UI visuals
- embed hero illustration on home page with lightweight CSS

## Testing
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875c75f8548832a88f6ff6dec8cea65