### PR TITLE
Fix UI service imports to avoid runtime module error

### DIFF
--- a/ai-stock-platform/ui/dependencies/common.py
+++ b/ai-stock-platform/ui/dependencies/common.py
@@ -4,7 +4,12 @@ from typing import Any, Dict, Optional, Tuple
 from core.config.constants import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from fastapi import Query, Request
 
-from ui.services.api_client import APIClient
+# Prefer the standalone ``services`` package but fall back to the
+# old ``ui.services`` path when running tests from the monorepo.
+try:
+    from services.api_client import APIClient
+except ModuleNotFoundError:  # pragma: no cover - fallback for tests
+    from ui.services.api_client import APIClient
 
 API_URL = "http://quantumvestai-dev-api:8000"
 

--- a/ai-stock-platform/ui/main.py
+++ b/ai-stock-platform/ui/main.py
@@ -18,7 +18,19 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from ui.services.api_client import APIClient
+# Import the API client from the local services package. The project
+# originally referenced ``ui.services`` but the UI Docker image only
+# includes the ``services`` package at the application root, so using
+# the explicit local import avoids missing-module errors when running
+# inside that container.
+# Import the API client. Prefer the ``services`` package which is included when
+# running the UI in isolation, but fall back to ``ui.services`` when running the
+# application from the monorepo where the compatibility package may not be on
+# ``PYTHONPATH`` yet.
+try:
+    from services.api_client import APIClient
+except ModuleNotFoundError:  # pragma: no cover - fallback for tests
+    from ui.services.api_client import APIClient
 
 import sentry_sdk
 import os

--- a/ai-stock-platform/ui/services/api_client.py
+++ b/ai-stock-platform/ui/services/api_client.py
@@ -9,16 +9,22 @@ from typing import Any, Dict, Optional, Union
 from urllib.parse import urljoin
 
 import requests
-# Attempt to load settings from the UI package first, then API package if available.
+# Attempt to load settings from the shared core package first.  In some
+# testing environments the ``ui`` package inserts its own ``core`` package
+# ahead of the shared one which lacks ``get_settings``.  Fall back to the
+# API package if importing from ``core.config`` fails for any reason.
 try:
-    from core.config import get_settings
-except ModuleNotFoundError:
+    from core.config import get_settings  # type: ignore[attr-defined]
+    # Ensure we actually imported the desired function
+    if not callable(get_settings):
+        raise ImportError
+except (ModuleNotFoundError, ImportError):
     try:
         from api.core.config.settings import get_settings
     except ModuleNotFoundError as e:
         raise ImportError(
-            "Could not import settings from either 'ui.config' or 'api.core.config.settings'. "
-            "Make sure PYTHONPATH includes /app/ai-stock-platform."
+            "Could not import settings from either 'core.config' or 'api.core.config.settings'. "
+            "Make sure PYTHONPATH includes the project directory."
         ) from e
 from requests.exceptions import ConnectionError, RequestException, Timeout
 

--- a/ai-stock-platform/ui/services/forecast_service.py
+++ b/ai-stock-platform/ui/services/forecast_service.py
@@ -1,7 +1,10 @@
 # ui/services/forecast_service.py
 from typing import Any, Dict, List, Optional
 
-from ui.services.api_client import APIClient
+# Import APIClient from the sibling ``services`` package. This keeps the
+# module working when the code is deployed without the legacy ``ui``
+# package at the repository root.
+from .api_client import APIClient
 
 
 def get_stock_info(ticker: str, token: Optional[str] = None) -> Optional[Dict[str, Any]]:

--- a/ai-stock-platform/ui/tests/conftest.py
+++ b/ai-stock-platform/ui/tests/conftest.py
@@ -7,9 +7,11 @@ import sys
 import pytest
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
-# Ensure ai-stock-platform packages are discoverable
+# Ensure project packages are discoverable
+sys.path.append(ROOT)
 sys.path.append(os.path.join(ROOT, "ai-stock-platform"))
 sys.path.append(os.path.join(ROOT, "ai-stock-platform", "api"))
+# Add the UI package path so tests can import from ``services`` directly
 
 pytest.importorskip("httpx")
 from unittest.mock import MagicMock, patch
@@ -22,7 +24,9 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from ui.main import app as ui_app
-from ui.services.api_client import APIClient
+# Use the services package directly; the ``ui.services`` alias may not be
+# available when running the UI container in isolation.
+from services.api_client import APIClient
 
 
 @pytest.fixture
@@ -56,7 +60,7 @@ def mock_api_client():
     Returns:
         MagicMock: Mocked API client
     """
-    with patch('ui.services.api_client.APIClient') as mock:
+    with patch('services.api_client.APIClient') as mock:
         mock_client = MagicMock(spec=APIClient)
         yield mock_client
 

--- a/ai-stock-platform/ui/tests/test_routes/test_auth_routes.py
+++ b/ai-stock-platform/ui/tests/test_routes/test_auth_routes.py
@@ -22,13 +22,13 @@ def test_login_page_get(client):
 def test_login_post_success(client, test_user, monkeypatch):
     monkeypatch.setenv("API_BASE_URL", "http://testserver/api")
     # Mock the APIClient.post_form method
-    with patch('ui.services.api_client.APIClient.post_form') as mock_post_form:
+    with patch('services.api_client.APIClient.post_form') as mock_post_form:
         mock_post_form.return_value = {
             "data": {"access_token": "test_token"},
             "message": "Login successful"
         }
         # Simulate user info fetch
-        with patch('ui.services.api_client.APIClient.get') as mock_get:
+        with patch('services.api_client.APIClient.get') as mock_get:
             mock_get.return_value = {"data": test_user}
             response = client.post(
                 "/login",
@@ -46,7 +46,7 @@ def test_login_post_success(client, test_user, monkeypatch):
 def test_login_post_failure(client, monkeypatch):
     monkeypatch.setenv("API_BASE_URL", "http://testserver/api")
     # Mock the APIClient.post_form method to return no token (invalid credentials)
-    with patch('ui.services.api_client.APIClient.post_form') as mock_post_form:
+    with patch('services.api_client.APIClient.post_form') as mock_post_form:
         mock_post_form.return_value = {"data": {}, "message": "Invalid username or password"}
         response = client.post(
             "/login",
@@ -60,12 +60,12 @@ def test_login_post_failure(client, monkeypatch):
 def test_login_with_next_parameter(client, test_user, monkeypatch):
     monkeypatch.setenv("API_BASE_URL", "http://testserver/api")
     # Mock the APIClient.post_form method
-    with patch('ui.services.api_client.APIClient.post_form') as mock_post_form:
+    with patch('services.api_client.APIClient.post_form') as mock_post_form:
         mock_post_form.return_value = {
             "data": {"access_token": "test_token"},
             "message": "Login successful"
         }
-        with patch('ui.services.api_client.APIClient.get') as mock_get:
+        with patch('services.api_client.APIClient.get') as mock_get:
             mock_get.return_value = {"data": test_user}
             response = client.post(
                 "/login?next=/forecast",
@@ -104,7 +104,7 @@ def test_register_page_get(client):
 def test_register_post_success(client, monkeypatch):
     monkeypatch.setenv("API_BASE_URL", "http://testserver/api")
     # Mock the APIClient.post method
-    with patch('ui.services.api_client.APIClient.post') as mock_post:
+    with patch('services.api_client.APIClient.post') as mock_post:
         mock_post.return_value = {"data": {"user_id": 123}, "message": "Registration successful"}
         response = client.post(
             "/register",
@@ -133,7 +133,7 @@ def test_register_post_success(client, monkeypatch):
 def test_register_post_username_taken(client, monkeypatch):
     monkeypatch.setenv("API_BASE_URL", "http://testserver/api")
     # Mock the APIClient.post method to raise an exception
-    with patch('ui.services.api_client.APIClient.post') as mock_post:
+    with patch('services.api_client.APIClient.post') as mock_post:
         mock_post.side_effect = Exception("Username already taken")
         response = client.post(
             "/register",

--- a/ai-stock-platform/ui/tests/test_services/test_api_client.py
+++ b/ai-stock-platform/ui/tests/test_services/test_api_client.py
@@ -20,7 +20,8 @@ import requests
 # are on ``sys.path`` during tests.
 from core.config import settings
 
-from ui.services.api_client import APIClient
+# Import directly from the services package used by the application
+from services.api_client import APIClient
 
 
 def test_api_client_initialization():

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,7 @@
+"""Compatibility package that forwards imports to the UI services module."""
+import sys
+from pathlib import Path
+_pkg_path = Path(__file__).resolve().parent.parent / 'ai-stock-platform' / 'ui' / 'services'
+__path__ = [str(_pkg_path)]
+if str(_pkg_path) not in sys.path:
+    sys.path.insert(0, str(_pkg_path))


### PR DESCRIPTION
## Summary
- provide fallback logic when importing the API client so the UI can run even if only the `services` package is available
- update dependencies to use this fallback logic
- make `services.api_client` resilient to misordered PYTHONPATH entries
- adjust forecast service import
- add a compatibility `services` package at repo root
- update tests to ensure project root is on `sys.path`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError & database connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_687fa67ec290832a8ac6a735f83d6c20