### PR TITLE
Fix db import wrapper

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -10,6 +10,17 @@ api_path = repo_root.parent / "ai-stock-platform" / "api"
 if api_path.exists() and str(api_path) not in sys.path:
     sys.path.insert(0, str(api_path))
 
+# Make this module appear as a package pointing to the real ``api/db``
+# directory so Python can locate submodules under ``db``.
+__path__ = [str(api_path / "db")]
+
+# Avoid circular import issues by registering this module under the "db" name
+# before loading the actual API package. Submodules inside ``api.db`` sometimes
+# import ``db`` during initialization. By setting the alias early, those imports
+# will resolve to this compatibility wrapper instead of failing with
+# ``ModuleNotFoundError``.
+sys.modules.setdefault("db", sys.modules[__name__])
+
 api_db = importlib.import_module("api.db")
 
 # Expose common submodules so `import db.session` works


### PR DESCRIPTION
## Summary
- fix compatibility wrapper for `db` to register package alias early
- set `__path__` to actual API db folder for submodule imports

## Testing
- `pytest -q` *(fails: 8 failed, 27 passed, 5 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687efc4a376c832aa75b743bd7674993