### PR TITLE
Fix missing User method on failed imports

### DIFF
--- a/ai-stock-platform/api/models/__init__.py
+++ b/ai-stock-platform/api/models/__init__.py
@@ -4,17 +4,32 @@ Created: 2025-05-20 05:58:02
 Updated: 2025-05-21 15:48:25
 Author: daparthi001
 """
-try:
+# Import models individually so failure of one does not mask the others
+try:  # Timestamp mixin is required by most models
     from db.base import TimestampMixin
-    from db.models.portfolio import (PortfolioSummary, Position, Transaction,
-                                     TransactionType)
-    from db.models.stock import Stock, WatchList
-    from db.models.user import User
 except Exception:  # pragma: no cover - optional in test environment
     TimestampMixin = object
-    User = object
+
+try:
+    from db.models.user import User
+except Exception:  # pragma: no cover - optional in test environment
+    class User:  # Minimal fallback to avoid attribute errors in tests
+        pass
+
+try:
+    from db.models.stock import Stock, WatchList
+except Exception:  # pragma: no cover - optional in test environment
     Stock = object
     WatchList = object
+
+try:
+    from db.models.portfolio import (
+        PortfolioSummary,
+        Position,
+        Transaction,
+        TransactionType,
+    )
+except Exception:  # pragma: no cover - optional in test environment
     Position = object
     Transaction = object
     PortfolioSummary = object


### PR DESCRIPTION
## Summary
- load each model individually in `api.models` to avoid fully failing if one import is missing
- provide stub `User` class when the database model can't be imported

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services.api_client')*

------
https://chatgpt.com/codex/tasks/task_e_6880ee2c677c832a886f683272bc75c1