### PR TITLE
Add data pipeline scheduler

### DIFF
--- a/ai-stock-platform/api/agents/__init__.py
+++ b/ai-stock-platform/api/agents/__init__.py
@@ -1,0 +1,11 @@
+"""Utility agents for data fetching and analysis."""
+
+from .data_fetch_agent import DataFetchAgent
+from .analysis_agent import DataAnalysisAgent
+from .pipeline import DataPipelineManager
+
+__all__ = [
+    "DataFetchAgent",
+    "DataAnalysisAgent",
+    "DataPipelineManager",
+]

--- a/ai-stock-platform/api/agents/analysis_agent.py
+++ b/ai-stock-platform/api/agents/analysis_agent.py
@@ -1,0 +1,17 @@
+"""Agent that performs analysis on fetched data."""
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class DataAnalysisAgent:
+    """Run a synchronous analysis function in the background."""
+
+    name: str
+    analysis_fn: Callable[[Any], Any]
+
+    async def analyze(self, data: Any) -> Any:
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, self.analysis_fn, data)

--- a/ai-stock-platform/api/agents/data_fetch_agent.py
+++ b/ai-stock-platform/api/agents/data_fetch_agent.py
@@ -1,0 +1,20 @@
+"""Asynchronous agent for fetching JSON data from external sources."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import aiohttp
+
+
+@dataclass
+class DataFetchAgent:
+    """Fetch data from a configured URL."""
+
+    name: str
+    source_url: str
+
+    async def fetch(self, params: Optional[Dict[str, Any]] = None) -> Any:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(self.source_url, params=params, timeout=10) as resp:
+                resp.raise_for_status()
+                return await resp.json()

--- a/ai-stock-platform/api/agents/pipeline.py
+++ b/ai-stock-platform/api/agents/pipeline.py
@@ -1,0 +1,38 @@
+"""Manager for coordinating data fetching and analysis agents."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, List
+
+from .data_fetch_agent import DataFetchAgent
+from .analysis_agent import DataAnalysisAgent
+
+
+@dataclass
+class DataPipelineManager:
+    """Run multiple fetch and analysis agents as a pipeline."""
+
+    fetch_agents: List[DataFetchAgent] = field(default_factory=list)
+    analysis_agents: List[DataAnalysisAgent] = field(default_factory=list)
+
+    def add_fetch_agent(self, agent: DataFetchAgent) -> None:
+        self.fetch_agents.append(agent)
+
+    def add_analysis_agent(self, agent: DataAnalysisAgent) -> None:
+        self.analysis_agents.append(agent)
+
+    async def run(self) -> List[Any]:
+        """Fetch data and run analyses concurrently."""
+        fetch_tasks = [agent.fetch() for agent in self.fetch_agents]
+        fetched = await asyncio.gather(*fetch_tasks, return_exceptions=True)
+
+        results: List[Any] = []
+        for data in fetched:
+            if isinstance(data, Exception):
+                continue
+            analysis_tasks = [agent.analyze(data) for agent in self.analysis_agents]
+            analysed = await asyncio.gather(*analysis_tasks, return_exceptions=True)
+            results.extend(r for r in analysed if not isinstance(r, Exception))
+        return results

--- a/ai-stock-platform/api/services/data_pipeline_scheduler.py
+++ b/ai-stock-platform/api/services/data_pipeline_scheduler.py
@@ -1,0 +1,31 @@
+import logging
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from agents import DataFetchAgent, DataAnalysisAgent, DataPipelineManager
+
+logger = logging.getLogger(__name__)
+
+async def run_pipeline() -> None:
+    """Example job that runs a simple data pipeline."""
+    fetch_agent = DataFetchAgent("sample", "https://example.com/data")
+    analysis_agent = DataAnalysisAgent("noop", lambda d: d)
+    manager = DataPipelineManager([fetch_agent], [analysis_agent])
+    try:
+        await manager.run()
+    except Exception as exc:  # pragma: no cover - scheduler context
+        logger.error("Pipeline job failed: %s", exc)
+
+
+def start_data_pipeline_scheduler() -> AsyncIOScheduler:
+    """Start scheduler that periodically runs the data pipeline."""
+    scheduler = AsyncIOScheduler()
+    scheduler.add_job(
+        run_pipeline,
+        trigger=IntervalTrigger(minutes=5),
+        id="data_pipeline_run",
+        replace_existing=True,
+    )
+    scheduler.start()
+    logger.info("Data pipeline scheduler started")
+    return scheduler

--- a/tests/test_data_agents.py
+++ b/tests/test_data_agents.py
@@ -1,0 +1,51 @@
+import asyncio
+from aiohttp import web
+import pytest
+
+from api.agents import DataFetchAgent, DataAnalysisAgent, DataPipelineManager
+
+
+@pytest.mark.asyncio
+async def test_fetch_agent():
+    async def handler(request):
+        return web.json_response({"value": 42})
+
+    app = web.Application()
+    app.router.add_get("/data", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "localhost", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+
+    agent = DataFetchAgent("test", f"http://localhost:{port}/data")
+    data = await agent.fetch()
+    assert data["value"] == 42
+
+    await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_manager():
+    async def handler(request):
+        return web.json_response({"number": 3})
+
+    app = web.Application()
+    app.router.add_get("/data", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "localhost", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+
+    fetch_agent = DataFetchAgent("fetch", f"http://localhost:{port}/data")
+    analysis_agent = DataAnalysisAgent("double", lambda d: d["number"] * 2)
+
+    manager = DataPipelineManager()
+    manager.add_fetch_agent(fetch_agent)
+    manager.add_analysis_agent(analysis_agent)
+
+    result = await manager.run()
+    assert result == [6]
+
+    await runner.cleanup()

--- a/tests/test_pipeline_scheduler.py
+++ b/tests/test_pipeline_scheduler.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+ROOT = os.path.join(os.path.dirname(__file__), "..", "ai-stock-platform")
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "api"))
+
+from api.services.data_pipeline_scheduler import start_data_pipeline_scheduler
+
+
+def test_pipeline_scheduler_adds_job():
+    scheduler = start_data_pipeline_scheduler()
+    try:
+        jobs = scheduler.get_jobs()
+        assert any(job.id == "data_pipeline_run" for job in jobs)
+    finally:
+        scheduler.shutdown()


### PR DESCRIPTION
## Summary
- add service to schedule DataPipelineManager using APScheduler
- test new scheduler adds the expected job

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: InvalidRequestError: Table 'users' is already defined)*

------
https://chatgpt.com/codex/tasks/task_e_688089b75dd8832a80e6c04ead3f709e