### PR TITLE
Fix UI startup without API package

### DIFF
--- a/ai-stock-platform/ui/config/__init__.py
+++ b/ai-stock-platform/ui/config/__init__.py
@@ -3,7 +3,10 @@
 
 # Import settings directly from the API package to avoid ambiguity with
 # the ``core`` compatibility package when both packages are on the path.
-from api.core.config.settings import settings
+try:  # pragma: no cover - may run without the API package
+    from api.core.config.settings import settings
+except ModuleNotFoundError:  # Fallback when UI is deployed standalone
+    from .settings import settings
 
 # This makes the settings available when importing from config directly
 # Usage: from ui.config import settings

--- a/ai-stock-platform/ui/services/api_client.py
+++ b/ai-stock-platform/ui/services/api_client.py
@@ -9,10 +9,13 @@ from typing import Any, Dict, Optional, Union
 from urllib.parse import urljoin
 
 import requests
-# Import settings directly from the API package instead of the ``core``
-# compatibility layer to ensure we get the Settings instance rather than
-# the module object when both packages are on ``PYTHONPATH``.
-from api.core.config.settings import settings
+# Attempt to load settings from the API package if available. When the UI is
+# deployed standalone (without the backend code present) fall back to its own
+# configuration module.
+try:  # pragma: no cover - api package may not be installed
+    from api.core.config.settings import settings
+except ModuleNotFoundError:
+    from ui.config import settings
 from requests.exceptions import ConnectionError, RequestException, Timeout
 
 


### PR DESCRIPTION
## Summary
- allow `ui.config` to work when the backend `api` package isn't installed
- update `APIClient` so it falls back to `ui.config` settings if the API package is missing

## Testing
- `pytest -q` *(fails: test failures and errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f09c96728832a9006878cff95490c