### PR TITLE
Fix import errors and add sentiment stub

### DIFF
--- a/ai-stock-platform/api/core/exceptions.py
+++ b/ai-stock-platform/api/core/exceptions.py
@@ -119,6 +119,20 @@ class ServiceUnavailableError(HTTPException):
         )
 
 
+class ConfigurationError(QuantumVestAIException):
+    """Raised when application configuration is invalid."""
+
+    def __init__(self, message: str = "Invalid configuration"):
+        super().__init__(message, error_code="CONFIGURATION_ERROR")
+
+
+class ExternalAPIError(QuantumVestAIException):
+    """Raised when an external API request fails."""
+
+    def __init__(self, message: str = "External API error"):
+        super().__init__(message, error_code="EXTERNAL_API_ERROR")
+
+
 # User-specific exceptions
 class UserNotFoundError(NotFoundError):
     """Raised when user is not found"""

--- a/ai-stock-platform/api/db/models/audit_log.py
+++ b/ai-stock-platform/api/db/models/audit_log.py
@@ -36,6 +36,9 @@ class AuditLog(Base):
             action.in_(['INSERT', 'UPDATE', 'DELETE', 'LOGIN', 'LOGOUT', 'ACCESS']),
             name='valid_action'
         ),
+        {
+            "extend_existing": True
+        }
     )
 
     def __repr__(self):

--- a/ai-stock-platform/api/db/models/role.py
+++ b/ai-stock-platform/api/db/models/role.py
@@ -15,6 +15,7 @@ from db.base import Base
 class Role(Base):
     """Role model for role-based access control"""
     __tablename__ = "roles"
+    __table_args__ = {"extend_existing": True}
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(50), unique=True, nullable=False, index=True)

--- a/ai-stock-platform/api/db/models/user.py
+++ b/ai-stock-platform/api/db/models/user.py
@@ -41,6 +41,9 @@ class User(Base):
     and comprehensive user management features.
     """
     __tablename__ = "users"
+    # Allow redefining the table in test environments where models may
+    # be imported multiple times.
+    __table_args__ = {"extend_existing": True}
 
     # Primary identification
     id = Column(Integer, primary_key=True, index=True)

--- a/ai-stock-platform/api/db/models/user_role.py
+++ b/ai-stock-platform/api/db/models/user_role.py
@@ -14,6 +14,7 @@ from db.base import Base
 class UserRole(Base):
     """Association model between User and Role"""
     __tablename__ = "user_roles"
+    __table_args__ = {"extend_existing": True}
 
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
     role_id = Column(Integer, ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True)

--- a/ai-stock-platform/api/db/models/user_session.py
+++ b/ai-stock-platform/api/db/models/user_session.py
@@ -16,6 +16,7 @@ from db.base import Base
 class UserSession(Base):
     """User session model for session management"""
     __tablename__ = "user_sessions"
+    __table_args__ = {"extend_existing": True}
 
     id = Column(Integer, primary_key=True, index=True)
     session_id = Column(String(255), unique=True, nullable=False, index=True)

--- a/ai-stock-platform/api/db/models/user_setting.py
+++ b/ai-stock-platform/api/db/models/user_setting.py
@@ -14,6 +14,10 @@ from db.base import Base
 class UserSetting(Base):
     """User-specific settings model"""
     __tablename__ = "user_settings"
+    __table_args__ = (
+        UniqueConstraint('user_id', 'category', 'key', name='uq_user_category_key'),
+        {"extend_existing": True}
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
@@ -25,11 +29,6 @@ class UserSetting(Base):
 
     # Relationships
     user = relationship("User", back_populates="user_settings")
-
-    # Unique constraint
-    __table_args__ = (
-        UniqueConstraint('user_id', 'category', 'key', name='uq_user_category_key'),
-    )
 
     def __repr__(self):
         return f"<UserSetting(user_id={self.user_id}, key='{self.category}.{self.key}')>"

--- a/ai-stock-platform/api/models/sentiment.py
+++ b/ai-stock-platform/api/models/sentiment.py
@@ -1,0 +1,9 @@
+class SentimentRecord:
+    """Simplified sentiment record used for tests."""
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    async def save(self) -> None:
+        """Persist the record (no-op in tests)."""
+        pass

--- a/ai-stock-platform/api/schemas/__init__.py
+++ b/ai-stock-platform/api/schemas/__init__.py
@@ -3,11 +3,13 @@ Schemas package initialization.
 """
 from .stock import *
 from .token import Token, TokenData
-from .user import User, UserBase, UserCreate, UserProfile, UserUpdate
+# The user schemas module no longer exposes a generic ``User`` class.
+# Import only the available schema classes to avoid import errors.
+from .user import UserBase, UserCreate, UserProfile, UserUpdate
 from .watchlist import *
 from .whitepaper import *
 
 __all__ = [
-    "User", "UserCreate", "UserBase", "UserUpdate", "UserProfile",
+    "UserCreate", "UserBase", "UserUpdate", "UserProfile",
     "Token", "TokenData"
 ]

--- a/ai-stock-platform/api/services/data_fetch_scheduler.py
+++ b/ai-stock-platform/api/services/data_fetch_scheduler.py
@@ -3,7 +3,9 @@ import logging
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
-from services.trending_stocks_service import TrendingStocksService
+# Import from the current package to avoid conflicts with the top-level
+# ``services`` package used for API clients.
+from .trending_stocks_service import TrendingStocksService
 from social.multi_source_sentiment import MultiSourceSentimentAnalyzer
 
 logger = logging.getLogger(__name__)

--- a/ai-stock-platform/api/social/twitter_sentiment.py
+++ b/ai-stock-platform/api/social/twitter_sentiment.py
@@ -17,7 +17,9 @@ from core.exceptions import (ConfigurationError, ExternalAPIError,
                              RateLimitError)
 from textblob import TextBlob
 
-from models.sentiment import SentimentRecord
+# Import the sentiment record from the API models package explicitly to avoid
+# confusion with the top-level ``models`` package.
+from api.models.sentiment import SentimentRecord
 
 logger = logging.getLogger("api.social")
 


### PR DESCRIPTION
## Summary
- adjust schema package imports to avoid missing `User`
- relax ORM table creation for tests
- use relative imports for scheduler and Twitter sentiment
- add missing exception classes and SentimentRecord stub

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6880969838bc832a978c90db3e603d5b