### PR TITLE
Add fallback for config import

### DIFF
--- a/ai-stock-platform/ui/services/api_client.py
+++ b/ai-stock-platform/ui/services/api_client.py
@@ -15,7 +15,10 @@ import requests
 try:  # pragma: no cover - api package may not be installed
     from api.core.config.settings import settings
 except ModuleNotFoundError:
-    from ui.config import settings
+    try:
+        from ui.config import settings
+    except ModuleNotFoundError:  # pragma: no cover - ui package may be renamed
+        from app.config import settings
 from requests.exceptions import ConnectionError, RequestException, Timeout
 
 


### PR DESCRIPTION
## Summary
- handle deployments where the UI package is named `app`

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: OperationalError: index ix_stocks_ticker already exists)*

------
https://chatgpt.com/codex/tasks/task_e_687f11ce6d8c832abf2ff531631a4e49