### PR TITLE
Enable live market data

### DIFF
--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -70,11 +70,37 @@ class TrendingStocksService:
         if not AIOHTTP_AVAILABLE:
             raise RuntimeError("aiohttp is required for real-time data access")
         
-        # Default trending symbols to fetch
-        self.trending_symbols = [
-            "AAPL", "MSFT", "AMZN", "GOOGL", "NVDA", 
-            "TSLA", "META", "NFLX", "CRM", "ADBE"
+        # Placeholder list used until live data is fetched
+        self.trending_symbols: List[str] = [
+            "AAPL",
+            "MSFT",
+            "AMZN",
+            "GOOGL",
+            "NVDA",
+            "TSLA",
+            "META",
+            "NFLX",
+            "CRM",
+            "ADBE",
         ]
+
+    async def _fetch_yahoo_trending_symbols(self) -> List[str]:
+        """Fetch trending tickers from Yahoo Finance."""
+        url = "https://query1.finance.yahoo.com/v1/finance/trending/US"
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, timeout=10) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        quotes = (
+                            data.get("finance", {})
+                            .get("result", [{}])[0]
+                            .get("quotes", [])
+                        )
+                        return [q.get("symbol") for q in quotes if q.get("symbol")]
+        except Exception as exc:
+            logger.warning(f"Failed to fetch Yahoo trending symbols: {exc}")
+        return []
     
     async def get_trending_stocks(self, page: int = 1, limit: int = 10) -> Dict[str, Any]:
         """
@@ -92,9 +118,26 @@ class TrendingStocksService:
             if self._is_cache_valid():
                 logger.info("Returning trending stocks from cache")
                 return self._get_paginated_data(self._cache["stocks"], page, limit)
-            
+
             # Fetch fresh data
             logger.info("Fetching fresh trending stocks data")
+            if not self.use_mock and not self.trending_symbols:
+                self.trending_symbols = await self._fetch_yahoo_trending_symbols()
+                if not self.trending_symbols:
+                    logger.warning("No trending symbols from Yahoo; using defaults")
+                    self.trending_symbols = [
+                        "AAPL",
+                        "MSFT",
+                        "AMZN",
+                        "GOOGL",
+                        "NVDA",
+                        "TSLA",
+                        "META",
+                        "NFLX",
+                        "CRM",
+                        "ADBE",
+                    ]
+
             stocks_data = await self._fetch_trending_stocks()
             
             # Update cache

--- a/ai-stock-platform/api/social/multi_source_sentiment.py
+++ b/ai-stock-platform/api/social/multi_source_sentiment.py
@@ -190,20 +190,32 @@ class MultiSourceSentimentAnalyzer:
     
     async def _fetch_yahoo_news(self, symbol: str, days: int) -> List[Dict[str, Any]]:
         """Fetch news from Yahoo Finance"""
+        url = "https://query1.finance.yahoo.com/v1/finance/search"
+        params = {"q": symbol, "newsCount": 5}
         try:
-            # Simulate Yahoo Finance news API call
-            # In a real implementation, this would use actual Yahoo Finance API
-            return [
-                {
-                    "title": f"{symbol} shows strong performance",
-                    "summary": "Stock continues to outperform market expectations",
-                    "timestamp": datetime.now() - timedelta(hours=i)
-                }
-                for i in range(5)
-            ]
+            async with self.session.get(url, params=params, timeout=10) as resp:
+                if resp.status == 200:
+                    data = await resp.json()
+                    articles = data.get("news", [])
+                    parsed = []
+                    for art in articles:
+                        ts = art.get("providerPublishTime")
+                        ts_dt = (
+                            datetime.fromtimestamp(ts)
+                            if isinstance(ts, (int, float))
+                            else datetime.now()
+                        )
+                        parsed.append(
+                            {
+                                "title": art.get("title"),
+                                "summary": art.get("summary", ""),
+                                "timestamp": ts_dt,
+                            }
+                        )
+                    return parsed
         except Exception as e:
             logger.error(f"Yahoo news fetch failed: {e}")
-            return []
+        return []
     
     async def _fetch_reddit_data(self, symbol: str, days: int) -> List[Dict[str, Any]]:
         """Fetch Reddit posts about the stock"""

--- a/ai-stock-platform/ui/controllers/stock_controller.py
+++ b/ai-stock-platform/ui/controllers/stock_controller.py
@@ -80,9 +80,11 @@ async def stock_search(
                             logger.error(f"Stock search API error: Status {response.status}")
                             
             except Exception as e:
-                # API not available, fall back to demo mode
-                logger.info(f"API not available, using demo mode for search: {q}")
-                search_results = _get_demo_search_results(q, sector, limit)
+                # API not available, fall back to Yahoo Finance search
+                logger.info(
+                    f"API not available, fetching live data from Yahoo Finance: {q}"
+                )
+                search_results = await _get_live_search_results(q, limit)
         
         # Process results to ensure proper data structure
         if search_results and isinstance(search_results, list):
@@ -126,42 +128,29 @@ async def stock_search(
             }
         )
 
-def _get_demo_search_results(query: str, sector: str = None, limit: int = 10):
-    """Generate demo search results when API is not available"""
-    # Demo stock data
-    demo_stocks = [
-        {"symbol": "AAPL", "name": "Apple Inc.", "sector": "Technology", "price": 175.43, "change": 2.15, "change_percent": 1.24},
-        {"symbol": "MSFT", "name": "Microsoft Corporation", "sector": "Technology", "price": 338.11, "change": -1.23, "change_percent": -0.36},
-        {"symbol": "GOOGL", "name": "Alphabet Inc.", "sector": "Technology", "price": 129.40, "change": 0.85, "change_percent": 0.66},
-        {"symbol": "AMZN", "name": "Amazon.com Inc.", "sector": "Consumer", "price": 131.93, "change": -0.47, "change_percent": -0.36},
-        {"symbol": "TSLA", "name": "Tesla Inc.", "sector": "Consumer", "price": 248.50, "change": 5.23, "change_percent": 2.15},
-        {"symbol": "META", "name": "Meta Platforms Inc.", "sector": "Technology", "price": 308.56, "change": 1.34, "change_percent": 0.44},
-        {"symbol": "NVDA", "name": "NVIDIA Corporation", "sector": "Technology", "price": 875.28, "change": 12.45, "change_percent": 1.44},
-        {"symbol": "JPM", "name": "JPMorgan Chase & Co.", "sector": "Financial", "price": 161.52, "change": -0.78, "change_percent": -0.48},
-        {"symbol": "JNJ", "name": "Johnson & Johnson", "sector": "Healthcare", "price": 155.99, "change": 0.23, "change_percent": 0.15},
-        {"symbol": "V", "name": "Visa Inc.", "sector": "Financial", "price": 237.08, "change": 1.87, "change_percent": 0.79},
-        {"symbol": "UNH", "name": "UnitedHealth Group Inc.", "sector": "Healthcare", "price": 493.22, "change": -2.15, "change_percent": -0.43},
-        {"symbol": "HD", "name": "The Home Depot Inc.", "sector": "Consumer", "price": 327.44, "change": 0.92, "change_percent": 0.28},
-        {"symbol": "PG", "name": "Procter & Gamble Co.", "sector": "Consumer", "price": 143.18, "change": -0.34, "change_percent": -0.24},
-        {"symbol": "XOM", "name": "Exxon Mobil Corporation", "sector": "Energy", "price": 108.87, "change": 1.42, "change_percent": 1.32},
-        {"symbol": "CVX", "name": "Chevron Corporation", "sector": "Energy", "price": 162.34, "change": 0.67, "change_percent": 0.41},
-    ]
-    
-    # Filter by query (symbol or name)
-    query_lower = query.lower()
-    filtered_stocks = []
-    
-    for stock in demo_stocks:
-        if (query_lower in stock["symbol"].lower() or 
-            query_lower in stock["name"].lower()):
-            filtered_stocks.append(stock)
-    
-    # Filter by sector if specified
-    if sector:
-        filtered_stocks = [s for s in filtered_stocks if s["sector"] == sector]
-    
-    # Limit results
-    return filtered_stocks[:limit]
+async def _get_live_search_results(query: str, limit: int = 10) -> list:
+    """Fetch search results from Yahoo Finance."""
+    url = "https://query1.finance.yahoo.com/v1/finance/search"
+    params = {"q": query, "quotesCount": limit}
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, params=params, timeout=5) as resp:
+                if resp.status == 200:
+                    data = await resp.json()
+                    results = []
+                    for quote in data.get("quotes", [])[:limit]:
+                        results.append({
+                            "symbol": quote.get("symbol"),
+                            "name": quote.get("shortname") or quote.get("longname"),
+                            "sector": quote.get("sector"),
+                            "price": quote.get("regularMarketPrice"),
+                            "change": quote.get("regularMarketChange"),
+                            "change_percent": quote.get("regularMarketChangePercent"),
+                        })
+                    return results
+    except Exception as exc:
+        logger.error(f"Yahoo Finance search failed: {exc}")
+    return []
 
 @router.get("/stock/{ticker}", response_class=HTMLResponse)
 async def stock_detail(


### PR DESCRIPTION
## Summary
- pull trending symbols from Yahoo Finance
- fetch Yahoo Finance news instead of demo stories
- use Yahoo search as the fallback data source

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'models.orders')*

------
https://chatgpt.com/codex/tasks/task_e_68829e5f91a8832aa4270fb6a869099b