### PR TITLE
Fix wait-for-db path in entry scripts

### DIFF
--- a/ai-stock-platform/api/scripts/db-init-entrypoint.sh
+++ b/ai-stock-platform/api/scripts/db-init-entrypoint.sh
@@ -7,8 +7,15 @@ set -e
 
 echo "[$(date -u '+%Y-%m-%d %H:%M:%S')] Starting database initialization..."
 
-# Wait for database
-/app/scripts/wait-for-db.sh
+# Wait for database. Support both old and new script locations
+if [ -x /app/scripts/wait-for-db.sh ]; then
+    /app/scripts/wait-for-db.sh
+elif [ -x /app/api/scripts/wait-for-db.sh ]; then
+    /app/api/scripts/wait-for-db.sh
+else
+    echo "wait-for-db.sh script not found!" >&2
+    exit 1
+fi
 
 # Run migrations
 echo "Running database migrations..."

--- a/ai-stock-platform/api/scripts/entrypoint.sh
+++ b/ai-stock-platform/api/scripts/entrypoint.sh
@@ -7,8 +7,15 @@ set -e
 
 echo "[$(date -u '+%Y-%m-%d %H:%M:%S')] Starting QuantumVestAI API..."
 
-# Wait for database
-/app/scripts/wait-for-db.sh
+# Wait for database. Support both old and new script locations
+if [ -x /app/scripts/wait-for-db.sh ]; then
+    /app/scripts/wait-for-db.sh
+elif [ -x /app/api/scripts/wait-for-db.sh ]; then
+    /app/api/scripts/wait-for-db.sh
+else
+    echo "wait-for-db.sh script not found!" >&2
+    exit 1
+fi
 
 # Start the application
 if [ "$ENVIRONMENT" = "development" ]; then


### PR DESCRIPTION
## Summary
- fix script path in db-init-entrypoint.sh
- fix script path in entrypoint.sh

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: KeyboardInterrupt and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d5c2aaa9c832aa66adad575d3c304