### PR TITLE
Fix db init migration imports

### DIFF
--- a/ai-stock-platform/api/scripts/db-init-entrypoint.sh
+++ b/ai-stock-platform/api/scripts/db-init-entrypoint.sh
@@ -12,11 +12,7 @@ echo "[$(date -u '+%Y-%m-%d %H:%M:%S')] Starting database initialization..."
 
 # Run migrations
 echo "Running database migrations..."
-# Temporarily remove PYTHONPATH so the real Alembic package is used
-PYTHONPATH_BACKUP="$PYTHONPATH"
-unset PYTHONPATH
 alembic upgrade head
-export PYTHONPATH="$PYTHONPATH_BACKUP"
 
 # Run seed script if specified
 if [ "${RUN_SEED:-false}" = "true" ]; then


### PR DESCRIPTION
## Summary
- fix path handling in `db-init-entrypoint.sh`
- run project tests

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: test failures and errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877279b13d4832a92c378bfb184419d