### PR TITLE
Fix logging module name collision

### DIFF
--- a/ai-stock-platform/ui/core/__init__.py
+++ b/ai-stock-platform/ui/core/__init__.py
@@ -1,6 +1,22 @@
-
 """
 Core utilities for QuantumVestAI UI.
 """
-from .http_client import (HTTPClient, HTTPClientConfig, cleanup_http_clients,
-                          get_http_client, safe_get_json, safe_post_json)
+from .http_client import (
+    HTTPClient,
+    HTTPClientConfig,
+    cleanup_http_clients,
+    get_http_client,
+    safe_get_json,
+    safe_post_json,
+)
+from .logger_utils import setup_logging
+
+__all__ = [
+    "HTTPClient",
+    "HTTPClientConfig",
+    "get_http_client",
+    "safe_get_json",
+    "safe_post_json",
+    "cleanup_http_clients",
+    "setup_logging",
+]

--- a/ai-stock-platform/ui/core/logger_utils.py
+++ b/ai-stock-platform/ui/core/logger_utils.py
@@ -23,14 +23,14 @@ def setup_logging(
 ) -> logging.Logger:
     """
     Configure and return a logger instance
-    
+
     Args:
         name: Logger name
         level: Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
         log_to_file: Whether to log to a file
         log_file: Path to log file
         log_format: Log message format
-    
+
     Returns:
         logging.Logger: Configured logger instance
     """
@@ -38,43 +38,39 @@ def setup_logging(
     level = level or settings.LOG_LEVEL
     log_file = log_file or settings.LOG_FILE
     log_format = log_format or settings.LOG_FORMAT
-    
+
     # Get or create logger
     logger = logging.getLogger(name)
-    
+
     # Only configure if not already configured
     if not logger.handlers:
         # Set log level
         logger.setLevel(getattr(logging, level.upper(), logging.INFO))
-        
+
         # Create formatter
         formatter = logging.Formatter(fmt=log_format)
-        
+
         # Add console handler
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
-        
+
         # Add file handler if requested
         if log_to_file and log_file:
             # Create logs directory if it doesn't exist
             log_dir = Path(log_file).parent
             log_dir.mkdir(parents=True, exist_ok=True)
-            
+
             # Add rotating file handler
             file_handler = RotatingFileHandler(
                 filename=log_file,
                 maxBytes=10 * 1024 * 1024,  # 10 MB
                 backupCount=5,
-                encoding='utf-8'
+                encoding="utf-8",
             )
             file_handler.setFormatter(formatter)
             logger.addHandler(file_handler)
-        
-        logger.debug(
-            "Logger initialized - Name: %s, Level: %s",
-            name,
-            level
-        )
-    
+
+        logger.debug("Logger initialized - Name: %s, Level: %s", name, level)
+
     return logger


### PR DESCRIPTION
## Summary
- avoid shadowing standard `logging` by renaming ui/core logging module
- expose `setup_logging` via `core` package

## Testing
- `pytest -q` *(fails: 11 failed, 24 passed, 5 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f94f7aafc832a8a6a8ee2aba46d20