### PR TITLE
Fix alembic path during migrations

### DIFF
--- a/ai-stock-platform/api/scripts/init_local_db.sh
+++ b/ai-stock-platform/api/scripts/init_local_db.sh
@@ -41,8 +41,12 @@ sudo -u postgres psql -f db_init/01_create_database.sql
 # Apply migrations
 echo "Applying database migrations..."
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-API_DIR="${SCRIPT_DIR}/.."
-alembic -c "${API_DIR}/alembic.ini" upgrade head
+API_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Run migrations from the API directory so Alembic can locate env.py
+pushd "$API_DIR" >/dev/null
+alembic upgrade head
+popd >/dev/null
 
 # Initialize reference data
 echo "Initializing reference data..."

--- a/ai-stock-platform/api/scripts/run_db_init.sh
+++ b/ai-stock-platform/api/scripts/run_db_init.sh
@@ -38,7 +38,9 @@ else
     exit 1
 fi
 
+pushd "$API_DIR" >/dev/null
 alembic -c "$ALEMBIC_CFG" upgrade head
+popd >/dev/null
 
 # Step 2: Apply reference data
 echo "Initializing reference data..."


### PR DESCRIPTION
## Summary
- ensure alembic is executed from the API directory
- update `run_db_init.sh` and `init_local_db.sh`

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: Database connection and auth tests)*

------
https://chatgpt.com/codex/tasks/task_e_687da6c325c8832aba9a85e160258281