### PR TITLE
Fix Alembic env import path logic

### DIFF
--- a/ai-stock-platform/api/alembic/env.py
+++ b/ai-stock-platform/api/alembic/env.py
@@ -20,16 +20,15 @@ from pathlib import Path
 # parent to ``sys.path``.
 import importlib.util
 
-if importlib.util.find_spec("api") is None:
-    current = Path(__file__).resolve()
-    for parent in current.parents:
-        if (parent / "api").exists():
-            sys.path.insert(0, str(parent))
-            break
-        alt = parent / "ai-stock-platform"
-        if (alt / "api").exists():
-            sys.path.insert(0, str(alt))
-            break
+current = Path(__file__).resolve()
+for parent in current.parents:
+    if (parent / "api").exists():
+        sys.path.insert(0, str(parent))
+        break
+    alt = parent / "ai-stock-platform"
+    if (alt / "api").exists():
+        sys.path.insert(0, str(alt))
+        break
 
 
 

--- a/ai-stock-platform/api/db/migrations/env.py
+++ b/ai-stock-platform/api/db/migrations/env.py
@@ -15,16 +15,15 @@ import sys
 from pathlib import Path
 import importlib.util
 
-if importlib.util.find_spec("api") is None:
-    current = Path(__file__).resolve()
-    for parent in current.parents:
-        if (parent / "api").exists():
-            sys.path.insert(0, str(parent))
-            break
-        alt = parent / "ai-stock-platform"
-        if (alt / "api").exists():
-            sys.path.insert(0, str(alt))
-            break
+current = Path(__file__).resolve()
+for parent in current.parents:
+    if (parent / "api").exists():
+        sys.path.insert(0, str(parent))
+        break
+    alt = parent / "ai-stock-platform"
+    if (alt / "api").exists():
+        sys.path.insert(0, str(alt))
+        break
 
 # Import settings directly from the API package to avoid the
 # ``core.config`` module shadowing the package when installed


### PR DESCRIPTION
## Summary
- make alembic env scripts always add repo paths

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: OperationalError connecting to postgres)*

------
https://chatgpt.com/codex/tasks/task_e_687ef4a54060832a91637fd6b74970eb