### PR TITLE
Fix scripts path in Dockerfile

### DIFF
--- a/ai-stock-platform/api/Dockerfile.db-init
+++ b/ai-stock-platform/api/Dockerfile.db-init
@@ -38,7 +38,7 @@ COPY models/ /app/api/models/
 COPY core/ /app/api/core/
 COPY db/ /app/api/
 COPY alembic/ /app/api/
-COPY scripts/ /app/api/
+COPY scripts/ /app/api/scripts/
 COPY __init__.py /app/api/__init__.py
 
 # Make scripts executable


### PR DESCRIPTION
## Summary
- copy entire `scripts` directory into Docker init image

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 8 failed, 27 passed, 5 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d637f6650832a8fcf2654286cf808