### PR TITLE
Improve registration validation

### DIFF
--- a/ai-stock-platform/api/routers/auth.py
+++ b/ai-stock-platform/api/routers/auth.py
@@ -17,7 +17,7 @@ from core.security.tokens import create_access_token
 from db.models.user import User
 from fastapi import APIRouter, Body, Depends, HTTPException, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, validator
 from schemas.auth import TokenResponse, UserBase
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -29,10 +29,27 @@ logger = logging.getLogger("quantumvestai_api.auth")
 
 # Registration request model
 class RegisterRequest(BaseModel):
+    """Registration request payload with basic validation."""
+
     username: str = Field(..., min_length=3, max_length=50)
     email: EmailStr
     password: str = Field(..., min_length=8)
+    confirm_password: str = Field(..., min_length=8)
     full_name: Optional[str] = None
+    terms_accepted: bool = Field(...)
+
+    @validator("confirm_password")
+    def passwords_match(cls, v, values):  # noqa: D417
+        password = values.get("password")
+        if password and v != password:
+            raise ValueError("Passwords do not match")
+        return v
+
+    @validator("terms_accepted")
+    def terms_required(cls, v):  # noqa: D417
+        if not v:
+            raise ValueError("Terms must be accepted")
+        return v
 
 
 # Registration response model

--- a/ai-stock-platform/ui/routes/auth.py
+++ b/ai-stock-platform/ui/routes/auth.py
@@ -187,7 +187,8 @@ async def register_post(
     email: str = Form(...),
     password: str = Form(...),
     confirm_password: str = Form(...),
-    full_name: str = Form(...)
+    full_name: str = Form(...),
+    terms: bool = Form(False)
 ):
     """Handle registration form submission (production)"""
     try:
@@ -208,6 +209,9 @@ async def register_post(
         
         if not full_name or len(full_name.strip()) < 2:
             raise ValueError("Full name must be at least 2 characters long")
+
+        if not terms:
+            raise ValueError("You must accept the Terms of Service")
         
         username = username.strip().lower()
         api = APIClient()
@@ -218,7 +222,9 @@ async def register_post(
                     "username": username,
                     "email": email,
                     "password": password,
+                    "confirm_password": confirm_password,
                     "full_name": full_name,
+                    "terms_accepted": terms,
                 },
             )
             # Check for API error
@@ -244,10 +250,11 @@ async def register_post(
                 "username": username,
                 "email": email,
                 "full_name": full_name,
+                "terms": terms,
                 "demo_mode": False,
-                "page_title": "Register - QuantumVestAI"
+                "page_title": "Register - QuantumVestAI",
             },
-            status_code=400
+            status_code=400,
         )
     except Exception as e:
         logger.error(f"Registration error: {str(e)}")
@@ -257,6 +264,7 @@ async def register_post(
                 "request": request,
                 "msg": "Registration failed due to a technical error. Please try again.",
                 "msg_type": "danger",
+                "terms": terms,
                 "demo_mode": False,
                 "page_title": "Register - QuantumVestAI"
             },

--- a/ai-stock-platform/ui/tests/test_routes/test_auth_routes.py
+++ b/ai-stock-platform/ui/tests/test_routes/test_auth_routes.py
@@ -113,7 +113,8 @@ def test_register_post_success(client, monkeypatch):
                 "email": "new@example.com",
                 "password": "Password123!",
                 "confirm_password": "Password123!",
-                "full_name": "Test User"
+                "full_name": "Test User",
+                "terms": "on"
             },
             follow_redirects=False
         )
@@ -126,8 +127,10 @@ def test_register_post_success(client, monkeypatch):
                 "username": "newuser",
                 "email": "new@example.com",
                 "password": "Password123!",
-                "full_name": "Test User"
-            }
+                "confirm_password": "Password123!",
+                "full_name": "Test User",
+                "terms_accepted": True,
+            },
         )
 
 def test_register_post_username_taken(client, monkeypatch):
@@ -142,13 +145,25 @@ def test_register_post_username_taken(client, monkeypatch):
                 "email": "new@example.com",
                 "password": "Password123!",
                 "confirm_password": "Password123!",
-                "full_name": "Test User"
+                "full_name": "Test User",
+                "terms": "on"
             },
             follow_redirects=False
         )
         # Should return 400 and render register page again
         assert response.status_code == 400
         assert "Username already taken" in response.text
+        mock_post.assert_called_once_with(
+            "/auth/register",
+            data={
+                "username": "existinguser",
+                "email": "new@example.com",
+                "password": "Password123!",
+                "confirm_password": "Password123!",
+                "full_name": "Test User",
+                "terms_accepted": True,
+            },
+        )
 
 def test_register_post_password_mismatch(client, monkeypatch):
     monkeypatch.setenv("API_BASE_URL", "http://testserver/api")
@@ -159,7 +174,8 @@ def test_register_post_password_mismatch(client, monkeypatch):
             "email": "new@example.com",
             "password": "Password123!",
             "confirm_password": "DifferentPassword123!",
-            "full_name": "Test User"
+            "full_name": "Test User",
+            "terms": "on"
         },
         follow_redirects=False
     )


### PR DESCRIPTION
## Summary
- enforce password/terms validation in backend registration logic
- pass confirm password & terms from UI and handle errors
- test registration flow with new fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError in test_order_management.py)*

------
https://chatgpt.com/codex/tasks/task_e_688147d6fb78832ab8551536cf46787e