### PR TITLE
Add alias for ResourceNotFoundError

### DIFF
--- a/ai-stock-platform/api/core/exceptions.py
+++ b/ai-stock-platform/api/core/exceptions.py
@@ -50,6 +50,12 @@ class NotFoundError(HTTPException):
         )
 
 
+class ResourceNotFoundError(NotFoundError):
+    """Backward compatibility alias for ``NotFoundError``."""
+
+    pass
+
+
 class PermissionError(HTTPException):
     """Raised when user lacks sufficient permissions"""
     


### PR DESCRIPTION
## Summary
- add `ResourceNotFoundError` alias to keep compatibility with older imports

## Testing
- `pytest -q` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6881ac87e0ec832a8161a291a9cb3f7e