### PR TITLE
Handle missing Alembic revision

### DIFF
--- a/ai-stock-platform/api/scripts/db-init-entrypoint.sh
+++ b/ai-stock-platform/api/scripts/db-init-entrypoint.sh
@@ -44,7 +44,13 @@ else
     exit 1
 fi
 
-alembic -c "$ALEMBIC_CFG" upgrade heads
+
+# Attempt upgrade, handle missing revisions by stamping baseline
+if ! alembic -c "$ALEMBIC_CFG" upgrade heads; then
+    echo "Alembic upgrade failed. Stamping database to initial revision and retrying..." >&2
+    alembic -c "$ALEMBIC_CFG" stamp 0001
+    alembic -c "$ALEMBIC_CFG" upgrade heads
+fi
 
 # Run seed script if specified
 if [ "${RUN_SEED:-false}" = "true" ]; then

--- a/ai-stock-platform/api/scripts/run_migrations.sh
+++ b/ai-stock-platform/api/scripts/run_migrations.sh
@@ -32,6 +32,12 @@ else
     exit 1
 fi
 
-alembic -c "$ALEMBIC_CFG" upgrade heads
+
+# Attempt upgrade, handle missing revisions by stamping baseline
+if ! alembic -c "$ALEMBIC_CFG" upgrade heads; then
+    echo "Alembic upgrade failed. Stamping database to initial revision and retrying..." >&2
+    alembic -c "$ALEMBIC_CFG" stamp 0001
+    alembic -c "$ALEMBIC_CFG" upgrade heads
+fi
 
 echo "[$(date -u '+%Y-%m-%d %H:%M:%S')] Migrations completed successfully!"


### PR DESCRIPTION
## Summary
- handle cases where migrations fail because a database references an unknown Alembic revision
- stamp to the initial revision and retry when running `run_migrations.sh` and `db-init-entrypoint.sh`

## Testing
- `pytest -q` *(fails: 5 failed, 30 passed, 5 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68804eb53904832a8851ed337eea559d