### PR TITLE
Fix ambiguous relationship in User model

### DIFF
--- a/ai-stock-platform/api/db/models/user.py
+++ b/ai-stock-platform/api/db/models/user.py
@@ -165,7 +165,13 @@ class User(Base):
 
 
     # Relationships
-    user_roles = relationship("UserRole", back_populates="user", cascade="all, delete-orphan", lazy="select")
+    user_roles = relationship(
+        "UserRole",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        lazy="select",
+        foreign_keys="UserRole.user_id",
+    )
     portfolios = relationship("Portfolio", back_populates="user", cascade="all, delete-orphan", lazy="select")
     user_settings = relationship("UserSetting", back_populates="user", cascade="all, delete-orphan", lazy="select")
     audit_logs = relationship("AuditLog", back_populates="user", lazy="select")


### PR DESCRIPTION
## Summary
- disambiguate `User.user_roles` by specifying foreign key

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 3 errors, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6880f88a3b84832a95a842be1dd658d0