### PR TITLE
Add ChatGPT integration guide and service

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This document provides a comprehensive list of API and UI endpoints for the QuantumVestAI application.
 For screenshots and icons used in the interface, see [UI Visuals](docs/UI_IMAGES.md).
+For instructions on integrating ChatGPT into the UI, see [ChatGPT Guide](docs/CHATGPT_UI_INTEGRATION.md).
 
 ---
 

--- a/ai-stock-platform/ui/requirements.txt
+++ b/ai-stock-platform/ui/requirements.txt
@@ -64,3 +64,4 @@ PyJWT==2.7.0
 # Monitoring & Observability
 sentry-sdk
 prometheus_client
+openai==1.14.3

--- a/ai-stock-platform/ui/services/__init__.py
+++ b/ai-stock-platform/ui/services/__init__.py
@@ -12,6 +12,7 @@ from .api_client import APIClient
 # Then import other services
 from .auth_service import AuthService
 from .cache_service import CacheService
+from .chatgpt_service import ChatGPTService
 
 
 # Only import these if they exist
@@ -30,5 +31,6 @@ __all__ = [
     'AuthService', 
     'CacheService',
     'ForecastService',
-    'YahooFinanceService'
+    'YahooFinanceService',
+    'ChatGPTService'
 ]

--- a/ai-stock-platform/ui/services/chatgpt_service.py
+++ b/ai-stock-platform/ui/services/chatgpt_service.py
@@ -1,0 +1,31 @@
+"""ChatGPT integration service."""
+
+import logging
+import os
+from typing import Optional
+
+import openai
+
+logger = logging.getLogger(__name__)
+
+class ChatGPTService:
+    """Wrapper for the OpenAI Chat Completion API."""
+
+    @classmethod
+    async def ask(cls, prompt: str, model: str = "gpt-3.5-turbo") -> str:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            logger.warning("OPENAI_API_KEY not configured")
+            return "ChatGPT is not available."
+        openai.api_key = api_key
+        try:
+            response = await openai.ChatCompletion.acreate(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.7,
+            )
+            return response.choices[0].message.content.strip()
+        except Exception as exc:
+            logger.error("ChatGPT request failed: %s", exc)
+            return "Unable to fetch response from ChatGPT."
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,3 +23,5 @@ graph TD
 ```
 
 The UI uses FastAPI and Jinja2 templates to render pages. The API service exposes REST endpoints for authentication, portfolio management, and prediction requests. Machine learning models (primarily LSTM-based) are managed by the `ModelManager` class, which can load models from local storage or AWS S3 and is capable of combining them using an ensemble predictor. The API persists data in a PostgreSQL database.
+
+An optional `ChatGPTService` allows the UI to send questions to OpenAI's ChatGPT API. When enabled, this service provides conversational explanations about predictions and market trends directly in the interface.

--- a/docs/CHATGPT_UI_INTEGRATION.md
+++ b/docs/CHATGPT_UI_INTEGRATION.md
@@ -1,0 +1,64 @@
+# ChatGPT UI Integration Guide
+
+This guide explains how to extend QuantumVestAI with conversational features powered by OpenAI's ChatGPT.
+
+## Overview
+The UI can optionally send user questions to the ChatGPT API and display the response directly in the web interface. This enables natural language explanations about predictions and market trends.
+
+## Requirements
+- An OpenAI API key (`OPENAI_API_KEY`) available as an environment variable.
+- The `openai` Python package.
+
+## Service Implementation
+Create a service `ChatGPTService` under `ui/services` that wraps the OpenAI API. The service should expose an async method `ask` which accepts a prompt and returns the assistant's reply. When no API key is provided, the service returns a helpful fallback message instead of raising an error.
+
+```python
+# ui/services/chatgpt_service.py
+import logging
+import os
+from typing import Optional
+
+import openai
+
+logger = logging.getLogger(__name__)
+
+class ChatGPTService:
+    """Simple wrapper around the OpenAI Chat Completion API."""
+
+    @classmethod
+    async def ask(cls, prompt: str, model: str = "gpt-3.5-turbo") -> str:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            logger.warning("OPENAI_API_KEY not configured")
+            return "ChatGPT is not available."
+        openai.api_key = api_key
+        try:
+            response = await openai.ChatCompletion.acreate(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.7,
+            )
+            return response.choices[0].message.content.strip()
+        except Exception as exc:
+            logger.error("ChatGPT request failed: %s", exc)
+            return "Unable to fetch response from ChatGPT."
+```
+
+## UI Endpoint
+Expose a FastAPI endpoint that calls `ChatGPTService.ask` and returns the reply as JSON. A simple example:
+
+```python
+@router.post("/chatgpt")
+async def chatgpt_endpoint(prompt: str) -> dict[str, str]:
+    answer = await ChatGPTService.ask(prompt)
+    return {"answer": answer}
+```
+
+You can render this through a small form in a template or integrate with the existing React frontend.
+
+## Usage
+1. Install dependencies and include `openai` in `ui/requirements.txt`.
+2. Set `OPENAI_API_KEY` in the environment before starting the UI.
+3. Access the `/chatgpt` endpoint from the browser or front-end component to receive responses.
+
+This modular approach keeps ChatGPT optional while allowing powerful conversational features in the UI.

--- a/tests/test_chatgpt_service.py
+++ b/tests/test_chatgpt_service.py
@@ -1,0 +1,15 @@
+import asyncio
+import os
+
+from ai_stock_platform.ui.services.chatgpt_service import ChatGPTService
+
+
+async def run():
+    # Ensure API key not set
+    os.environ.pop("OPENAI_API_KEY", None)
+    result = await ChatGPTService.ask("Hello")
+    assert "ChatGPT is not available" in result
+
+
+def test_chatgpt_no_api_key():
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- document how to connect the UI to ChatGPT
- expose new `ChatGPTService` within UI services
- reference the guide from the README and architecture document
- add `openai` requirement for the UI package
- include a simple test for the service

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: sqlalchemy.exc.InvalidRequestError: Table 'users' is already defined for this MetaData instance)*

------
https://chatgpt.com/codex/tasks/task_e_688094758674832a996ec7651bee9b85