### PR TITLE
Fix api client settings import

### DIFF
--- a/ai-stock-platform/ui/services/api_client.py
+++ b/ai-stock-platform/ui/services/api_client.py
@@ -21,9 +21,13 @@ except (ModuleNotFoundError, ImportError):
     import sys
     from pathlib import Path
 
-    # Remove any previously imported ``core.config`` module that may have
-    # originated from ``ui.core`` so we can re-import it from the project root.
+    # Remove any previously imported ``core`` package or ``core.config`` module
+    # that may have originated from ``ui.core`` so we can re-import them from
+    # the project root.  If only ``core.config`` is removed, Python will reuse
+    # the already-imported ``core`` package and still resolve ``core.config`` to
+    # the wrong location.
     sys.modules.pop("core.config", None)
+    sys.modules.pop("core", None)
 
     candidate = Path(__file__).resolve()
     project_root = None


### PR DESCRIPTION
## Summary
- fix sys.modules cleanup when falling back to project root

## Testing
- `pytest -q` *(fails: database connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_687fe4b8f5e0832a92f42d09347b035e