### PR TITLE
Fix role setter in User model

### DIFF
--- a/ai-stock-platform/api/db/models/user.py
+++ b/ai-stock-platform/api/db/models/user.py
@@ -304,7 +304,12 @@ class User(Base):
                         if user_role.role.name == "admin":
                             return "admin"
                 return "user"  # Has roles but not admin
-            return "free"  # No roles assigned
+            return getattr(self, "_role", "free")  # Fallback if no roles assigned
+
+        @role.setter
+        def role(self, value: str) -> None:
+            """Allow setting a role when no dedicated column exists."""
+            setattr(self, "_role", value)
 
     @hybrid_property
     def permissions(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- handle setting the legacy role property when no role column exists

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6881c8beab30832a8d7d2b62d171a02a