### PR TITLE
Add predictive analytics chart

### DIFF
--- a/ai-stock-platform/ui/src/components/Analytics.tsx
+++ b/ai-stock-platform/ui/src/components/Analytics.tsx
@@ -7,6 +7,7 @@ import { Container, Row, Col, Card, Button, Spinner, Alert, Badge, Table } from 
 import { Link } from 'react-router-dom';
 import { ROUTES } from '../config/constants';
 import apiService, { MarketOverview, Stock } from '../services/api-service';
+import PredictiveAnalytics from './analysis/PredictiveAnalytics';
 
 const Analytics: React.FC = () => {
   const [marketOverview, setMarketOverview] = useState<MarketOverview | null>(null);
@@ -210,26 +211,29 @@ const Analytics: React.FC = () => {
   );
 
   const renderAnalysisTab = () => (
-    <Card className="mb-4">
-      <Card.Header>
-        <h5 className="mb-0">Market Analysis</h5>
-      </Card.Header>
-      <Card.Body>
-        <Alert variant="info">
-          <Alert.Heading>AI-Powered Market Analysis</Alert.Heading>
-          <p>Advanced market analysis features are coming soon. This will include:</p>
-          <ul>
-            <li>Risk analysis and portfolio optimization</li>
-            <li>Correlation analysis between stocks and sectors</li>
-            <li>Economic indicators and their market impact</li>
-            <li>Predictive analytics and forecasting</li>
-          </ul>
-          <Button variant="primary" as={Link as any} to={ROUTES.AI_ASSISTANT}>
-            Try AI Assistant
-          </Button>
-        </Alert>
-      </Card.Body>
-    </Card>
+    <>
+      <Card className="mb-4">
+        <Card.Header>
+          <h5 className="mb-0">Market Analysis</h5>
+        </Card.Header>
+        <Card.Body>
+          <Alert variant="info">
+            <Alert.Heading>AI-Powered Market Analysis</Alert.Heading>
+            <p>Advanced market analysis features are coming soon. This will include:</p>
+            <ul>
+              <li>Risk analysis and portfolio optimization</li>
+              <li>Correlation analysis between stocks and sectors</li>
+              <li>Economic indicators and their market impact</li>
+              <li>Predictive analytics and forecasting</li>
+            </ul>
+            <Button variant="primary" as={Link as any} to={ROUTES.AI_ASSISTANT}>
+              Try AI Assistant
+            </Button>
+          </Alert>
+        </Card.Body>
+      </Card>
+      <PredictiveAnalytics />
+    </>
   );
 
   return (

--- a/ai-stock-platform/ui/src/components/analysis/PredictiveAnalytics.tsx
+++ b/ai-stock-platform/ui/src/components/analysis/PredictiveAnalytics.tsx
@@ -1,0 +1,77 @@
+/**
+ * Predictive Analytics Component
+ * Displays AI predictions in a chart
+ */
+import React, { useState, useEffect } from 'react';
+import { Card, Spinner, Alert } from 'react-bootstrap';
+import { Line } from 'react-chartjs-2';
+import apiService from '../../services/api-service';
+
+interface PredictiveAnalyticsProps {
+  symbols?: string[];
+}
+
+const PredictiveAnalytics: React.FC<PredictiveAnalyticsProps> = ({ symbols = ['AAPL'] }) => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [chartData, setChartData] = useState<any>(null);
+
+  useEffect(() => {
+    fetchPredictiveData();
+  }, [symbols.join(',')]);
+
+  const fetchPredictiveData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await apiService.getPredictiveAnalytics(symbols);
+      if (!data || !data.predictions?.length) {
+        throw new Error('No prediction data');
+      }
+      const labels = data.predictions.map((p: any) => p.symbol);
+      const targets = data.predictions.map((p: any) => p.target);
+      setChartData({
+        labels,
+        datasets: [
+          {
+            label: 'Predicted Price',
+            data: targets,
+            borderColor: '#4e73df',
+            backgroundColor: 'rgba(78,115,223,0.1)',
+            tension: 0.1
+          }
+        ]
+      });
+    } catch (err: any) {
+      console.error('Error fetching predictive analytics:', err);
+      setError('Failed to load predictive analytics');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card className="mb-4">
+      <Card.Header>
+        <h5 className="mb-0">Predictive Analysis</h5>
+      </Card.Header>
+      <Card.Body>
+        {loading ? (
+          <div className="text-center p-4">
+            <Spinner animation="border" role="status">
+              <span className="visually-hidden">Loading...</span>
+            </Spinner>
+          </div>
+        ) : error ? (
+          <Alert variant="danger">{error}</Alert>
+        ) : (
+          <div style={{ height: '300px' }}>
+            <Line data={chartData} options={{ responsive: true }} />
+          </div>
+        )}
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default PredictiveAnalytics;

--- a/ai-stock-platform/ui/src/config/constants.ts
+++ b/ai-stock-platform/ui/src/config/constants.ts
@@ -63,6 +63,7 @@ export const API_ENDPOINTS = {
     MARKET_OVERVIEW: '/api/v1/analytics/market-overview',
     SECTORS: '/api/v1/analytics/sectors',
     TOP_MOVERS: '/api/v1/analytics/top-movers',
+    PREDICTIVE: '/api/v1/analytics/predictive',
     MARKET_BREADTH: '/api/v1/analytics/market-breadth',
     ECONOMIC_INDICATORS: '/api/v1/analytics/economic-indicators',
     CORRELATIONS: '/api/v1/analytics/correlations',

--- a/ai-stock-platform/ui/src/services/api-service.ts
+++ b/ai-stock-platform/ui/src/services/api-service.ts
@@ -271,6 +271,22 @@ class ApiService {
     return response.data.data;
   }
 
+  async getPredictiveAnalytics(
+    symbols: string[],
+    horizon = '1w',
+    confidenceLevel = 0.95
+  ): Promise<any> {
+    const params = new URLSearchParams({
+      symbols: symbols.join(','),
+      horizon,
+      confidence_level: confidenceLevel.toString()
+    });
+    const response = await apiClient.get<StandardResponse<any>>(
+      `${API_ENDPOINTS.ANALYTICS.PREDICTIVE}?${params.toString()}`
+    );
+    return response.data.data;
+  }
+
   // Backtest methods
   async runBacktest(backtestRequest: BacktestRequest): Promise<BacktestResult> {
     const response = await apiClient.post<StandardResponse<BacktestResult>>(


### PR DESCRIPTION
## Summary
- add predictive analytics endpoint constant
- extend API service with `getPredictiveAnalytics`
- render predictive analytics chart in Analytics page
- implement `PredictiveAnalytics` React component

## Testing
- `./setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688093f453ac832a95a4894df6226a42