### PR TITLE
Fix missing JWT config in settings

### DIFF
--- a/ai-stock-platform/api/core/config/settings.py
+++ b/ai-stock-platform/api/core/config/settings.py
@@ -59,7 +59,12 @@ class Settings(BaseSettings):
     
     # Security Settings
     SECRET_KEY: str = Field(default="your-secret-key", env='SECRET_KEY')
+    ALGORITHM: str = Field(default="HS256", env="ALGORITHM")
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    JWT_SECRET: SecretStr = Field(
+        default_factory=lambda: os.getenv("JWT_SECRET", os.getenv("SECRET_KEY", "your-secret-key"))
+    )
+    JWT_ALGORITHM: str = Field(default="HS256", env="JWT_ALGORITHM")
     
     # External Services
     TWITTER_BEARER_TOKEN: Optional[str] = Field(default=None, env='TWITTER_BEARER_TOKEN')


### PR DESCRIPTION
## Summary
- add JWT_SECRET and ALGORITHM settings
- run project tests

## Testing
- `./setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f95195c3c832ab0c6880d59186a3c