### PR TITLE
Fix backward compatibility for user name fields

### DIFF
--- a/ai-stock-platform/api/db/models/user.py
+++ b/ai-stock-platform/api/db/models/user.py
@@ -11,6 +11,7 @@ from db.models.associations import user_watchlist
 from sqlalchemy import Boolean, Column, Integer, String, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import relationship, synonym
+from sqlalchemy.ext.hybrid import hybrid_property
 
 
 class User(Base, TimestampMixin):
@@ -33,6 +34,7 @@ class User(Base, TimestampMixin):
     # column.  ``password_hash`` is kept as a backward compatible synonym.
 
     _pwd_column_name = "hashed_password"
+    _use_split_names = False
     try:  # Introspect the DB to determine which column actually exists
         from core.config import get_settings
         from sqlalchemy import create_engine, inspect
@@ -44,6 +46,8 @@ class User(Base, TimestampMixin):
         engine.dispose()
         if "password_hash" in cols and "hashed_password" not in cols:
             _pwd_column_name = "password_hash"
+        if "full_name" not in cols and "first_name" in cols and "last_name" in cols:
+            _use_split_names = True
     except Exception:
         # If inspection fails (e.g., during tests with no DB) default to the
         # original ``hashed_password`` column name.
@@ -51,7 +55,31 @@ class User(Base, TimestampMixin):
 
     hashed_password = Column(_pwd_column_name, String, nullable=False)
     password_hash = synonym("hashed_password")
-    full_name = Column(String)
+
+    if _use_split_names:
+        first_name = Column("first_name", String)
+        last_name = Column("last_name", String)
+
+        @hybrid_property
+        def full_name(self) -> Optional[str]:
+            parts = []
+            if self.first_name:
+                parts.append(self.first_name)
+            if self.last_name:
+                parts.append(self.last_name)
+            return " ".join(parts) if parts else None
+
+        @full_name.setter
+        def full_name(self, value: Optional[str]) -> None:
+            if value:
+                names = value.split(" ", 1)
+                self.first_name = names[0]
+                self.last_name = names[1] if len(names) > 1 else None
+            else:
+                self.first_name = None
+                self.last_name = None
+    else:
+        full_name = Column("full_name", String)
     is_active = Column(Boolean, default=True)
     is_superuser = Column(Boolean, default=False)
     role = Column(String, default="free", nullable=False)


### PR DESCRIPTION
## Summary
- support databases that have `first_name` and `last_name` instead of `full_name`
- introspect columns at import and expose a hybrid `full_name` property when needed

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: test_login_success, test_login_invalid_credentials, test_get_current_user, test_async_connection, test_migrations_can_run, and other DB connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68802323b474832ab21f341da94f8c6b