### PR TITLE
Fix alembic path lookup in scripts

### DIFF
--- a/ai-stock-platform/api/scripts/db-init-entrypoint.sh
+++ b/ai-stock-platform/api/scripts/db-init-entrypoint.sh
@@ -20,8 +20,20 @@ fi
 # Run migrations
 echo "Running database migrations..."
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-API_DIR="${SCRIPT_DIR}/.."
-alembic -c "${API_DIR}/alembic.ini" upgrade head
+API_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$(dirname "$API_DIR")"
+
+# Prefer alembic.ini next to the API directory, fall back to project root
+if [ -f "${API_DIR}/alembic.ini" ]; then
+    ALEMBIC_CFG="${API_DIR}/alembic.ini"
+elif [ -f "${ROOT_DIR}/alembic.ini" ]; then
+    ALEMBIC_CFG="${ROOT_DIR}/alembic.ini"
+else
+    echo "alembic.ini not found" >&2
+    exit 1
+fi
+
+alembic -c "$ALEMBIC_CFG" upgrade head
 
 # Run seed script if specified
 if [ "${RUN_SEED:-false}" = "true" ]; then

--- a/ai-stock-platform/api/scripts/run_db_init.sh
+++ b/ai-stock-platform/api/scripts/run_db_init.sh
@@ -8,7 +8,7 @@ DB_HOST="${DB_HOST}"
 DB_PORT="${DB_PORT}"
 DB_NAME="${DB_NAME}"
 DB_USER="${DB_USER}"
-DB_PASSWORD="${DB_PASSWORD }"
+DB_PASSWORD="${DB_PASSWORD}"
 
 # Wait for database to be ready
 echo "Waiting for database to be ready..."
@@ -25,8 +25,19 @@ export PYTHONPATH=/db-init
 # Step 1: Run database migrations
 echo "Running database migrations..."
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-API_DIR="${SCRIPT_DIR}/.."
-alembic -c "${API_DIR}/alembic.ini" upgrade head
+API_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$(dirname "$API_DIR")"
+
+if [ -f "${API_DIR}/alembic.ini" ]; then
+    ALEMBIC_CFG="${API_DIR}/alembic.ini"
+elif [ -f "${ROOT_DIR}/alembic.ini" ]; then
+    ALEMBIC_CFG="${ROOT_DIR}/alembic.ini"
+else
+    echo "alembic.ini not found" >&2
+    exit 1
+fi
+
+alembic -c "$ALEMBIC_CFG" upgrade head
 
 # Step 2: Apply reference data
 echo "Initializing reference data..."

--- a/ai-stock-platform/api/scripts/run_migrations.sh
+++ b/ai-stock-platform/api/scripts/run_migrations.sh
@@ -18,9 +18,19 @@ echo "Running database migrations..."
 
 # Determine the directory of this script and the API root
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-API_DIR="${SCRIPT_DIR}/.."
+API_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$(dirname "$API_DIR")"
 
-# Run Alembic using the configuration inside the api directory
-alembic -c "${API_DIR}/alembic.ini" upgrade head
+# Run Alembic using the configuration inside the api directory or project root
+if [ -f "${API_DIR}/alembic.ini" ]; then
+    ALEMBIC_CFG="${API_DIR}/alembic.ini"
+elif [ -f "${ROOT_DIR}/alembic.ini" ]; then
+    ALEMBIC_CFG="${ROOT_DIR}/alembic.ini"
+else
+    echo "alembic.ini not found" >&2
+    exit 1
+fi
+
+alembic -c "$ALEMBIC_CFG" upgrade head
 
 echo "[$(date -u '+%Y-%m-%d %H:%M:%S')] Migrations completed successfully!"

--- a/ai-stock-platform/api/scripts/start.sh
+++ b/ai-stock-platform/api/scripts/start.sh
@@ -18,8 +18,19 @@ if [ "${AUTO_MIGRATE}" = "true" ]; then
     echo "Running database migrations..."
     if command -v alembic >/dev/null 2>&1; then
         SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-        API_DIR="${SCRIPT_DIR}/.."
-        alembic -c "${API_DIR}/alembic.ini" upgrade head
+        API_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+        ROOT_DIR="$(dirname "$API_DIR")"
+
+        if [ -f "${API_DIR}/alembic.ini" ]; then
+            ALEMBIC_CFG="${API_DIR}/alembic.ini"
+        elif [ -f "${ROOT_DIR}/alembic.ini" ]; then
+            ALEMBIC_CFG="${ROOT_DIR}/alembic.ini"
+        else
+            echo "alembic.ini not found" >&2
+            exit 1
+        fi
+
+        alembic -c "$ALEMBIC_CFG" upgrade head
     else
         echo "Alembic not installed; skipping migrations" >&2
     fi


### PR DESCRIPTION
## Summary
- ensure db initialization scripts search for `alembic.ini` in both `/app/api` and project root
- fix `DB_PASSWORD` variable quoting
- normalize script directory paths when determining config location

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 8 failed, 27 passed, 5 skipped, 5 errors)*


------
https://chatgpt.com/codex/tasks/task_e_687d92493aac832aadc3662e2dfbfe1a