### PR TITLE
Fix config imports to load settings correctly

### DIFF
--- a/ai-stock-platform/api/db/session.py
+++ b/ai-stock-platform/api/db/session.py
@@ -30,14 +30,16 @@ logger = logging.getLogger(__name__)
 
 # Defensive import strategy
 try:
-    # Try the correct import path first
-    from core.config.settings import settings
-    logger.info("Successfully imported settings from core.config.settings")
+    # Try the API package first to avoid the ``core`` compatibility
+    # module which can return the settings module instead of the
+    # ``settings`` instance when imported from "core.config.settings".
+    from api.core.config.settings import settings
+    logger.info("Successfully imported settings from api.core.config.settings")
 except ImportError:
     try:
         # Try alternate import path
-        from core.config import settings
-        logger.info("Successfully imported settings from core.config")
+        from core.config.settings import settings
+        logger.info("Successfully imported settings from core.config.settings")
     except ImportError:
         # Create fallback settings if all imports fail
         logger.error("Failed to import settings, using environment variables directly")

--- a/ai-stock-platform/api/services/stock_service.py
+++ b/ai-stock-platform/api/services/stock_service.py
@@ -12,7 +12,10 @@ import aiohttp
 # Import settings explicitly from the configuration module to avoid
 # accidentally importing the module itself when the `core.config`
 # package is present in the Python path.
-from core.config.settings import settings
+# Import settings directly from the API package.  Importing via the
+# ``core`` compatibility package may resolve to the ``core.config.settings``
+# module instead of the ``settings`` instance which causes attribute errors.
+from api.core.config.settings import settings
 from sqlalchemy.orm import Session
 
 from models.stock import Stock, WatchList

--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -15,7 +15,11 @@ from typing import Any, Dict, List, Optional
 
 # Explicitly import the settings instance to avoid ambiguity with the
 # `core.config` package which also contains a `settings` submodule.
-from core.config.settings import settings
+# Import settings directly from the API package to avoid the compatibility
+# module in ``core`` which exposes a submodule with the same name.  Importing
+# via ``core.config.settings`` can result in the module object being returned
+# instead of the ``settings`` instance, leading to missing attribute errors.
+from api.core.config.settings import settings
 
 # Try to import aiohttp, fallback to None if not available
 try:

--- a/ai-stock-platform/api/social/twitter_sentiment.py
+++ b/ai-stock-platform/api/social/twitter_sentiment.py
@@ -12,7 +12,9 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 import tweepy
-from core.config.settings import settings
+# Import settings from the API package to avoid the ``core`` compatibility
+# layer returning the module rather than the settings instance.
+from api.core.config.settings import settings
 from core.exceptions import (ConfigurationError, ExternalAPIError,
                              RateLimitError)
 from textblob import TextBlob

--- a/ai-stock-platform/ui/config/__init__.py
+++ b/ai-stock-platform/ui/config/__init__.py
@@ -1,7 +1,9 @@
 # This file makes the config directory a proper Python package.
 # It can be empty or can include package-level imports that should be available when importing the config package.
 
-from core.config.settings import settings
+# Import settings directly from the API package to avoid ambiguity with
+# the ``core`` compatibility package when both packages are on the path.
+from api.core.config.settings import settings
 
 # This makes the settings available when importing from config directly
 # Usage: from ui.config import settings

--- a/ai-stock-platform/ui/controllers/profile_controller.py
+++ b/ai-stock-platform/ui/controllers/profile_controller.py
@@ -7,7 +7,10 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from core.config.settings import settings
+# Import settings from the API package directly.  Importing via the
+# ``core`` compatibility package may load the module instead of the
+# ``settings`` instance when multiple ``core`` packages are on the path.
+from api.core.config.settings import settings
 from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates

--- a/ai-stock-platform/ui/core/config/__init__.py
+++ b/ai-stock-platform/ui/core/config/__init__.py
@@ -5,6 +5,9 @@ Updated: 2025-06-15 03:42:15
 Author: daparthi001
 """
 # Re-export settings from settings module
-from core.config.settings import Settings, get_settings, settings
+# Re-export settings directly from the API package to avoid accidentally
+# importing the compatibility module which may expose the ``settings``
+# submodule rather than the instance.
+from api.core.config.settings import Settings, get_settings, settings
 
 __all__ = ["settings", "Settings", "get_settings"]

--- a/ai-stock-platform/ui/middleware/auth_middleware.py
+++ b/ai-stock-platform/ui/middleware/auth_middleware.py
@@ -18,7 +18,10 @@ from jose import JWTError, jwt
 logger = logging.getLogger(__name__)
 
 try:
-    from core.config.settings import settings
+    # Import from the API package to ensure we get the actual Settings
+    # instance.  Using the ``core`` compatibility layer can return the
+    # module object when both packages are present on ``PYTHONPATH``.
+    from api.core.config.settings import settings
 except Exception:  # pragma: no cover - fallback for demo mode
     class Settings:
         SECRET_KEY = "supersecretkey123456789abcdef"

--- a/ai-stock-platform/ui/services/api_client.py
+++ b/ai-stock-platform/ui/services/api_client.py
@@ -9,7 +9,10 @@ from typing import Any, Dict, Optional, Union
 from urllib.parse import urljoin
 
 import requests
-from core.config.settings import settings
+# Import settings directly from the API package instead of the ``core``
+# compatibility layer to ensure we get the Settings instance rather than
+# the module object when both packages are on ``PYTHONPATH``.
+from api.core.config.settings import settings
 from requests.exceptions import ConnectionError, RequestException, Timeout
 
 

--- a/ai-stock-platform/ui/tests/conftest.py
+++ b/ai-stock-platform/ui/tests/conftest.py
@@ -14,7 +14,10 @@ sys.path.append(os.path.join(ROOT, "ai-stock-platform", "api"))
 pytest.importorskip("httpx")
 from unittest.mock import MagicMock, patch
 
-from core.config.settings import settings
+# Import the settings instance directly from the API package.  Using the
+# compatibility package can result in the module object being imported
+# when both UI and API packages modify ``sys.path``.
+from api.core.config.settings import settings
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 

--- a/ai-stock-platform/ui/tests/test_services/test_api_client.py
+++ b/ai-stock-platform/ui/tests/test_services/test_api_client.py
@@ -15,7 +15,10 @@ pytest.importorskip("requests")
 import json
 
 import requests
-from core.config.settings import settings
+# Import settings from the API package to ensure we obtain the actual
+# Settings instance rather than the module when both UI and API paths
+# are on ``sys.path`` during tests.
+from api.core.config.settings import settings
 
 from ui.services.api_client import APIClient
 


### PR DESCRIPTION
## Summary
- ensure settings are imported from `api.core.config.settings`
- update database session fallback imports
- adjust UI and service modules to avoid importing the wrong module

## Testing
- `pytest -q` *(fails: KeyboardInterrupt, 7 failed, 27 passed, 6 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6876ae164554832ab1fa2b59a979f4e0