### PR TITLE
Fix DB host defaults

### DIFF
--- a/ai-stock-platform/api/api_safe_setup_Version2.py
+++ b/ai-stock-platform/api/api_safe_setup_Version2.py
@@ -147,7 +147,7 @@ class Settings(BaseSettings):
     # Database
     SQLALCHEMY_DATABASE_URI: str = os.getenv(
         "DATABASE_URL",
-        "postgresql://user:password@localhost:5432/dbname"
+        "postgresql://user:password@db:5432/dbname"
     )
     
     # Security

--- a/ai-stock-platform/api/config/settings.py
+++ b/ai-stock-platform/api/config/settings.py
@@ -32,7 +32,7 @@ class Settings(BaseSettings):
     
     # Database Settings
     DB_HOST: str = Field(
-        default_factory=lambda: os.getenv("DB_HOST", os.getenv("POSTGRES_SERVER", "localhost"))
+        default_factory=lambda: os.getenv("DB_HOST", os.getenv("POSTGRES_SERVER", "db"))
     )
     DB_USER: str = Field(
         default_factory=lambda: os.getenv("DB_USER", os.getenv("POSTGRES_USER", "postgres"))

--- a/ai-stock-platform/api/core/config.py
+++ b/ai-stock-platform/api/core/config.py
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
     LOG_FILE_BACKUP_COUNT: int = Field(default=5, env='LOG_FILE_BACKUP_COUNT')
     
     # Database settings
-    DB_HOST: str = Field(default="localhost", env='DB_HOST')
+    DB_HOST: str = Field(default="db", env='DB_HOST')
     DB_PORT: str = Field(default="5432", env='DB_PORT')
     DB_NAME: str = Field(default="quantumvestaidb", env='DB_NAME')
     DB_USER: str = Field(default="dbadmin", env='DB_USER')

--- a/ai-stock-platform/api/core/config/__init__.py
+++ b/ai-stock-platform/api/core/config/__init__.py
@@ -18,7 +18,7 @@ from urllib.parse import quote
 
 class Settings(BaseSettings):
     # Database connection details
-    DB_HOST: str = os.getenv("DB_HOST", "localhost")
+    DB_HOST: str = os.getenv("DB_HOST", "db")
     DB_PORT: str = os.getenv("DB_PORT", "5432")
     DB_NAME: str = os.getenv("DB_NAME", "dbname")
     DB_USER: str = os.getenv("DB_USER", "user")

--- a/ai-stock-platform/api/core/database.py
+++ b/ai-stock-platform/api/core/database.py
@@ -28,7 +28,7 @@ class DatabaseConnectionManager:
             # This is a placeholder - in a real implementation you would
             # initialize your actual database connection here
             # For now, just simulate connection status
-            db_host = os.environ.get("DB_HOST", "localhost")
+            db_host = os.environ.get("DB_HOST", "db")
             db_port = os.environ.get("DB_PORT", "5432")
             db_name = os.environ.get("DB_NAME", "quantumvestai")
             
@@ -97,7 +97,7 @@ class DatabaseConnectionManager:
         return {
             "connected": self.is_connected,
             "last_error": self.last_error,
-            "host": os.environ.get("DB_HOST", "localhost"),
+            "host": os.environ.get("DB_HOST", "db"),
             "port": os.environ.get("DB_PORT", "5432"),
             "database": os.environ.get("DB_NAME", "quantumvestai")
         }
@@ -142,7 +142,7 @@ def _convert_to_async(db_url: str) -> str:
 # Build database URL from environment variables
 db_user = os.environ.get("DB_USER", "dbadmin")
 db_password = os.environ.get("DB_PASSWORD", "")
-db_host = os.environ.get("DB_HOST", "localhost")
+db_host = os.environ.get("DB_HOST", "db")
 db_port = os.environ.get("DB_PORT", "5432")
 db_name = os.environ.get("DB_NAME", "quantumvestai")
 

--- a/ai-stock-platform/api/core/settings.py
+++ b/ai-stock-platform/api/core/settings.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
     
     # Database settings
     DB_HOST: str = Field(
-        default_factory=lambda: os.getenv("DB_HOST", os.getenv("POSTGRES_SERVER", "localhost"))
+        default_factory=lambda: os.getenv("DB_HOST", os.getenv("POSTGRES_SERVER", "db"))
     )
     DB_USER: str = Field(
         default_factory=lambda: os.getenv("DB_USER", os.getenv("POSTGRES_USER", "postgres"))

--- a/ai-stock-platform/api/db/session.py
+++ b/ai-stock-platform/api/db/session.py
@@ -46,7 +46,7 @@ except ImportError:
         
         class FallbackSettings:
             def __init__(self):
-                self.DB_HOST = os.environ.get("DB_HOST", "localhost")
+                self.DB_HOST = os.environ.get("DB_HOST", "db")
                 self.DB_PORT = os.environ.get("DB_PORT", "5432")
                 self.DB_NAME = os.environ.get("DB_NAME", "quantumvestaidb")
                 self.DB_USER = os.environ.get("DB_USER", "dbadmin")
@@ -63,7 +63,7 @@ def create_db_engine(retries: int = 3, delay: int = 5):
     for attempt in range(retries):
         try:
             # Get database connection parameters
-            db_host = getattr(settings, 'DB_HOST', os.environ.get('DB_HOST', 'localhost'))
+            db_host = getattr(settings, 'DB_HOST', os.environ.get('DB_HOST', 'db'))
             db_port = getattr(settings, 'DB_PORT', os.environ.get('DB_PORT', '5432'))
             db_name = getattr(settings, 'DB_NAME', os.environ.get('DB_NAME', 'quantumvestaidb'))
             db_user = getattr(settings, 'DB_USER', os.environ.get('DB_USER', 'dbadmin'))

--- a/ai-stock-platform/api/db_init/01_seed_data.py
+++ b/ai-stock-platform/api/db_init/01_seed_data.py
@@ -32,7 +32,7 @@ def seed_data():
     # Get database connection details from environment
     db_user = os.environ.get('DB_USER', 'postgres')
     db_password = os.environ.get('DB_PASSWORD', 'postgres')
-    db_host = os.environ.get('DB_HOST', 'localhost')
+    db_host = os.environ.get('DB_HOST', 'db')
     db_port = os.environ.get('DB_PORT', '5432')
     db_name = os.environ.get('DB_NAME', 'quantumvestai')
     

--- a/ai-stock-platform/api/scripts/database_migrator.py
+++ b/ai-stock-platform/api/scripts/database_migrator.py
@@ -21,14 +21,14 @@ class DatabaseMigrator:
         connection string. Finally a sensible local default is used.
         """
 
-        default_url = "postgresql://postgres:postgres@localhost:5432/quantumvestai"
+        default_url = "postgresql://postgres:postgres@db:5432/quantumvestai"
 
         env_url = db_url or os.getenv("DATABASE_URL") or os.getenv("ASYNC_DATABASE_URL")
 
         if not env_url:
             db_user = os.getenv("DB_USER", "postgres")
             db_password = os.getenv("DB_PASSWORD", "postgres")
-            db_host = os.getenv("DB_HOST", "localhost")
+            db_host = os.getenv("DB_HOST", "db")
             db_port = os.getenv("DB_PORT", "5432")
             db_name = os.getenv("DB_NAME", "quantumvestai")
             env_url = f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"

--- a/ai-stock-platform/ui/config/settings.py
+++ b/ai-stock-platform/ui/config/settings.py
@@ -69,7 +69,7 @@ class Settings(BaseSettings):
     LOG_FILE_BACKUP_COUNT: int = Field(default=5, env='LOG_FILE_BACKUP_COUNT')
     
     # Database settings
-    DB_HOST: str = Field(default="localhost", env='DB_HOST')
+    DB_HOST: str = Field(default="db", env='DB_HOST')
     DB_PORT: str = Field(default="5432", env='DB_PORT')
     DB_NAME: str = Field(default="quantumvestaidb", env='DB_NAME')
     DB_USER: str = Field(default="dbadmin", env='DB_USER')

--- a/ai-stock-platform/ui/core/config/settings.py
+++ b/ai-stock-platform/ui/core/config/settings.py
@@ -51,7 +51,7 @@ class Settings:
     REDIS_DB = int(os.environ.get("REDIS_DB", "0"))
     
     # Database settings
-    DB_HOST = os.environ.get("DB_HOST", "localhost")
+    DB_HOST = os.environ.get("DB_HOST", "db")
     DB_PORT = int(os.environ.get("DB_PORT", "5432"))
     DB_NAME = os.environ.get("DB_NAME", "quantumvestai")
     DB_USER = os.environ.get("DB_USER", "postgres")


### PR DESCRIPTION
## Summary
- default to `db` instead of `localhost` for DB host in all Python config and setup scripts
- update migrator and seed scripts to use `db`

## Testing
- `pytest -q` *(fails: 7 failed, 27 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687706169c88832aaa99e6fa7c55f739