### PR TITLE
Fix Alembic env settings import

### DIFF
--- a/ai-stock-platform/api/alembic/env.py
+++ b/ai-stock-platform/api/alembic/env.py
@@ -28,7 +28,12 @@ if not (project_root / "core").exists():
 # is resolved before the local ``core`` directory inside the Alembic folder.
 sys.path.insert(0, str(project_root))
 
-from core.config import settings
+# Import settings directly from the API package to avoid
+# the ``core.config`` module shadowing the package when the
+# project is installed. Using the explicit path ensures the
+# ``settings`` instance is imported reliably across different
+# deployment scenarios.
+from api.core.config.settings import settings
 # Import the SQLAlchemy metadata
 from db.base import Base
 

--- a/ai-stock-platform/api/db/migrations/env.py
+++ b/ai-stock-platform/api/db/migrations/env.py
@@ -6,7 +6,11 @@ Author: daparthi001
 from logging.config import fileConfig
 
 from alembic import context
-from core.config import settings
+# Import settings directly from the API package to avoid the
+# ``core.config`` module shadowing the package when installed
+# without the full repository. This ensures the Alembic environment
+# can always access the correct configuration.
+from api.core.config.settings import settings
 from db.base import Base
 from sqlalchemy import engine_from_config, pool
 


### PR DESCRIPTION
## Summary
- load settings from `api.core.config.settings` in Alembic env files

## Testing
- `pytest -q` *(fails: 7 failed, 27 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876e01776d0832a8ac758c8a33ca33f