### PR TITLE
Add data fetch scheduler

### DIFF
--- a/ai-stock-platform/api/services/data_fetch_scheduler.py
+++ b/ai-stock-platform/api/services/data_fetch_scheduler.py
@@ -1,0 +1,56 @@
+import asyncio
+import logging
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from services.trending_stocks_service import TrendingStocksService
+from social.multi_source_sentiment import MultiSourceSentimentAnalyzer
+
+logger = logging.getLogger(__name__)
+
+
+async def fetch_and_analyze() -> None:
+    """Fetch trending stocks and analyze Twitter sentiment."""
+    service = TrendingStocksService()
+    try:
+        trending = await service.get_trending_stocks(page=1, limit=5)
+    except Exception as exc:
+        logger.error("Failed fetching trending stocks: %s", exc)
+        return
+
+    symbols = [s.get("symbol") for s in trending.get("stocks", [])]
+    if not symbols:
+        logger.warning("No symbols returned from trending stocks service")
+        return
+
+    async with MultiSourceSentimentAnalyzer() as analyzer:
+        for symbol in symbols:
+            try:
+                sentiment = await analyzer.analyze_comprehensive_sentiment(symbol)
+                logger.info(
+                    "Sentiment for %s: %s", symbol, sentiment.get("sentiment_category")
+                )
+            except Exception as exc:
+                logger.error("Sentiment analysis failed for %s: %s", symbol, exc)
+
+
+def start_data_fetch_scheduler() -> AsyncIOScheduler:
+    """Start scheduler to fetch market and sentiment data every 15 minutes."""
+    scheduler = AsyncIOScheduler()
+    scheduler.add_job(
+        fetch_and_analyze,
+        trigger=IntervalTrigger(minutes=15),
+        id="market_sentiment_fetch",
+        replace_existing=True,
+    )
+    scheduler.start()
+    logger.info("Data fetch scheduler started")
+    return scheduler
+
+
+if __name__ == "__main__":
+    sched = start_data_fetch_scheduler()
+    try:
+        asyncio.get_event_loop().run_forever()
+    except (KeyboardInterrupt, SystemExit):
+        sched.shutdown()

--- a/tests/test_data_fetch_scheduler.py
+++ b/tests/test_data_fetch_scheduler.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+ROOT = os.path.join(os.path.dirname(__file__), "..", "ai-stock-platform")
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "api"))
+
+from api.services.data_fetch_scheduler import start_data_fetch_scheduler
+
+
+def test_data_fetch_scheduler_adds_job():
+    scheduler = start_data_fetch_scheduler()
+    try:
+        jobs = scheduler.get_jobs()
+        assert any(job.id == "market_sentiment_fetch" for job in jobs)
+    finally:
+        scheduler.shutdown()


### PR DESCRIPTION
## Summary
- schedule trending stocks sentiment collection
- test that scheduler sets up the job

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q tests` *(fails: ImportError in `test_config.py`)*

------
https://chatgpt.com/codex/tasks/task_e_6880854c47c4832a96430963b1fdc922