### PR TITLE
Fix Alembic version reference

### DIFF
--- a/ci-cd/k8s/dev/08-db-migration-job.yaml
+++ b/ci-cd/k8s/dev/08-db-migration-job.yaml
@@ -217,7 +217,7 @@ spec:
                       
                       -- Insert current version
                       INSERT INTO alembic_version (version_num)
-                      VALUES ('20250615_initial')
+                      VALUES ('0001')
                       ON CONFLICT (version_num) DO NOTHING;
                       
                       -- Record that this migration has been applied


### PR DESCRIPTION
## Summary
- fix the alembic_version inserted during Kubernetes job

## Testing
- `pytest -q` *(fails: OperationalError connecting to DB)*

------
https://chatgpt.com/codex/tasks/task_e_68805ef68390832a9983219495876985