### PR TITLE
Fix PYTHONPATH variable in UI Dockerfile

### DIFF
--- a/ai-stock-platform/ui/Dockerfile
+++ b/ai-stock-platform/ui/Dockerfile
@@ -95,7 +95,7 @@ ENV PORT=3000 \
     APP_VERSION=1.5.2 \
     LAST_UPDATED="2025-06-20 03:25:47" \
     UPDATED_BY="daparthi001" \
-    PYTHONPATH=/app/core:/app/ai-stock-platform:/app/ai-stock-platform/ui:/app/ui:/app/api:/app:$PYTHONPATH
+    PYTHONPATH=/app/core:/app/ai-stock-platform:/app/ai-stock-platform/ui:/app/ui:/app/api:/app
 
 # Expose port
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- fix PYTHONPATH reference in UI Dockerfile to avoid undefined variable warnings

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'models.orders')*

------
https://chatgpt.com/codex/tasks/task_e_6882a17b93c4832a8d858bcc63acf5cc