### PR TITLE
Update setup docs for PYTHONPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ To create a virtual environment and install dependencies, run:
 ./setup_env.sh
 ```
 Activate it with `source venv/bin/activate`.
+After activating, add the API package to your `PYTHONPATH` so tools like
+Alembic can locate the `api` module when run from outside the repository root:
+```bash
+export PYTHONPATH="$(pwd)/ai-stock-platform:$PYTHONPATH"
+```
 
 ## External API Key
 To fetch real-time stock market data you must set the `ALPHA_VANTAGE_API_KEY`

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -17,3 +17,4 @@ pip install --upgrade pip
 pip install -r requirements.txt
 
 echo "Environment setup complete. Activate with 'source venv/bin/activate'"
+echo "Add the API package to PYTHONPATH: export PYTHONPATH=\"$(pwd)/ai-stock-platform:$PYTHONPATH\""


### PR DESCRIPTION
## Summary
- document the need to add the API package to PYTHONPATH when activating the venv
- print a PYTHONPATH hint in `setup_env.sh`

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: index ix_stocks_id already exists)*

------
https://chatgpt.com/codex/tasks/task_e_687edee0c47c832aa87aa840b771be9c