### PR TITLE
Fix alembic path in DB init Dockerfile

### DIFF
--- a/ai-stock-platform/api/Dockerfile.db-init
+++ b/ai-stock-platform/api/Dockerfile.db-init
@@ -24,7 +24,7 @@ RUN mkdir -p /app/models \
     /app/core \
     /app/db \
     /app/scripts \
-    /app/alembic
+    /app/api/alembic
 
 # Copy requirements and configuration files first (for better layer caching)
 COPY requirements.txt .
@@ -37,13 +37,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY models/ /app/models/
 COPY core/ /app/core/
 COPY db/ /app/db/
-COPY alembic/ /app/alembic/
+COPY alembic/ /app/api/alembic/
 COPY scripts/ /app/scripts/
 
 # Make scripts executable
 RUN chmod +x /app/scripts/*.sh && \
-    chmod -R 644 /app/models /app/core /app/db /app/alembic && \
-    chmod 755 /app/models /app/core /app/db /app/alembic /app/scripts
+    chmod -R 644 /app/models /app/core /app/db /app/api/alembic && \
+    chmod 755 /app/models /app/core /app/db /app/api/alembic /app/scripts
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
## Summary
- ensure DB init container copies migrations to `/app/api/alembic`

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875f20483dc832a80b79968cd860edf