### PR TITLE
Fix settings import fallback

### DIFF
--- a/ai-stock-platform/api/services/stock_service.py
+++ b/ai-stock-platform/api/services/stock_service.py
@@ -15,7 +15,10 @@ import aiohttp
 # Import settings directly from the API package.  Importing via the
 # ``core`` compatibility package may resolve to the ``core.config.settings``
 # module instead of the ``settings`` instance which causes attribute errors.
-from api.core.config.settings import settings
+try:
+    from api.core.config.settings import settings
+except ModuleNotFoundError:  # pragma: no cover - fallback when wrapper absent
+    from ..core.config.settings import settings
 from sqlalchemy.orm import Session
 
 from models.stock import Stock, WatchList

--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -19,7 +19,10 @@ from typing import Any, Dict, List, Optional
 # module in ``core`` which exposes a submodule with the same name.  Importing
 # via ``core.config.settings`` can result in the module object being returned
 # instead of the ``settings`` instance, leading to missing attribute errors.
-from api.core.config.settings import settings
+try:
+    from api.core.config.settings import settings
+except ModuleNotFoundError:  # pragma: no cover - fallback for missing wrapper
+    from ..core.config.settings import settings
 
 # Try to import aiohttp, fallback to None if not available
 try:


### PR DESCRIPTION
## Summary
- update `stock_service` and `trending_stocks_service` to fall back to relative imports when the `api` wrapper module is unavailable

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f091f3f70832ab1a08746c996a74d