### PR TITLE
Fix db import alias

### DIFF
--- a/ai-stock-platform/api/__init__.py
+++ b/ai-stock-platform/api/__init__.py
@@ -35,6 +35,13 @@ for name in ("exceptions", "responses", "validation", "database", "security", "m
     except Exception:
         pass
 
+# Expose the ``db`` package as a top level module. Several modules import
+# ``db.session`` or ``db.models`` assuming ``db`` is available on ``sys.path``.
+# When the application is executed from outside of ``api`` this alias ensures
+# those imports resolve to ``api.db``.
+db_pkg = importlib.import_module('api.db')
+sys.modules.setdefault('db', db_pkg)
+
 # Remove local ``multipart`` stub if present so the real ``python-multipart``
 # package can be used by FastAPI/Starlette.
 sys.modules.pop('multipart', None)


### PR DESCRIPTION
## Summary
- expose `api.db` as a top-level `db` package in `api/__init__.py`

## Testing
- `pytest -q` *(fails: templates directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68767a0f2c58832aa2c17f83be4c812c