### PR TITLE
Fix Alembic path in migration tests

### DIFF
--- a/ai-stock-platform/api/tests/test_migrations.py
+++ b/ai-stock-platform/api/tests/test_migrations.py
@@ -7,6 +7,8 @@ import pytest
 
 pytest.importorskip("alembic")
 pytest.importorskip("sqlalchemy")
+from pathlib import Path
+
 from alembic.config import Config
 from alembic.runtime.environment import EnvironmentContext
 from alembic.script import ScriptDirectory
@@ -22,7 +24,8 @@ def test_migrations_can_run():
     
     # Create alembic config
     config = Config()
-    config.set_main_option("script_location", "alembic")
+    script_dir = Path(__file__).resolve().parents[1] / "alembic"
+    config.set_main_option("script_location", str(script_dir))
     
     # Get migration script directory
     script = ScriptDirectory.from_config(config)


### PR DESCRIPTION
## Summary
- update migration tests to locate the Alembic directory using `Path`

## Testing
- `pytest -q` *(fails: 8 failed, 27 passed, 5 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d7cb08a70832a8dd34b56bb5e0b4d