### PR TITLE
Fix db init issues

### DIFF
--- a/ai-stock-platform/api/alembic/core/db_init.py
+++ b/ai-stock-platform/api/alembic/core/db_init.py
@@ -141,7 +141,10 @@ def initialize_database():
             from alembic import command
             from alembic.config import Config
             
-            alembic_cfg = Config(str(Path(__file__).parent.parent.parent / "alembic.ini"))
+            # Alembic configuration is located in the api package root
+            alembic_cfg = Config(
+                str(Path(__file__).resolve().parent.parent / "alembic.ini")
+            )
             command.upgrade(alembic_cfg, "head")
         
         # Create admin user if none exists
@@ -160,7 +163,8 @@ def initialize_database():
             logger.info("Initializing essential reference data")
             # Execute reference data script
             with engine.begin() as conn:
-                with open(str(Path(__file__).parent.parent.parent / "db_init" / "02_reference_data.sql")) as f:
+                ref_sql = Path(__file__).resolve().parent.parent / "db_init" / "02_reference_data.sql"
+                with open(ref_sql) as f:
                     conn.execute(text(f.read()))
         
         logger.info("Database initialization completed")

--- a/ai-stock-platform/api/core/db_init.py
+++ b/ai-stock-platform/api/core/db_init.py
@@ -141,7 +141,10 @@ def initialize_database():
             from alembic import command
             from alembic.config import Config
             
-            alembic_cfg = Config(str(Path(__file__).parent.parent.parent / "alembic.ini"))
+            # Alembic configuration file lives in the api package root
+            alembic_cfg = Config(
+                str(Path(__file__).resolve().parent.parent / "alembic.ini")
+            )
             command.upgrade(alembic_cfg, "head")
         
         # Create admin user if none exists
@@ -160,7 +163,8 @@ def initialize_database():
             logger.info("Initializing essential reference data")
             # Execute reference data script
             with engine.begin() as conn:
-                with open(str(Path(__file__).parent.parent.parent / "db_init" / "02_reference_data.sql")) as f:
+                ref_sql = Path(__file__).resolve().parent.parent / "db_init" / "02_reference_data.sql"
+                with open(ref_sql) as f:
                     conn.execute(text(f.read()))
         
         logger.info("Database initialization completed")


### PR DESCRIPTION
## Summary
- fix path resolution for `alembic.ini` and reference data script during DB initialization
- update both `core/db_init.py` modules accordingly

## Testing
- `pytest -q` *(fails: test_login_success, test_login_invalid_credentials, test_get_current_user, TestDatabaseConnection, test_migrations_can_run, test_get_trending_stocks, test_trending_stocks_pagination, test_cache_functionality)*

------
https://chatgpt.com/codex/tasks/task_e_687d677a91e8832a81666da97828be81