### PR TITLE
Improve Alembic env package lookup

### DIFF
--- a/ai-stock-platform/api/alembic/env.py
+++ b/ai-stock-platform/api/alembic/env.py
@@ -26,6 +26,10 @@ if importlib.util.find_spec("api") is None:
         if (parent / "api").exists():
             sys.path.insert(0, str(parent))
             break
+        alt = parent / "ai-stock-platform"
+        if (alt / "api").exists():
+            sys.path.insert(0, str(alt))
+            break
 
 
 

--- a/ai-stock-platform/api/db/migrations/env.py
+++ b/ai-stock-platform/api/db/migrations/env.py
@@ -21,6 +21,10 @@ if importlib.util.find_spec("api") is None:
         if (parent / "api").exists():
             sys.path.insert(0, str(parent))
             break
+        alt = parent / "ai-stock-platform"
+        if (alt / "api").exists():
+            sys.path.insert(0, str(alt))
+            break
 
 # Import settings directly from the API package to avoid the
 # ``core.config`` module shadowing the package when installed


### PR DESCRIPTION
## Summary
- fix Alembic env scripts to locate API package even when it lives in `ai-stock-platform`

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 8 failed, 27 passed, 5 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ee87da484832a9ebfecf7c528f4fb