### PR TITLE
Fix core.config import issues

### DIFF
--- a/ai-stock-platform/api/core/config/__init__.py
+++ b/ai-stock-platform/api/core/config/__init__.py
@@ -1,5 +1,11 @@
+"""Application configuration wrapper.
+
+This module used to contain the application's configuration but the
+implementation was moved to :mod:`core.config.settings`.  It now
+re-exports the new settings objects so that older imports of
+``api.core.config`` keep working.
 """
-Application configuration.
-"""
-# DEPRECATED: All config is now in core/config/
-# This file is no longer used and can be deleted.
+
+from .settings import Settings, get_settings, settings
+
+__all__ = ["Settings", "get_settings", "settings"]

--- a/ai-stock-platform/core/config/__init__.py
+++ b/ai-stock-platform/core/config/__init__.py
@@ -2,4 +2,10 @@
 
 from .settings import Settings, get_settings, settings
 
-__all__ = ["settings", "Settings", "get_settings"]
+
+def validate_settings(cfg: Settings) -> None:
+    """Simple validation helper used in tests."""
+    cfg.SQLALCHEMY_DATABASE_URI
+
+
+__all__ = ["settings", "Settings", "get_settings", "validate_settings"]

--- a/ai-stock-platform/core/config/settings.py
+++ b/ai-stock-platform/core/config/settings.py
@@ -3,8 +3,8 @@ Centralized Application Configuration Settings
 This module provides the canonical settings and configuration for all QuantumVestAI services.
 """
 from typing import Optional
-from pydantic import BaseModel, Field, PostgresDsn, SecretStr
-from pydantic_settings import BaseSettings
+from pydantic import BaseModel, Field, PostgresDsn, SecretStr, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class DatabaseSettings(BaseModel):
     host: str = Field(default="quantumvestai-dev.cwbsqsiywwaa.us-east-1.rds.amazonaws.com", env='DB_HOST')
@@ -23,6 +23,30 @@ class Settings(BaseSettings):
     API_V1_STR: str = "/api/v1"
     DEBUG: bool = Field(default=True, env="DEBUG")
     database: DatabaseSettings = DatabaseSettings()
+    ENVIRONMENT: str = Field(default="development", env="ENVIRONMENT")
+
+    # Allow arbitrary extra fields for backwards compatibility
+    model_config = SettingsConfigDict(extra="ignore")
+
+    # API base URL used by the UI when calling the backend
+    API_BASE_URL: str = Field(default="http://quantumvestai-dev-api:8000", env="API_BASE_URL")
+
+    # Security Settings
+    SECRET_KEY: str = Field(default="your-secret-key", env="SECRET_KEY")
+    ALGORITHM: str = Field(default="HS256", env="ALGORITHM")
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = Field(default=30, env="ACCESS_TOKEN_EXPIRE_MINUTES")
+
+    # Logging
+    LOG_LEVEL: str = Field(default="INFO", env="LOG_LEVEL")
+
+    BACKEND_CORS_ORIGINS: list[str] | str | None = None
+
+    @field_validator("BACKEND_CORS_ORIGINS", mode="before")
+    @classmethod
+    def assemble_cors_origins(cls, v):
+        if isinstance(v, str) and v:
+            return [i.strip() for i in v.split(",")]
+        return v or []
 
     @property
     def SQLALCHEMY_DATABASE_URI(self) -> str:


### PR DESCRIPTION
## Summary
- ensure api.core.config exposes actual settings
- add validation helper to core.config
- expand default settings for backwards compatibility

## Testing
- `pytest -q` *(fails: 11 failed, 24 passed, 5 skipped, 67 warnings, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f5e5366a0832a8e1f861065bc2456