### PR TITLE
Fix Alembic module path resolution

### DIFF
--- a/ai-stock-platform/api/alembic/env.py
+++ b/ai-stock-platform/api/alembic/env.py
@@ -10,8 +10,13 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-# Add the parent directory to Python path
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+# Add the project root containing the ``core`` package to ``sys.path``.
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+if not (project_root / "core").exists():
+    project_root = project_root.parent
+sys.path.append(str(project_root))
 
 from core.config import settings
 # Import the SQLAlchemy metadata


### PR DESCRIPTION
## Summary
- ensure Alembic finds the `core` package regardless of directory layout
- add runtime check for project root to env.py

## Testing
- `pytest -q` *(fails: Application structure issues)*

------
https://chatgpt.com/codex/tasks/task_e_6875f67256ac832ab83bc9b0e29c22ca