### PR TITLE
Fix DB host fallback

### DIFF
--- a/ai-stock-platform/api/db_init/03_create_admin.py
+++ b/ai-stock-platform/api/db_init/03_create_admin.py
@@ -22,7 +22,7 @@ pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 def create_admin_user():
     """Create admin user in the database."""
     # Get credentials from environment variables
-    db_host = os.environ.get('DB_HOST', os.environ.get('POSTGRES_SERVER'))
+    db_host = os.environ.get('DB_HOST', os.environ.get('POSTGRES_SERVER', 'db'))
     db_name = os.environ.get('DB_NAME', os.environ.get('POSTGRES_DB'))
     db_user = os.environ.get('DB_USER', os.environ.get('POSTGRES_USER'))
     db_password = os.environ.get('DB_PASSWORD', os.environ.get('POSTGRES_PASSWORD'))

--- a/ai-stock-platform/api/db_init/04_seed_sample_data.py
+++ b/ai-stock-platform/api/db_init/04_seed_sample_data.py
@@ -23,7 +23,7 @@ logger = logging.getLogger('db-init')
 def get_db_connection():
     """Get database connection from environment variables."""
     return psycopg2.connect(
-        host=os.environ.get('DB_HOST', os.environ.get('POSTGRES_SERVER')),
+        host=os.environ.get('DB_HOST', os.environ.get('POSTGRES_SERVER', 'db')),
         database=os.environ.get('DB_NAME', os.environ.get('POSTGRES_DB')),
         user=os.environ.get('DB_USER', os.environ.get('POSTGRES_USER')),
         password=os.environ.get('DB_PASSWORD', os.environ.get('POSTGRES_PASSWORD')),

--- a/ai-stock-platform/api/ml/train_models.py
+++ b/ai-stock-platform/api/ml/train_models.py
@@ -35,7 +35,7 @@ class ModelTrainer:
         # Database connection
         self.db_user = os.environ.get('DB_USER', os.environ.get('POSTGRES_USER'))
         self.db_password = os.environ.get('DB_PASSWORD', os.environ.get('POSTGRES_PASSWORD'))
-        self.db_host = os.environ.get('DB_HOST', os.environ.get('POSTGRES_SERVER'))
+        self.db_host = os.environ.get('DB_HOST', os.environ.get('POSTGRES_SERVER', 'db'))
         self.db_port = os.environ.get('DB_PORT', os.environ.get('POSTGRES_PORT', '5432'))
         self.db_name = os.environ.get('DB_NAME', os.environ.get('POSTGRES_DB'))
         


### PR DESCRIPTION
## Summary
- fix DB host env fallback for create_admin, seed_sample_data and ml training script
- keep `db` as default when POSTGRES_SERVER is not set

## Testing
- `pytest -q` *(fails: 7 failed, 27 passed, 6 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68771ffc85f0832a9744164fa9d54baf