### PR TITLE
Fix role property error

### DIFF
--- a/ai-stock-platform/api/alembic/core/db_init.py
+++ b/ai-stock-platform/api/alembic/core/db_init.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 from core.config import settings
 from db.models.user import User
+from db.models.user_role import UserRole
+from db.models.role import Role
 from db.session import engine, get_db
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.exc import SQLAlchemyError
@@ -60,7 +62,13 @@ def verify_admin_exists():
     """Verify that at least one admin user exists."""
     try:
         db = next(get_db())
-        admin = db.query(User).filter(User.role == "admin").first()
+        admin = (
+            db.query(User)
+            .join(UserRole, UserRole.user_id == User.id)
+            .join(Role, Role.id == UserRole.role_id)
+            .filter(Role.name == "admin")
+            .first()
+        )
         db.close()
         
         if admin:

--- a/ai-stock-platform/api/core/db_init.py
+++ b/ai-stock-platform/api/core/db_init.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 from core.config import settings
 from db.models.user import User
+from db.models.user_role import UserRole
+from db.models.role import Role
 from db.session import engine, get_db
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.exc import SQLAlchemyError
@@ -60,7 +62,13 @@ def verify_admin_exists():
     """Verify that at least one admin user exists."""
     try:
         db = next(get_db())
-        admin = db.query(User).filter(User.role == "admin").first()
+        admin = (
+            db.query(User)
+            .join(UserRole, UserRole.user_id == User.id)
+            .join(Role, Role.id == UserRole.role_id)
+            .filter(Role.name == "admin")
+            .first()
+        )
         db.close()
         
         if admin:

--- a/ai-stock-platform/api/db/models/user.py
+++ b/ai-stock-platform/api/db/models/user.py
@@ -290,20 +290,21 @@ class User(Base):
         """Alias for is_admin (backward compatibility) - FIXED"""
         return self.is_admin
 
-    @hybrid_property
-    def role(self) -> str:
-        """
-        Legacy role property for backward compatibility - FIXED.
-        Returns 'admin' for admin users, 'free' for others.
-        """
-        # Direct database lookup instead of calling is_admin to avoid circular reference
-        if hasattr(self, 'user_roles') and self.user_roles:
-            for user_role in self.user_roles:
-                if hasattr(user_role, 'role') and user_role.role:
-                    if user_role.role.name == "admin":
-                        return "admin"
-            return "user"  # Has roles but not admin
-        return "free"  # No roles assigned
+    if not _has_role:
+        @property
+        def role(self) -> str:
+            """
+            Legacy role property for backward compatibility - FIXED.
+            Returns 'admin' for admin users, 'free' for others.
+            """
+            # Direct database lookup instead of calling is_admin to avoid circular reference
+            if hasattr(self, 'user_roles') and self.user_roles:
+                for user_role in self.user_roles:
+                    if hasattr(user_role, 'role') and user_role.role:
+                        if user_role.role.name == "admin":
+                            return "admin"
+                return "user"  # Has roles but not admin
+            return "free"  # No roles assigned
 
     @hybrid_property
     def permissions(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- fix indentation and change hybrid `role` property to a plain property when the database does not contain a role column
- update admin verification queries to join through `UserRole` and `Role`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'models.orders')*

------
https://chatgpt.com/codex/tasks/task_e_6881c39cbf90832abf9ad7592db37c7a