### PR TITLE
Fix Alembic path for migration scripts

### DIFF
--- a/ai-stock-platform/api/scripts/db-init-entrypoint.sh
+++ b/ai-stock-platform/api/scripts/db-init-entrypoint.sh
@@ -19,7 +19,9 @@ fi
 
 # Run migrations
 echo "Running database migrations..."
-alembic upgrade head
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+API_DIR="${SCRIPT_DIR}/.."
+alembic -c "${API_DIR}/alembic.ini" upgrade head
 
 # Run seed script if specified
 if [ "${RUN_SEED:-false}" = "true" ]; then

--- a/ai-stock-platform/api/scripts/init_local_db.sh
+++ b/ai-stock-platform/api/scripts/init_local_db.sh
@@ -40,7 +40,9 @@ sudo -u postgres psql -f db_init/01_create_database.sql
 
 # Apply migrations
 echo "Applying database migrations..."
-alembic upgrade head
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+API_DIR="${SCRIPT_DIR}/.."
+alembic -c "${API_DIR}/alembic.ini" upgrade head
 
 # Initialize reference data
 echo "Initializing reference data..."

--- a/ai-stock-platform/api/scripts/run_db_init.sh
+++ b/ai-stock-platform/api/scripts/run_db_init.sh
@@ -24,7 +24,9 @@ export PYTHONPATH=/db-init
 
 # Step 1: Run database migrations
 echo "Running database migrations..."
-alembic upgrade head
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+API_DIR="${SCRIPT_DIR}/.."
+alembic -c "${API_DIR}/alembic.ini" upgrade head
 
 # Step 2: Apply reference data
 echo "Initializing reference data..."

--- a/ai-stock-platform/api/scripts/run_migrations.sh
+++ b/ai-stock-platform/api/scripts/run_migrations.sh
@@ -15,6 +15,12 @@ fi
 
 # Run migrations
 echo "Running database migrations..."
-alembic upgrade head
+
+# Determine the directory of this script and the API root
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+API_DIR="${SCRIPT_DIR}/.."
+
+# Run Alembic using the configuration inside the api directory
+alembic -c "${API_DIR}/alembic.ini" upgrade head
 
 echo "[$(date -u '+%Y-%m-%d %H:%M:%S')] Migrations completed successfully!"

--- a/ai-stock-platform/api/scripts/start.sh
+++ b/ai-stock-platform/api/scripts/start.sh
@@ -17,7 +17,9 @@ timeout 30 bash -c "until curl -s http://${DB_HOST}:${DB_PORT}; do sleep 1; done
 if [ "${AUTO_MIGRATE}" = "true" ]; then
     echo "Running database migrations..."
     if command -v alembic >/dev/null 2>&1; then
-        alembic upgrade head
+        SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+        API_DIR="${SCRIPT_DIR}/.."
+        alembic -c "${API_DIR}/alembic.ini" upgrade head
     else
         echo "Alembic not installed; skipping migrations" >&2
     fi


### PR DESCRIPTION
## Summary
- ensure shell scripts run Alembic using the api/alembic.ini config

## Testing
- `pytest -q` *(fails: 8 failed, 27 passed, 5 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d8cab03a0832a8401148ddefee376