### PR TITLE
Fix config import fallback

### DIFF
--- a/ai-stock-platform/api/services/stock_service.py
+++ b/ai-stock-platform/api/services/stock_service.py
@@ -19,12 +19,20 @@ import aiohttp
 # explicit ``api.core.config`` path avoids mistakenly importing the
 # similarly named package in the repository root which does not expose the
 # ``ALPHA_VANTAGE_API_KEY`` attribute.
+# Attempt to import settings from ``api.core.config``. When the service is
+# executed inside the Docker image the working directory already contains the
+# package contents, so the ``api`` package name may not be importable.  In that
+# case fall back to the ``core`` compatibility package which exposes the same
+# settings object.
 try:
     from api.core.config import settings
-except ModuleNotFoundError as e:  # pragma: no cover - explicit error path
-    raise ImportError(
-        "Could not import API configuration. Ensure PYTHONPATH includes the api package."
-    ) from e
+except ModuleNotFoundError:
+    try:
+        from core.config import settings  # type: ignore[attr-defined]
+    except ModuleNotFoundError as e:  # pragma: no cover - explicit error path
+        raise ImportError(
+            "Could not import API configuration. Ensure PYTHONPATH includes the api package."
+        ) from e
 from sqlalchemy.orm import Session
 
 from models.stock import Stock, WatchList

--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -24,12 +24,19 @@ from typing import Any, Dict, List, Optional
 # This avoids accidentally importing the similarly named package located in
 # the repository root which lacks several attributes such as
 # ``ALPHA_VANTAGE_API_KEY``.
+# Attempt to import the settings object. When running inside the Docker
+# container the ``api`` package may not be available because the working
+# directory is already the package itself. In that case fall back to the
+# ``core`` compatibility package which exposes the same settings instance.
 try:
     from api.core.config import settings
-except ModuleNotFoundError as e:  # pragma: no cover - explicit error path
-    raise ImportError(
-        "Could not import API configuration. Ensure PYTHONPATH includes the api package."
-    ) from e
+except ModuleNotFoundError:
+    try:
+        from core.config import settings  # type: ignore[attr-defined]
+    except ModuleNotFoundError as e:  # pragma: no cover - explicit error path
+        raise ImportError(
+            "Could not import API configuration. Ensure PYTHONPATH includes the api package."
+        ) from e
 
 # Try to import aiohttp, fallback to None if not available
 try:


### PR DESCRIPTION
## Summary
- use `core.config` fallback when `api` package isn't available

## Testing
- `pytest ai-stock-platform/api/tests/test_trending_stocks.py::test_trending_stocks_service_initialization -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services.api_client')*

------
https://chatgpt.com/codex/tasks/task_e_68802b2ac0dc832aad7116ced3648bb9