### PR TITLE
Remove leftover demo text from templates

### DIFF
--- a/ai-stock-platform/ui/templates/login.html
+++ b/ai-stock-platform/ui/templates/login.html
@@ -89,14 +89,6 @@
             </div>
         </form>
         
-        <!-- Demo credentials info -->
-        <div class="alert alert-info mt-3" role="alert">
-            <small>
-                <strong>Demo credentials:</strong><br>
-                Username: <code>demo</code><br>
-                Password: <code>demo</code>
-            </small>
-        </div>
         </div>
         
         <div class="auth-footer text-center">

--- a/ai-stock-platform/ui/templates/news/article.html
+++ b/ai-stock-platform/ui/templates/news/article.html
@@ -34,10 +34,7 @@
                     <div class="article-content">
                         <p>{{ data.article.summary }}</p>
                         
-                        <!-- Demo article content -->
-                        <p>This is a demo article showcasing the QuantumVestAI news functionality. In a real implementation, this would contain the full article content retrieved from the news API.</p>
                         
-                        <p>Key highlights from this article include market trends, financial insights, and relevant analysis for investors using the QuantumVestAI platform.</p>
                         
                         {% if data.sentiment.status == 'available' %}
                         <!-- Sentiment Analysis -->


### PR DESCRIPTION
## Summary
- delete demo login credentials from the login page
- drop placeholder demo article text from the news article template

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError in api tests)*

------
https://chatgpt.com/codex/tasks/task_e_68829be546dc832abedec9e1bb8e88d1