### PR TITLE
Fix missing confirm password in register

### DIFF
--- a/ai-stock-platform/ui/main.py
+++ b/ai-stock-platform/ui/main.py
@@ -578,7 +578,9 @@ async def register_post(
                 "username": username,
                 "email": email,
                 "password": password,
+                "confirm_password": confirm_password,
                 "full_name": username,
+                "terms_accepted": terms,
             },
         )
 


### PR DESCRIPTION
## Summary
- include `confirm_password` and `terms_accepted` in the API request payload when registering from `ui/main.py`

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6881aafe730c832a9cf0e49a30c80a98