### PR TITLE
Fix PROJECT_ROOT determination for UI

### DIFF
--- a/ai-stock-platform/ui/main.py
+++ b/ai-stock-platform/ui/main.py
@@ -18,8 +18,16 @@ from pathlib import Path
 # alongside this file when running the application directly from this
 # folder.  This prevents "attempted relative import beyond top-level"
 # errors that occur when the namespace package is chosen instead of the
-# intended package with an ``__init__``.
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
+# intended package with an ``__init__``. In some production images this
+# file may live directly under ``/app`` with only two parents. Attempting
+# to access ``parents[2]`` in that scenario raises ``IndexError``.  To be
+# resilient, use ``parents[2]`` when available and fall back to the
+# immediate parent directory otherwise.
+file_path = Path(__file__).resolve()
+if len(file_path.parents) >= 3:
+    PROJECT_ROOT = file_path.parents[2]
+else:  # pragma: no cover - handles shallow directory structures
+    PROJECT_ROOT = file_path.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 


### PR DESCRIPTION
## Summary
- avoid IndexError in ui by dynamically resolving PROJECT_ROOT when fewer parent directories exist

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 11 failed, 24 passed, 5 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68800260c760832ab7323469da624f61