### PR TITLE
Fix watchlist model registration

### DIFF
--- a/ai-stock-platform/api/db/models/stock_forecast.py
+++ b/ai-stock-platform/api/db/models/stock_forecast.py
@@ -1,4 +1,5 @@
-from db.base_class import Base, TimestampMixin
+# Register this model on the shared SQLAlchemy Base used by other models.
+from db.base import Base, TimestampMixin
 from sqlalchemy import (Column, Date, ForeignKey, Integer, Numeric, String,
                         UniqueConstraint)
 from sqlalchemy.orm import relationship

--- a/ai-stock-platform/api/db/models/user.py
+++ b/ai-stock-platform/api/db/models/user.py
@@ -36,6 +36,13 @@ except ImportError:  # pragma: no cover - optional dependency may be missing
 from db.base import Base
 from db.models.associations import user_watchlist
 
+# Import related models so that SQLAlchemy is aware of them when this module
+# is imported in isolation. Without these imports the mapper configuration can
+# fail when resolving relationship targets like "Watchlist" or "WatchList".
+from .watchlist import Watchlist  # noqa: F401
+from .watchlist_stock import WatchlistStock  # noqa: F401
+from .stock import WatchList  # noqa: F401
+
 
 class User(Base):
     """

--- a/ai-stock-platform/api/db/models/user_activity_log.py
+++ b/ai-stock-platform/api/db/models/user_activity_log.py
@@ -1,4 +1,6 @@
-from db.base_class import Base, TimestampMixin
+# Use the common Base so that User relationships resolve correctly during
+# mapper configuration.
+from db.base import Base, TimestampMixin
 from sqlalchemy import JSON, Column, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 

--- a/ai-stock-platform/api/db/models/watchlist.py
+++ b/ai-stock-platform/api/db/models/watchlist.py
@@ -1,4 +1,8 @@
-from db.base_class import Base, TimestampMixin
+# Use the same Base and mixins as the rest of the models so that SQLAlchemy
+# registers this model on the shared metadata.  Using a different Base causes
+# relationship resolution errors such as the "Watchlist" class not being found
+# when the ``User`` model is imported before this module.
+from db.base import Base, TimestampMixin
 from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import relationship
 

--- a/ai-stock-platform/api/db/models/watchlist_stock.py
+++ b/ai-stock-platform/api/db/models/watchlist_stock.py
@@ -1,4 +1,6 @@
-from db.base_class import Base
+# Register the watchlist stock model on the main SQLAlchemy Base. Using a
+# separate Base prevents relationship strings from resolving correctly.
+from db.base import Base
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func

--- a/ai-stock-platform/api/db/models/whitepaper.py
+++ b/ai-stock-platform/api/db/models/whitepaper.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 
-from db.base_class import Base
+# Use the main Base registry so relationships to ``User`` are discoverable.
+from db.base import Base
 from sqlalchemy import (JSON, Column, DateTime, ForeignKey, Integer, String,
                         Text)
 from sqlalchemy.dialects.postgresql import ARRAY  # If using PostgreSQL


### PR DESCRIPTION
## Summary
- ensure watchlist-related models share the main SQLAlchemy Base
- import watchlist models inside `User` model so mappers can resolve

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'models.orders')*

------
https://chatgpt.com/codex/tasks/task_e_6881256f8004832a964b6c910b36846a