### PR TITLE
Fix login role access

### DIFF
--- a/ai-stock-platform/api/routers/auth.py
+++ b/ai-stock-platform/api/routers/auth.py
@@ -84,8 +84,11 @@ async def login(
     """Authenticate user and return token"""
     logger.info(f"Login attempt for user: {form_data.username}")
 
-    # Find user by username
+    # Find user by username and ensure related roles are loaded to avoid
+    # asynchronous lazy loading issues
     user = await User.get_by_username(db, form_data.username)
+    if user:
+        await db.refresh(user, attribute_names=["user_roles"])
 
     # Check if user exists and password is correct
     if not user or not verify_password(form_data.password, user.hashed_password):


### PR DESCRIPTION
## Summary
- refresh user roles in login handler to avoid async lazy-load errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services.api_client')*

------
https://chatgpt.com/codex/tasks/task_e_68827317fa80832a86844c159944544b