### PR TITLE
Fix path for update cronjob

### DIFF
--- a/ci-cd/k8s/dev/10-db-update-cronjob.yaml
+++ b/ci-cd/k8s/dev/10-db-update-cronjob.yaml
@@ -29,7 +29,7 @@ spec:
           containers:
             - name: db-update
               image: 921930869047.dkr.ecr.us-east-1.amazonaws.com/quantumvestai:db-init-dev-latest
-              command: ['python', 'scripts/update_market_data.py']
+              command: ['python', 'api/scripts/update_market_data.py']
               envFrom:
                 - configMapRef:
                     name: quantumvestai-config


### PR DESCRIPTION
## Summary
- fix `db-update` cronjob script path to use api folder

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError and other DB-related failures)*

------
https://chatgpt.com/codex/tasks/task_e_687ed4b9e954832aa251d233b53c53f5