### PR TITLE
Fix PYTHONPATH instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Activate it with `source venv/bin/activate`.
 After activating, add the API package to your `PYTHONPATH` so tools like
 Alembic can locate the `api` module when run from outside the repository root:
 ```bash
-export PYTHONPATH="$(pwd)/ai-stock-platform:$PYTHONPATH"
+export PYTHONPATH="$(pwd)/ai-stock-platform:$(pwd)/ai-stock-platform/api:$PYTHONPATH"
 ```
 
 > **Important**: Ensure that the top-level `ai-stock-platform` directory is

--- a/ai-stock-platform/api/scripts/run_db_init.sh
+++ b/ai-stock-platform/api/scripts/run_db_init.sh
@@ -20,7 +20,7 @@ done
 echo "Database is available"
 
 # Set environment variables for Alembic
-export PYTHONPATH=/db-init
+export PYTHONPATH="/db-init:${PYTHONPATH}"
 
 # Step 1: Run database migrations
 echo "Running database migrations..."

--- a/ci-cd/k8s/dev/07-db-init-configmap.yaml
+++ b/ci-cd/k8s/dev/07-db-init-configmap.yaml
@@ -21,7 +21,7 @@ data:
     file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d%%(second).2d_%%(rev)s_%%(slug)s
     timezone = UTC
     # Ensure PYTHONPATH is set for Alembic migrations
-    PYTHONPATH = /app/ai-stock-platform:/app/ai-stock-platform/api
+    PYTHONPATH=/app/ai-stock-platform:/app/ai-stock-platform/api
 
   wait-for-db.sh: |
     #!/bin/sh

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -17,4 +17,4 @@ pip install --upgrade pip
 pip install -r requirements.txt
 
 echo "Environment setup complete. Activate with 'source venv/bin/activate'"
-echo "Add the API package to PYTHONPATH: export PYTHONPATH=\"$(pwd)/ai-stock-platform:$PYTHONPATH\""
+echo "Add the API package to PYTHONPATH: export PYTHONPATH=\"$(pwd)/ai-stock-platform:$(pwd)/ai-stock-platform/api:$PYTHONPATH\""


### PR DESCRIPTION
## Summary
- correct PYTHONPATH export in `run_db_init.sh`
- fix spacing in `07-db-init-configmap.yaml`
- update setup instructions and README

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 5 failed, 30 passed, 5 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68802fc3c4e4832a82cb4e8618f8a508