### PR TITLE
Enable live data mode

### DIFF
--- a/ai-stock-platform/core/config/settings.py
+++ b/ai-stock-platform/core/config/settings.py
@@ -41,6 +41,9 @@ class Settings(BaseSettings):
 
     BACKEND_CORS_ORIGINS: list[str] | str | None = None
 
+    # Toggle demo mode for UI. When False the UI fetches live data.
+    DEMO_MODE: bool = Field(default=True, env="DEMO_MODE")
+
     @field_validator("BACKEND_CORS_ORIGINS", mode="before")
     @classmethod
     def assemble_cors_origins(cls, v):

--- a/ai-stock-platform/ui/README.md
+++ b/ai-stock-platform/ui/README.md
@@ -3,16 +3,15 @@
 **Version**: 2.0.0  
 **Author**: hemanth9398  
 **Updated**: 2025-07-07 21:54:42  
-**Status**: Production Ready with Demo Mode
+**Status**: Production Ready (Demo Mode configurable)
 
 ## 🎯 Overview
 
-This is a complete, production-ready web UI for the QuantumVestAI platform featuring AI-driven stock market predictions and comprehensive portfolio management. The application is fully functional in demo mode with realistic data and can be deployed immediately.
+This is a complete, production-ready web UI for the QuantumVestAI platform featuring AI-driven stock market predictions and comprehensive portfolio management. The UI supports a demo mode for quick evaluations, but it can also operate with live data for subscribed users by disabling demo mode.
 
 ## ✨ Features
 
 ### 🔐 Authentication System
-- **Demo Accounts**: Pre-configured demo users for testing
 - **Secure Login**: Session-based authentication with cookie management
 - **User Registration**: Complete registration flow with validation
 - **Profile Management**: User profile and preferences
@@ -87,19 +86,8 @@ This is a complete, production-ready web UI for the QuantumVestAI platform featu
 
 4. **Access the Application**:
    - Open your browser to: http://ui-service
-   - Use demo accounts to login (see Demo Accounts section below)
-
-## 👤 Demo Accounts
-
-The application includes pre-configured demo accounts for testing:
-
-| Username | Password | Role  | Features |
-|----------|----------|-------|----------|
-| `demo`   | `demo`   | User  | Full feature access |
-| `admin`  | `admin`  | Admin | All permissions + admin features |
-| `test`   | `test`   | User  | Basic features |
-| `user`   | `password` | User  | Standard features |
+   - Login with your registered account
 
 ## 🎉 Ready for Production Deployment!
 
-This application is fully functional and ready for immediate deployment. All features work in demo mode with realistic data, providing a complete user experience without requiring external API connections.
+This application is fully functional and ready for immediate deployment. By default it runs in demo mode using sample data. Set `DEMO_MODE=false` and configure the database variables (`DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`) to enable live data for subscribed users. When live mode is enabled, market data is persisted to the configured PostgreSQL database and AI price predictions are displayed on the dashboard.

--- a/ai-stock-platform/ui/routes/dashboard.py
+++ b/ai-stock-platform/ui/routes/dashboard.py
@@ -11,6 +11,10 @@ from typing import List, Optional
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
+from core.config import settings
+from services.yahoo_finance import YahooFinanceService
+from services.trending_stocks_service import TrendingStocksService
+from services.api_client import APIClient
 
 # Setup router
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
@@ -25,41 +29,67 @@ def get_templates(request: Request) -> Jinja2Templates:
     """Return app-level templates if available."""
     return getattr(request.app.state, "templates", templates)
 
-# Demo data removed
+
+# Demo placeholder data
 DEMO_MARKET_DATA = {}
 DEMO_STOCKS = []
 DEMO_NEWS = []
 
+
 @router.get("/", response_class=HTMLResponse)
 async def dashboard_page(request: Request):
-    """Render main dashboard page (demo mode)"""
+    """Render main dashboard page"""
     try:
-        logger.info("Loading dashboard page in demo mode")
-        
-        # Do not assume a logged-in demo user
-        user = None
-        
-        # Demo watchlist removed
-        watchlist_items = []
+        demo_mode = settings.DEMO_MODE
 
-        # Demo portfolio performance removed
-        portfolio_data = {}
-        
+        token = request.cookies.get("access_token")
+        api = APIClient(token=token) if token else None
+        user = api.get("/users/me") if api else None
+        subscribed = bool(user and user.get("role") != "free")
+        watchlist_items: List[str] = []
+        portfolio_data: dict = {}
+
+        market_summary = DEMO_MARKET_DATA
+        popular_stocks = DEMO_STOCKS
+        news = DEMO_NEWS
+
+        if not demo_mode and subscribed:
+            market_summary = YahooFinanceService.get_market_summary()
+            try:
+                trending = await TrendingStocksService().get_trending_stocks(limit=5)
+                popular_stocks = trending.get("stocks", [])
+                for stock in popular_stocks:
+                    try:
+                        symbol = stock.get("symbol") or stock.get("ticker")
+                        if symbol and api:
+                            pred = api.get(f"/predictions/{symbol}")
+                            price = (
+                                pred.get("data", {})
+                                .get("predictions", [{}])[0]
+                                .get("predicted_price")
+                            )
+                            if price is not None:
+                                stock["prediction"] = price
+                    except Exception as exc:  # pragma: no cover
+                        logger.warning(f"Prediction fetch failed for {symbol}: {exc}")
+            except Exception as ex:  # pragma: no cover - network errors
+                logger.warning(f"Trending stocks fetch failed: {ex}")
+
         return get_templates(request).TemplateResponse(
             "dashboard/index.html",
             {
                 "request": request,
                 "user": user,
-                "demo_mode": True,
-                "market_summary": DEMO_MARKET_DATA,
-                "popular_stocks": DEMO_STOCKS,
-                "news": DEMO_NEWS,
+                "demo_mode": demo_mode,
+                "market_summary": market_summary,
+                "popular_stocks": popular_stocks,
+                "news": news,
                 "watchlist": watchlist_items,
                 "portfolio": portfolio_data,
-                "page_title": "Dashboard - QuantumVestAI"
-            }
+                "page_title": "Dashboard - QuantumVestAI",
+            },
         )
-        
+
     except Exception as e:
         logger.error(f"Error loading dashboard: {str(e)}")
         return get_templates(request).TemplateResponse(
@@ -67,17 +97,18 @@ async def dashboard_page(request: Request):
             {
                 "request": request,
                 "user": None,
-                "demo_mode": True,
+                "demo_mode": demo_mode,
                 "market_summary": {"indices": {}, "sectors": {}, "top_movers": {}},
                 "popular_stocks": [],
                 "news": [],
                 "watchlist": [],
                 "portfolio": {},
                 "error": f"Error loading dashboard: {str(e)}",
-                "page_title": "Dashboard Error"
+                "page_title": "Dashboard Error",
             },
-            status_code=500
+            status_code=500,
         )
+
 
 @router.get("/portfolio", response_class=HTMLResponse)
 async def portfolio_page(request: Request):
@@ -85,17 +116,17 @@ async def portfolio_page(request: Request):
     try:
         # Demo portfolio data removed
         portfolio_data = {}
-        
+
         return get_templates(request).TemplateResponse(
             "dashboard/portfolio.html",
             {
                 "request": request,
                 "portfolio": portfolio_data,
-                "demo_mode": True,
-                "page_title": "Portfolio - QuantumVestAI"
-            }
+                "demo_mode": settings.DEMO_MODE,
+                "page_title": "Portfolio - QuantumVestAI",
+            },
         )
-        
+
     except Exception as e:
         logger.error(f"Error loading portfolio page: {str(e)}")
         return get_templates(request).TemplateResponse(
@@ -103,28 +134,29 @@ async def portfolio_page(request: Request):
             {
                 "request": request,
                 "error": "Unable to load portfolio data",
-                "page_title": "Portfolio Error"
+                "page_title": "Portfolio Error",
             },
-            status_code=500
+            status_code=500,
         )
 
-@router.get("/analytics", response_class=HTMLResponse) 
+
+@router.get("/analytics", response_class=HTMLResponse)
 async def analytics_page(request: Request):
     """Advanced analytics page"""
     try:
         # Demo analytics data removed
         analytics_data = {}
-        
+
         return get_templates(request).TemplateResponse(
             "dashboard/analytics.html",
             {
                 "request": request,
                 "analytics": analytics_data,
-                "demo_mode": True,
-                "page_title": "Analytics - QuantumVestAI"
-            }
+                "demo_mode": settings.DEMO_MODE,
+                "page_title": "Analytics - QuantumVestAI",
+            },
         )
-        
+
     except Exception as e:
         logger.error(f"Error loading analytics page: {str(e)}")
         return get_templates(request).TemplateResponse(
@@ -132,24 +164,47 @@ async def analytics_page(request: Request):
             {
                 "request": request,
                 "error": "Unable to load analytics data",
-                "page_title": "Analytics Error"
+                "page_title": "Analytics Error",
             },
-            status_code=500
+            status_code=500,
         )
+
 
 @router.get("/api/summary")
 async def dashboard_api_summary(request: Request):
     """API endpoint for dashboard summary data"""
     try:
+        token = request.cookies.get("access_token")
+        api = APIClient(token=token) if token else None
+        if settings.DEMO_MODE or not api:
+            data = {}
+        else:
+            data = YahooFinanceService.get_market_summary()
+            trending = await TrendingStocksService().get_trending_stocks(limit=5)
+            stocks = trending.get("stocks", [])
+            for stock in stocks:
+                symbol = stock.get("symbol") or stock.get("ticker")
+                if symbol:
+                    pred = api.get(f"/predictions/{symbol}")
+                    price = (
+                        pred.get("data", {})
+                        .get("predictions", [{}])[0]
+                        .get("predicted_price")
+                        if pred
+                        else None
+                    )
+                    if price is not None:
+                        stock["prediction"] = price
+            data["trending"] = stocks
         return {
             "status": "success",
-            "data": {},
-            "timestamp": datetime.utcnow().isoformat()
+            "data": data,
+            "timestamp": datetime.utcnow().isoformat(),
         }
     except Exception as e:
         logger.error(f"Error getting dashboard summary: {str(e)}")
         return {
             "status": "error",
             "message": str(e),
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.utcnow().isoformat(),
         }

--- a/ai-stock-platform/ui/templates/dashboard/index.html
+++ b/ai-stock-platform/ui/templates/dashboard/index.html
@@ -58,114 +58,27 @@
     </div>
     <!-- Market Overview Cards -->
     <div class="row mb-4">
+        {% for symbol, idx in market_summary.indices.items()|dictsort %}
         <div class="col-md-3">
             <div class="card quantum-card micro-interaction">
                 <div class="card-body">
                     <div class="d-flex justify-content-between align-items-start mb-2">
                         <div>
-                            <h6 class="text-muted mb-1">S&P 500</h6>
-                            <h4 class="mb-0">SPY</h4>
+                            <h6 class="text-muted mb-1">{{ idx.name }}</h6>
+                            <h4 class="mb-0">{{ symbol }}</h4>
                         </div>
-                        <span class="badge quantum-badge">📈</span>
+                        <span class="badge quantum-badge">{% if idx.change >= 0 %}📈{% else %}📉{% endif %}</span>
                     </div>
                     <div class="mb-2">
-                        <div class="h3 mb-1 price-display">$459.32</div>
-                        <div class="fw-bold text-success">+$2.15 (+0.47%)</div>
-                    </div>
-                    <div class="row text-muted small">
-                        <div class="col-6">
-                            <div>High: $460.12</div>
-                            <div>Low: $456.78</div>
-                        </div>
-                        <div class="col-6">
-                            <div>Vol: 45.2M</div>
-                            <div>Cap: $4.2T</div>
+                        <div class="h3 mb-1 price-display">{{ format_currency(idx.price) }}</div>
+                        <div class="fw-bold {% if idx.change >= 0 %}text-success{% else %}text-danger{% endif %}">
+                            {{ format_change_value(idx.change) }} ({{ format_percentage(idx.change_percent/100) }})
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-        <div class="col-md-3">
-            <div class="card quantum-card micro-interaction">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-2">
-                        <div>
-                            <h6 class="text-muted mb-1">NASDAQ 100</h6>
-                            <h4 class="mb-0">QQQ</h4>
-                        </div>
-                        <span class="badge quantum-badge">📉</span>
-                    </div>
-                    <div class="mb-2">
-                        <div class="h3 mb-1 price-display">$398.45</div>
-                        <div class="fw-bold text-danger">-$1.23 (-0.31%)</div>
-                    </div>
-                    <div class="row text-muted small">
-                        <div class="col-6">
-                            <div>High: $401.23</div>
-                            <div>Low: $397.45</div>
-                        </div>
-                        <div class="col-6">
-                            <div>Vol: 32.1M</div>
-                            <div>Cap: $2.8T</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-3">
-            <div class="card quantum-card micro-interaction">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-2">
-                        <div>
-                            <h6 class="text-muted mb-1">Dow Jones</h6>
-                            <h4 class="mb-0">DIA</h4>
-                        </div>
-                        <span class="badge quantum-badge">📈</span>
-                    </div>
-                    <div class="mb-2">
-                        <div class="h3 mb-1 price-display">$342.67</div>
-                        <div class="fw-bold text-success">+$0.89 (+0.26%)</div>
-                    </div>
-                    <div class="row text-muted small">
-                        <div class="col-6">
-                            <div>High: $343.12</div>
-                            <div>Low: $340.23</div>
-                        </div>
-                        <div class="col-6">
-                            <div>Vol: 12.3M</div>
-                            <div>Cap: $1.5T</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-3">
-            <div class="card quantum-card micro-interaction">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-2">
-                        <div>
-                            <h6 class="text-muted mb-1">Volatility Index</h6>
-                            <h4 class="mb-0">VIX</h4>
-                        </div>
-                        <span class="badge quantum-badge">📉</span>
-                    </div>
-                    <div class="mb-2">
-                        <div class="h3 mb-1 price-display">$18.45</div>
-                        <div class="fw-bold text-success">-$0.67 (-3.51%)</div>
-                    </div>
-                    <div class="row text-muted small">
-                        <div class="col-6">
-                            <div>High: $19.23</div>
-                            <div>Low: $17.89</div>
-                        </div>
-                        <div class="col-6">
-                            <div>Vol: 8.8M</div>
-                            <div>Fear: Low</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+        {% endfor %}
     </div>
 
     <!-- Portfolio Overview -->
@@ -233,26 +146,18 @@
                 </div>
                 <div class="card-body">
                     <div class="top-movers-list">
+                        {% for stock in popular_stocks %}
                         <div class="top-mover-item d-flex justify-content-between align-items-center mb-2">
                             <div>
-                                <div class="fw-bold">NVDA</div>
-                                <div class="text-muted small">$789.23</div>
+                                <div class="fw-bold">{{ stock.ticker }}</div>
+                                <div class="text-muted small">{{ format_currency(stock.price) }}</div>
                             </div>
-                            <div class="text-end text-success">
-                                <div class="fw-bold">+6.14%</div>
-                                <div class="small">+$45.67</div>
-                            </div>
-                        </div>
-                        <div class="top-mover-item d-flex justify-content-between align-items-center mb-2">
-                            <div>
-                                <div class="fw-bold">TSLA</div>
-                                <div class="text-muted small">$245.67</div>
-                            </div>
-                            <div class="text-end text-danger">
-                                <div class="fw-bold">-4.78%</div>
-                                <div class="small">-$12.34</div>
+                            <div class="text-end {% if stock.change >= 0 %}text-success{% else %}text-danger{% endif %}">
+                                <div class="fw-bold">{{ format_percentage(stock.change_percent/100) }}</div>
+                                <div class="small">{{ format_change_value(stock.change) }}</div>
                             </div>
                         </div>
+                        {% endfor %}
                     </div>
                     <div class="mt-3">
                         <a href="/stocks" class="btn btn-outline-primary w-100">


### PR DESCRIPTION
## Summary
- add live-data section to the dashboard page
- fetch user info and predictions when subscribed
- return trending data from dashboard API
- document that live data persists to the DB

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: sqlalchemy.exc.InvalidRequestError)*

------
https://chatgpt.com/codex/tasks/task_e_6880937cb64c832a97c0f8a9341f78ec