### PR TITLE
Fix Dockerfile permissions for db init

### DIFF
--- a/ai-stock-platform/api/Dockerfile.db-init
+++ b/ai-stock-platform/api/Dockerfile.db-init
@@ -43,8 +43,9 @@ COPY __init__.py /app/api/__init__.py
 
 # Make scripts executable
 RUN chmod +x /app/api/scripts/*.sh && \
-    chmod -R 644 /app/api/models /app/api/core /app/api/db /app/alembic && \
-    chmod 755 /app/api/models /app/api/core /app/api/db /app/alembic /app/api/scripts
+    find /app/api/models /app/api/core /app/api/db /app/alembic -type f -exec chmod 644 {} + && \
+    find /app/api/models /app/api/core /app/api/db /app/alembic -type d -exec chmod 755 {} + && \
+    chmod 755 /app/api/scripts
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
## Summary
- ensure DB init container sets directory permissions correctly

## Testing
- `pytest -q` *(fails: 8 failed, 27 passed, 5 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e4e23edb0832ab5299e98a7af00c7