### PR TITLE
Update dashboard colors and ensure API coverage

### DIFF
--- a/ai-stock-platform/ui/src/contexts/ApiContext.tsx
+++ b/ai-stock-platform/ui/src/contexts/ApiContext.tsx
@@ -26,6 +26,18 @@ interface ApiContextType {
   
   // Backtest methods
   runBacktest: typeof apiService.runBacktest;
+
+  // Preference methods
+  getUserPreferences: typeof apiService.getUserPreferences;
+  updateUserPreferences: typeof apiService.updateUserPreferences;
+  updateTheme: typeof apiService.updateTheme;
+  updateNotificationSettings: typeof apiService.updateNotificationSettings;
+
+  // AI methods
+  chatWithAI: typeof apiService.chatWithAI;
+  analyzeText: typeof apiService.analyzeText;
+  generateStrategy: typeof apiService.generateStrategy;
+  getPortfolioSuggestion: typeof apiService.getPortfolioSuggestion;
 }
 
 // Create context with default values
@@ -37,6 +49,14 @@ const ApiContext = createContext<ApiContextType>({
   getStockSentiment: apiService.getStockSentiment.bind(apiService),
   getMarketOverview: apiService.getMarketOverview.bind(apiService),
   runBacktest: apiService.runBacktest.bind(apiService),
+  getUserPreferences: apiService.getUserPreferences.bind(apiService),
+  updateUserPreferences: apiService.updateUserPreferences.bind(apiService),
+  updateTheme: apiService.updateTheme.bind(apiService),
+  updateNotificationSettings: apiService.updateNotificationSettings.bind(apiService),
+  chatWithAI: apiService.chatWithAI.bind(apiService),
+  analyzeText: apiService.analyzeText.bind(apiService),
+  generateStrategy: apiService.generateStrategy.bind(apiService),
+  getPortfolioSuggestion: apiService.getPortfolioSuggestion.bind(apiService),
 });
 
 // Props interface for the provider
@@ -55,6 +75,14 @@ export const ApiProvider: React.FC<ApiProviderProps> = ({ children }) => {
     getStockSentiment: apiService.getStockSentiment.bind(apiService),
     getMarketOverview: apiService.getMarketOverview.bind(apiService),
     runBacktest: apiService.runBacktest.bind(apiService),
+    getUserPreferences: apiService.getUserPreferences.bind(apiService),
+    updateUserPreferences: apiService.updateUserPreferences.bind(apiService),
+    updateTheme: apiService.updateTheme.bind(apiService),
+    updateNotificationSettings: apiService.updateNotificationSettings.bind(apiService),
+    chatWithAI: apiService.chatWithAI.bind(apiService),
+    analyzeText: apiService.analyzeText.bind(apiService),
+    generateStrategy: apiService.generateStrategy.bind(apiService),
+    getPortfolioSuggestion: apiService.getPortfolioSuggestion.bind(apiService),
   };
 
   return <ApiContext.Provider value={value}>{children}</ApiContext.Provider>;

--- a/ai-stock-platform/ui/src/services/api-service.ts
+++ b/ai-stock-platform/ui/src/services/api-service.ts
@@ -416,6 +416,71 @@ class ApiService {
     return response.data.data;
   }
 
+  // Preference methods
+  async getUserPreferences() {
+    const response = await apiClient.get<StandardResponse<any>>(
+      API_ENDPOINTS.PREFERENCES.GET
+    );
+    return response.data.data;
+  }
+
+  async updateUserPreferences(prefs: any) {
+    const response = await apiClient.put<StandardResponse<any>>(
+      API_ENDPOINTS.PREFERENCES.UPDATE,
+      prefs
+    );
+    return response.data.data;
+  }
+
+  async updateTheme(theme: string) {
+    const response = await apiClient.put<StandardResponse<any>>(
+      API_ENDPOINTS.PREFERENCES.THEME,
+      { theme }
+    );
+    return response.data.data;
+  }
+
+  async updateNotificationSettings(settings: any) {
+    const response = await apiClient.put<StandardResponse<any>>(
+      API_ENDPOINTS.PREFERENCES.NOTIFICATIONS,
+      settings
+    );
+    return response.data.data;
+  }
+
+  // AI methods
+  async chatWithAI(message: string) {
+    const response = await apiClient.post<StandardResponse<any>>(
+      API_ENDPOINTS.AI.CHAT,
+      { message }
+    );
+    return response.data.data;
+  }
+
+  async analyzeText(text: string) {
+    const response = await apiClient.post<StandardResponse<any>>(
+      API_ENDPOINTS.AI.ANALYZE,
+      { text }
+    );
+    return response.data.data;
+  }
+
+  async generateStrategy(data: any) {
+    const response = await apiClient.post<StandardResponse<any>>(
+      API_ENDPOINTS.AI.STRATEGY,
+      data
+    );
+    return response.data.data;
+  }
+
+  async getPortfolioSuggestion(data: any) {
+    const response = await apiClient.post<StandardResponse<any>>(
+      API_ENDPOINTS.AI.PORTFOLIO_SUGGESTION,
+      data
+    );
+    return response.data.data;
+  }
+
   // Performance monitoring
   getApiPerformanceMetrics() {
     return {

--- a/ai-stock-platform/ui/static/css/dashboard-enhancements.css
+++ b/ai-stock-platform/ui/static/css/dashboard-enhancements.css
@@ -33,8 +33,8 @@
 }
 
 .chart-controls .btn.active {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    border-color: #667eea;
+    background: linear-gradient(135deg, #1fd1f9 0%, #b621fe 100%);
+    border-color: #1fd1f9;
     color: white;
 }
 
@@ -203,7 +203,7 @@
 
 .quantum-badge {
     font-size: 1.2rem;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #1fd1f9 0%, #b621fe 100%);
     color: white;
     border-radius: 50%;
     width: 40px;

--- a/ai-stock-platform/ui/static/css/quantum-enhancements.css
+++ b/ai-stock-platform/ui/static/css/quantum-enhancements.css
@@ -8,7 +8,7 @@
 /* Enhanced CSS Custom Properties for Global Recognition */
 :root {
   /* Enhanced Quantum Color Palette */
-  --quantum-primary: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  --quantum-primary: linear-gradient(135deg, #1fd1f9 0%, #b621fe 100%);
   --quantum-secondary: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
   --quantum-accent: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
   --quantum-success: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);

--- a/tests/test_api_usage.py
+++ b/tests/test_api_usage.py
@@ -1,0 +1,36 @@
+import re
+from pathlib import Path
+
+CONSTANTS_PATH = Path('ai-stock-platform/ui/src/config/constants.ts')
+SERVICE_PATH = Path('ai-stock-platform/ui/src/services/api-service.ts')
+
+
+def extract_endpoints():
+    endpoints = []
+    text = CONSTANTS_PATH.read_text()
+    # Extract API_ENDPOINTS block
+    m = re.search(r"API_ENDPOINTS\s*=\s*{(.*?)};", text, re.S)
+    if not m:
+        return endpoints
+    block = m.group(1)
+    current_category = None
+    for line in block.splitlines():
+        line = line.strip()
+        cat_match = re.match(r"([A-Z_]+):\s*{", line)
+        if cat_match:
+            current_category = cat_match.group(1)
+            continue
+        if line.startswith('},') or line == '},':
+            current_category = None
+            continue
+        item_match = re.match(r"([A-Z_]+):", line)
+        if current_category and item_match:
+            endpoints.append(f"{current_category}.{item_match.group(1)}")
+    return endpoints
+
+
+def test_all_endpoints_used():
+    endpoints = extract_endpoints()
+    service_code = SERVICE_PATH.read_text()
+    unused = [e for e in endpoints if f"API_ENDPOINTS.{e}" not in service_code]
+    assert not unused, f"Unused endpoints: {unused}"


### PR DESCRIPTION
## Summary
- refresh dashboard gradients with new teal and purple palette
- expose preference and AI endpoints through `api-service` and `ApiContext`
- add regression test verifying all defined API endpoints are called

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services.api_client')*

------
https://chatgpt.com/codex/tasks/task_e_68829da2990c832a93b98c37c07be4ea