### PR TITLE
Fix watchlist stock relationship

### DIFF
--- a/ai-stock-platform/api/db/models/stock.py
+++ b/ai-stock-platform/api/db/models/stock.py
@@ -60,6 +60,13 @@ class Stock(Base, TimestampMixin):
     # Alias used by older code
     watchlists = watchlist_entries
 
+    # New watchlist stocks relationship used by modern watchlist implementation
+    watchlist_stocks: Mapped[List["WatchlistStock"]] = relationship(
+        "WatchlistStock",
+        back_populates="stock",
+        cascade="all, delete-orphan",
+    )
+
     price_history: Mapped[List["StockPrice"]] = relationship(
         "StockPrice",
         back_populates="stock",

--- a/ai-stock-platform/api/db/models/watchlist_stock.py
+++ b/ai-stock-platform/api/db/models/watchlist_stock.py
@@ -16,4 +16,4 @@ class WatchlistStock(Base):
 
     # Relationships
     watchlist = relationship("Watchlist", back_populates="stocks")
-    stock = relationship("Stock", back_populates="watchlists")
+    stock = relationship("Stock", back_populates="watchlist_stocks")


### PR DESCRIPTION
## Summary
- define `watchlist_stocks` relationship on `Stock`
- connect `WatchlistStock.stock` to the new relationship

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'models.orders')*

------
https://chatgpt.com/codex/tasks/task_e_68812deda1c8832a8a1897348d7d8824