### PR TITLE
Fix Alembic env path to prioritize core package

### DIFF
--- a/ai-stock-platform/api/alembic/env.py
+++ b/ai-stock-platform/api/alembic/env.py
@@ -24,7 +24,9 @@ if not (project_root / "core").exists():
         project_root = alt_root
     else:
         project_root = project_root.parent
-sys.path.append(str(project_root))
+# Prepend the project root to ``sys.path`` so the top-level ``core`` package
+# is resolved before the local ``core`` directory inside the Alembic folder.
+sys.path.insert(0, str(project_root))
 
 from core.config import settings
 # Import the SQLAlchemy metadata


### PR DESCRIPTION
## Summary
- ensure Alembic finds the real `core` package by prepending project root to `sys.path`

## Testing
- `./setup_env.sh`
- `source venv/bin/activate && pytest -q` *(fails: 10 failed, 24 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687687323858832a9dd01b2190c8fa23