### PR TITLE
Add prediction data ingestion agent

### DIFF
--- a/ai-stock-platform/api/services/prediction_data_agent.py
+++ b/ai-stock-platform/api/services/prediction_data_agent.py
@@ -1,0 +1,103 @@
+import logging
+from datetime import datetime
+from typing import List, Optional, Type
+
+import pandas as pd
+import yfinance as yf
+from sqlalchemy.orm import Session
+
+try:  # Lazy import so tests can inject models without triggering DB setup
+    from db.models.stock import Stock, StockPrice
+except Exception:  # pragma: no cover - allow tests to provide mocks
+    Stock = None  # type: ignore
+    StockPrice = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+class PredictionDataAgent:
+    """Fetch price data from external sources and store in the database."""
+
+    def __init__(
+        self,
+        db: Session,
+        symbols: List[str],
+        stock_model: Optional[Type] = None,
+        price_model: Optional[Type] = None,
+    ) -> None:
+        self.db = db
+        self.symbols = symbols
+        # Allow dependency injection of models for easier testing
+        self.Stock = stock_model or Stock
+        self.StockPrice = price_model or StockPrice
+
+    def fetch_prices(self, symbol: str, days: int = 1) -> pd.DataFrame:
+        """Retrieve recent historical prices using yfinance."""
+        try:
+            df = yf.download(symbol, period=f"{days}d", interval="1d", progress=False)
+            df = df.reset_index()
+            df.rename(
+                columns={
+                    "Date": "date",
+                    "Open": "open",
+                    "High": "high",
+                    "Low": "low",
+                    "Close": "close",
+                    "Adj Close": "adjusted_close",
+                    "Volume": "volume",
+                },
+                inplace=True,
+            )
+            df["date"] = pd.to_datetime(df["date"])
+            return df
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.error("Failed to fetch prices for %s: %s", symbol, exc)
+            return pd.DataFrame()
+
+    def store_prices(self, symbol: str, df: pd.DataFrame) -> None:
+        """Insert fetched prices into the database."""
+        if df.empty:
+            return
+
+        stock = self.db.query(self.Stock).filter_by(ticker=symbol).first()
+        if not stock:
+            stock = self.Stock(ticker=symbol, name=symbol, exchange="")
+            self.db.add(stock)
+            self.db.commit()
+            self.db.refresh(stock)
+
+        for _, row in df.iterrows():
+            price = (
+                self.db.query(self.StockPrice)
+                .filter_by(stock_id=stock.id, date=row["date"])
+                .first()
+            )
+            if price:
+                price.open = row["open"]
+                price.high = row["high"]
+                price.low = row["low"]
+                price.close = row["close"]
+                price.adjusted_close = row["adjusted_close"]
+                price.volume = int(row["volume"])
+            else:
+                price = self.StockPrice(
+                    stock_id=stock.id,
+                    date=row["date"],
+                    open=row["open"],
+                    high=row["high"],
+                    low=row["low"],
+                    close=row["close"],
+                    adjusted_close=row["adjusted_close"],
+                    volume=int(row["volume"]),
+                )
+                self.db.add(price)
+
+        stock.last_price = float(df.iloc[-1]["close"])
+        stock.last_updated = datetime.utcnow()
+        self.db.commit()
+
+    def update_symbols(self, days: int = 1) -> None:
+        """Fetch and store data for all configured symbols."""
+        for symbol in self.symbols:
+            df = self.fetch_prices(symbol, days=days)
+            self.store_prices(symbol, df)

--- a/tests/test_prediction_data_agent.py
+++ b/tests/test_prediction_data_agent.py
@@ -1,0 +1,69 @@
+from datetime import datetime
+
+import pandas as pd
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+from api.services.prediction_data_agent import PredictionDataAgent
+from sqlalchemy.orm import declarative_base
+from sqlalchemy import Column, Integer, Float, String, DateTime
+
+TestBase = declarative_base()
+
+
+class TestStock(TestBase):
+    __tablename__ = "stocks"
+    id = Column(Integer, primary_key=True)
+    ticker = Column(String)
+    name = Column(String)
+    exchange = Column(String)
+    last_price = Column(Float)
+    last_updated = Column(DateTime)
+
+
+class TestStockPrice(TestBase):
+    __tablename__ = "stock_prices"
+    id = Column(Integer, primary_key=True)
+    stock_id = Column(Integer)
+    date = Column(DateTime)
+    open = Column(Float)
+    high = Column(Float)
+    low = Column(Float)
+    close = Column(Float)
+    adjusted_close = Column(Float)
+    volume = Column(Integer)
+
+
+def test_prediction_data_agent(monkeypatch):
+    # Set up in-memory database
+    engine = create_engine("sqlite:///:memory:")
+    TestBase.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+
+    # Fake yfinance download
+    def fake_download(symbol, period="1d", interval="1d", progress=False):
+        return pd.DataFrame({
+            "Date": [datetime(2024, 1, 1)],
+            "Open": [100.0],
+            "High": [110.0],
+            "Low": [90.0],
+            "Close": [105.0],
+            "Adj Close": [105.0],
+            "Volume": [1000],
+        })
+
+    monkeypatch.setattr("api.services.prediction_data_agent.yf.download", fake_download)
+
+    agent = PredictionDataAgent(
+        session,
+        ["TEST"],
+        stock_model=TestStock,
+        price_model=TestStockPrice,
+    )
+    agent.update_symbols(days=1)
+
+    assert session.query(TestStock).count() == 1
+    assert session.query(TestStockPrice).count() == 1
+


### PR DESCRIPTION
## Summary
- implement `PredictionDataAgent` for ingesting price data
- allow injection of models for testability
- add unit test using in-memory database

## Testing
- `pytest tests/test_prediction_data_agent.py -q`
- `pytest -q` *(fails: Table 'users' already defined)*

------
https://chatgpt.com/codex/tasks/task_e_68808ccb8bb0832aad1907e77541f0cf