### PR TITLE
Fix Alembic env import

### DIFF
--- a/ai-stock-platform/api/alembic/env.py
+++ b/ai-stock-platform/api/alembic/env.py
@@ -57,7 +57,13 @@ settings_module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(settings_module)
 settings = settings_module.settings
 # Import the SQLAlchemy metadata
-from db.base import Base
+try:
+    from db.base import Base
+except ModuleNotFoundError:
+    # When the compatibility ``db`` package isn't available (such as when
+    # the project is installed without the repository root), fall back to the
+    # ``api.db`` package which always ships with the application.
+    from api.db.base import Base
 
 # this is the Alembic Config object
 config = context.config

--- a/ai-stock-platform/api/db/migrations/env.py
+++ b/ai-stock-platform/api/db/migrations/env.py
@@ -27,7 +27,10 @@ if importlib.util.find_spec("api") is None:
 # without the full repository. This ensures the Alembic environment
 # can always access the correct configuration.
 from api.core.config.settings import settings
-from db.base import Base
+try:
+    from db.base import Base
+except ModuleNotFoundError:
+    from api.db.base import Base
 from sqlalchemy import engine_from_config, pool
 
 config = context.config


### PR DESCRIPTION
## Summary
- fallback to `api.db.base` when `db` module is missing in Alembic envs

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 8 failed, 27 passed, 5 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687eda64a230832a86510939df9407b3