### PR TITLE
Fix overlap warnings for watchlist relationships

### DIFF
--- a/ai-stock-platform/api/db/models/stock.py
+++ b/ai-stock-platform/api/db/models/stock.py
@@ -119,7 +119,7 @@ class WatchList(Base, TimestampMixin):
     user: Mapped["User"] = relationship(
         "User",
         back_populates="watchlist_entries",
-        overlaps="watchlists"
+        overlaps="watchlists,user"
     )
     stock: Mapped["Stock"] = relationship("Stock", back_populates="watchlist_entries")
     

--- a/ai-stock-platform/api/db/models/watchlist.py
+++ b/ai-stock-platform/api/db/models/watchlist.py
@@ -21,7 +21,7 @@ class Watchlist(Base, TimestampMixin):
     user = relationship(
         "User",
         back_populates="watchlists",
-        overlaps="watchlist_entries"
+        overlaps="watchlist_entries,user"
     )
     stocks = relationship(
         "WatchlistStock",


### PR DESCRIPTION
## Summary
- tweak Watchlist and WatchList models to avoid duplicate mapping warnings

## Testing
- `pytest -q` *(fails: 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68827d698c70832aa8c29742938a84e2