### PR TITLE
Fix user registration error when using split name schema

### DIFF
--- a/ai-stock-platform/api/db/models/user.py
+++ b/ai-stock-platform/api/db/models/user.py
@@ -118,6 +118,17 @@ class User(Base):
     else:
         full_name = Column("full_name", String)
 
+    def __init__(self, **kwargs):
+        """Allow ``full_name`` for split-name schemas."""
+        if "full_name" in kwargs and type(self)._use_split_names:
+            value = kwargs.pop("full_name")
+            if value:
+                parts = value.split(" ", 1)
+                kwargs.setdefault("first_name", parts[0])
+                if len(parts) > 1:
+                    kwargs.setdefault("last_name", parts[1])
+        super().__init__(**kwargs)
+
     is_active = Column(Boolean, default=True)
     if _has_is_superuser:
         is_superuser = Column(Boolean, default=False)


### PR DESCRIPTION
## Summary
- handle `full_name` in `User` initializer when DB uses `first_name`/`last_name`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68813edcfbe8832ab6cef19888c66037