### PR TITLE
Fix JSON fields for SQLite fallback

### DIFF
--- a/ai-stock-platform/api/db/models/audit_log.py
+++ b/ai-stock-platform/api/db/models/audit_log.py
@@ -3,8 +3,17 @@ AuditLog model for QuantumVestAI
 Created: 2025-07-23
 Author: daparthi001
 """
-from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, CheckConstraint
-from sqlalchemy.dialects.postgresql import JSONB, INET
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Text,
+    DateTime,
+    ForeignKey,
+    CheckConstraint,
+    JSON,
+)
+from sqlalchemy.dialects.postgresql import INET
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -20,8 +29,8 @@ class AuditLog(Base):
     table_name = Column(String(50), nullable=False, index=True)
     record_id = Column(Integer, index=True)
     action = Column(String(20), nullable=False, index=True)
-    old_values = Column(JSONB)
-    new_values = Column(JSONB)
+    old_values = Column(JSON)
+    new_values = Column(JSON)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
     ip_address = Column(INET)
     user_agent = Column(Text)

--- a/ai-stock-platform/api/db/models/role.py
+++ b/ai-stock-platform/api/db/models/role.py
@@ -3,8 +3,7 @@ Role model for QuantumVestAI
 Created: 2025-07-23
 Author: daparthi001
 """
-from sqlalchemy import Column, Integer, String, Text, DateTime
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import Column, Integer, String, Text, DateTime, JSON
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -20,7 +19,7 @@ class Role(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(50), unique=True, nullable=False, index=True)
     description = Column(Text)
-    permissions = Column(JSONB, default={})
+    permissions = Column(JSON, default={})
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     # Relationships


### PR DESCRIPTION
## Summary
- support SQLite fallback by using cross-database JSON column types
- update `Role` and `AuditLog` models accordingly

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ERROR ai-stock-platform/api/tests/test_order_management.py ...)*

------
https://chatgpt.com/codex/tasks/task_e_688144e8c588832aa9898793b52089d4