### PR TITLE
Fix Alembic config path

### DIFF
--- a/ai-stock-platform/api/alembic/alembic.ini
+++ b/ai-stock-platform/api/alembic/alembic.ini
@@ -4,7 +4,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = alembic
+script_location = .
 
 # template used to generate migration files
 file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s


### PR DESCRIPTION
## Summary
- correct Alembic `script_location` path so migration environment can be found

## Testing
- `pytest ai-stock-platform/api/tests/test_migrations.py -q` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_687dcfb09dcc832a86956f8bf17534a4