### PR TITLE
Fix SQLAlchemy registry for watchlist models

### DIFF
--- a/ai-stock-platform/api/db/models/__init__.py
+++ b/ai-stock-platform/api/db/models/__init__.py
@@ -11,6 +11,15 @@ from .user_role import UserRole
 from .user_setting import UserSetting
 from .audit_log import AuditLog
 from .user_session import UserSession
+from .stock import Stock, WatchList
+from .portfolio import (
+    Position,
+    Transaction,
+    PortfolioSummary,
+    TransactionType,
+)
+from .watchlist import Watchlist
+from .watchlist_stock import WatchlistStock
 
 # Import utility functions
 from .user import (
@@ -37,6 +46,8 @@ __all__ = [
     "create_user",
     "Stock",
     "WatchList",
+    "Watchlist",
+    "WatchlistStock",
     "Position",
     "Transaction",
     "PortfolioSummary",


### PR DESCRIPTION
## Summary
- ensure `Watchlist` and related models are imported when initializing the ORM

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services.api_client')*

------
https://chatgpt.com/codex/tasks/task_e_688114082a14832ab786a0bdd6a7e582