### PR TITLE
Fix missing synonym import

### DIFF
--- a/ai-stock-platform/api/db/models/user.py
+++ b/ai-stock-platform/api/db/models/user.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.hybrid import hybrid_property, hybrid_method
-from sqlalchemy.orm import relationship, Session
+from sqlalchemy.orm import relationship, Session, synonym
 from sqlalchemy.sql import func, select, exists, case
 try:
     from werkzeug.security import generate_password_hash, check_password_hash


### PR DESCRIPTION
## Summary
- fix missing synonym import in User model

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: Table 'users' is already defined)*


------
https://chatgpt.com/codex/tasks/task_e_6880919b9448832ab4828f445f14f1ee