### PR TITLE
Fix registration attribute error

### DIFF
--- a/ai-stock-platform/api/db/models/stock.py
+++ b/ai-stock-platform/api/db/models/stock.py
@@ -116,7 +116,11 @@ class WatchList(Base, TimestampMixin):
     is_favorite: Mapped[bool] = Column(Boolean, default=False)
     
     # Relationships
-    user: Mapped["User"] = relationship("User", back_populates="watchlist_entries")
+    user: Mapped["User"] = relationship(
+        "User",
+        back_populates="watchlist_entries",
+        overlaps="watchlists"
+    )
     stock: Mapped["Stock"] = relationship("Stock", back_populates="watchlist_entries")
     
     def __repr__(self) -> str:

--- a/ai-stock-platform/api/db/models/user.py
+++ b/ai-stock-platform/api/db/models/user.py
@@ -222,12 +222,14 @@ class User(Base):
         back_populates="user",
         cascade="all, delete-orphan",
         lazy="select",
+        overlaps="user,watchlists",
     )
     watchlists = relationship(
         "Watchlist",
         back_populates="user",
         cascade="all, delete-orphan",
         lazy="select",
+        overlaps="user,watchlist_entries",
     )
     alerts = relationship(
         "Alert",
@@ -755,9 +757,9 @@ def validate_user_before_insert(mapper, connection, target):
         target.email = target.email.lower().strip()
         
     # Ensure names are properly formatted
-    if target.first_name:
+    if hasattr(target, "first_name") and target.first_name:
         target.first_name = target.first_name.strip()
-    if target.last_name:
+    if hasattr(target, "last_name") and target.last_name:
         target.last_name = target.last_name.strip()
     if target.display_name:
         target.display_name = target.display_name.strip()

--- a/ai-stock-platform/api/db/models/watchlist.py
+++ b/ai-stock-platform/api/db/models/watchlist.py
@@ -18,7 +18,11 @@ class Watchlist(Base, TimestampMixin):
     is_public = Column(Boolean, default=False)
 
     # Relationships
-    user = relationship("User", back_populates="watchlists")
+    user = relationship(
+        "User",
+        back_populates="watchlists",
+        overlaps="watchlist_entries"
+    )
     stocks = relationship(
         "WatchlistStock",
         back_populates="watchlist",


### PR DESCRIPTION
## Summary
- prevent AttributeError when `first_name` column is absent
- silence relationship overlap warnings on watchlist models

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6881cf8a6238832aa2326fd5fc562089