### PR TITLE
Fix Alembic migration path

### DIFF
--- a/ai-stock-platform/api/alembic.ini
+++ b/ai-stock-platform/api/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = alembic
+script_location = api/alembic
 
 # template used to generate migration files
 file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d%%(second).2d_%%(slug)s

--- a/ai-stock-platform/api/alembic/alembic.ini
+++ b/ai-stock-platform/api/alembic/alembic.ini
@@ -4,7 +4,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = alembic
+script_location = api/alembic
 
 # template used to generate migration files
 file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s

--- a/ai-stock-platform/api/config/alembic.ini
+++ b/ai-stock-platform/api/config/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = alembic
+script_location = api/alembic
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s

--- a/ci-cd/k8s/dev/07-db-init-configmap.yaml
+++ b/ci-cd/k8s/dev/07-db-init-configmap.yaml
@@ -15,7 +15,7 @@ metadata:
 data:
   alembic.ini: |
     [alembic]
-    script_location = alembic
+    script_location = api/alembic
     sqlalchemy.url = postgresql://%(username)s:%(password)s@%(host)s:%(port)s/%(dbname)s
     file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d%%(second).2d_%%(rev)s_%%(slug)s
     timezone = UTC

--- a/ci-cd/k8s/dev/db-migration-bypass-conflict.yaml
+++ b/ci-cd/k8s/dev/db-migration-bypass-conflict.yaml
@@ -81,7 +81,7 @@ spec:
               # Create a minimal alembic.ini
               cat > /tmp/migration/alembic.ini << 'EOF'
               [alembic]
-              script_location = alembic
+              script_location = api/alembic
               sqlalchemy.url = postgresql://%(PGUSER)s:%(PGPASSWORD)s@%(PGHOST)s:%(PGPORT)s/%(PGDATABASE)s
               file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d%%(second).2d_%%(rev)s_%%(slug)s
               timezone = UTC


### PR DESCRIPTION
## Summary
- update alembic.ini files to use `api/alembic`
- fix k8s ConfigMap and bypass migration job

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 8 failed, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d79497954832a92bd12322bb577c6