### PR TITLE
Fix db import path

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,24 @@
+"""Compatibility wrapper for API db package."""
+import importlib
+import sys
+from pathlib import Path
+
+# Ensure api package path is on sys.path
+repo_root = Path(__file__).resolve().parent
+api_path = repo_root / "ai-stock-platform" / "api"
+if api_path.exists() and str(api_path) not in sys.path:
+    sys.path.insert(0, str(api_path))
+
+api_db = importlib.import_module("api.db")
+
+# Expose common submodules so `import db.session` works
+for sub in ("session", "models", "base", "base_class", "mixins", "init_db", "rds_session"):
+    try:
+        sys.modules[f"db.{sub}"] = importlib.import_module(f"api.db.{sub}")
+    except Exception:
+        pass
+
+# Re-export all public attributes from api.db
+__all__ = getattr(api_db, "__all__", [])
+for name in __all__:
+    globals()[name] = getattr(api_db, name)


### PR DESCRIPTION
## Summary
- add `db` wrapper to expose API db modules on import path

## Testing
- `pytest -q` *(fails: 8 failed, 27 passed, 5 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ddaf3828c832a9421c2e1127068f6