### PR TITLE
Remove demo data from UI

### DIFF
--- a/ai-stock-platform/ui/controllers/dashboard_controller.py
+++ b/ai-stock-platform/ui/controllers/dashboard_controller.py
@@ -12,46 +12,47 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Union
 
 import httpx
-from fastapi import (APIRouter, Depends, HTTPException, Query, Request,
-                     Response, status)
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 API_URL = "http://quantumvestai-dev-api:8000"
 # Auth dependencies removed as per requirements
 
+
 # Define mock metrics classes that do nothing
 class NoOpMetric:
     """A no-operation metric that implements the basic prometheus interface"""
-    
+
     def __init__(self, name=None, documentation=None, labelnames=None):
         self.name = name
         self.documentation = documentation
         self.labelnames = labelnames or []
-    
+
     def labels(self, **kwargs):
         return self
-    
+
     def inc(self, amount=1):
         pass
-    
+
     def observe(self, amount):
         pass
-    
+
     def set(self, value):
         pass
+
 
 # Create mock metrics
 http_requests_total = NoOpMetric(
     name="http_requests_total",
     documentation="Total number of HTTP requests",
-    labelnames=["method", "endpoint", "status"]
+    labelnames=["method", "endpoint", "status"],
 )
 
 http_request_duration_seconds = NoOpMetric(
     name="http_request_duration_seconds",
     documentation="HTTP request duration in seconds",
-    labelnames=["method", "endpoint"]
+    labelnames=["method", "endpoint"],
 )
 
 # Set up logging
@@ -71,18 +72,19 @@ CACHE_ENABLED = os.getenv("CACHE_ENABLED", "true").lower() == "true"
 CACHE_TTL = int(os.getenv("CACHE_TTL", "300"))  # Default: 5 minutes
 cache_store = {}
 
+
 def get_cached_data(key: str) -> Union[Dict[str, Any], None]:
     """Get data from cache if it exists and is not expired.
-    
+
     Args:
         key: Cache key
-        
+
     Returns:
         Cached data or None if not found or expired
     """
     if not CACHE_ENABLED:
         return None
-        
+
     if key in cache_store:
         entry = cache_store[key]
         if entry["expires"] > time.time():
@@ -91,13 +93,14 @@ def get_cached_data(key: str) -> Union[Dict[str, Any], None]:
         else:
             logger.debug(f"Cache expired for {key}")
             del cache_store[key]
-    
+
     logger.debug(f"Cache miss for {key}")
     return None
 
+
 def set_cached_data(key: str, data: Dict[str, Any], ttl: int = CACHE_TTL) -> None:
     """Store data in cache with expiration time.
-    
+
     Args:
         key: Cache key
         data: Data to cache
@@ -105,139 +108,110 @@ def set_cached_data(key: str, data: Dict[str, Any], ttl: int = CACHE_TTL) -> Non
     """
     if not CACHE_ENABLED:
         return
-        
+
     expires = time.time() + ttl
-    cache_store[key] = {
-        "data": data,
-        "expires": expires
-    }
+    cache_store[key] = {"data": data, "expires": expires}
     logger.debug(f"Cached data for {key}, expires in {ttl} seconds")
+
 
 @router.get("/dashboard", response_class=HTMLResponse)
 async def dashboard(
-    request: Request, 
+    request: Request,
     response: Response,
     period: Optional[str] = Query("month", description="Time period for data analysis"),
-    refresh: Optional[bool] = Query(False, description="Force refresh data from API")
+    refresh: Optional[bool] = Query(False, description="Force refresh data from API"),
 ):
     """
     Dashboard main view showing portfolio performance and analytics.
-    
+
     Args:
         request: FastAPI request object
         period: Time period for analysis (day, week, month, year, all)
         refresh: Whether to force refresh data from API
-        
+
     Returns:
         HTMLResponse: Rendered dashboard template
     """
     # Check if user is authenticated (get from session/cookies/headers)
-    user = getattr(request.state, 'user', None)
+    user = getattr(request.state, "user", None)
     if user is None:
-        # For now, allow anonymous access with demo data
-        user = {"username": "demo_user", "token": None}
-    
+        user = {"username": "anonymous", "token": None}
+
     try:
         # Start timing for metrics
         start_time = time.time()
-        
+
         # Record metric
         http_requests_total.labels(
-            method="GET", 
-            endpoint="/dashboard", 
-            status=200
+            method="GET", endpoint="/dashboard", status=200
         ).inc()
-        
+
         # Create cache key based on user and period
         # Use safe username access with default value
-        username = user.get('username', 'anonymous')
+        username = user.get("username", "anonymous")
         cache_key = f"dashboard_{username}_{period}"
-        
+
         # Try to get data from cache unless refresh is requested
         dashboard_data = None if refresh else get_cached_data(cache_key)
-        
+
         if dashboard_data is None:
             # Check if app.state has settings attribute
-            api_url_base = getattr(request.app.state, 'settings', {}).get('API_URL', os.getenv('API_URL', 'http://quantumvestai-dev-api:8000'))
-            
+            api_url_base = getattr(request.app.state, "settings", {}).get(
+                "API_URL", os.getenv("API_URL", "http://quantumvestai-dev-api:8000")
+            )
+
             try:
                 # Get portfolio data from API using centralized HTTP client
                 from core.http_client import safe_get_json
-                
-                auth_token = user.get('token')
+
+                auth_token = user.get("token")
                 portfolio_data = await safe_get_json(
                     url=f"{api_url_base}/api/portfolio/summary",
                     params={"period": period},
-                    auth_token=auth_token
+                    auth_token=auth_token,
                 )
-                
+
                 if portfolio_data is None:
                     logger.error("Failed to fetch portfolio data from API")
                     raise HTTPException(
-                        status_code=503,
-                        detail="Error fetching portfolio data"
+                        status_code=503, detail="Error fetching portfolio data"
                     )
-                
+
                 # Get market overview
                 market_data = await safe_get_json(
-                    url=f"{api_url_base}/api/market/overview",
-                    auth_token=auth_token
+                    url=f"{api_url_base}/api/market/overview", auth_token=auth_token
                 )
-                
+
                 if market_data is None:
                     logger.warning("Market data unavailable")
                     market_data = {"status": "unavailable"}
-                
+
                 # Get recent transactions
                 transactions_data = await safe_get_json(
                     url=f"{api_url_base}/api/transactions/recent",
                     params={"limit": 5},
-                    auth_token=auth_token
+                    auth_token=auth_token,
                 )
-                
+
                 if transactions_data is None:
                     logger.warning("Transactions data unavailable")
                     transactions = []
                 else:
                     transactions = transactions_data.get("transactions", [])
-                
+
             except Exception as e:
                 logger.error(f"API request error: {str(e)}")
-                # Use fallback data
-                portfolio_data = {
-                    "value": 125350.75,
-                    "daily_change": 2850.25,
-                    "daily_change_percent": 2.34,
-                    "total_return": 25350.75,
-                    "total_return_percent": 25.35,
-                    "holdings": [
-                        {"symbol": "AAPL", "name": "Apple Inc.", "value": 45350.25, "change_percent": 1.5},
-                        {"symbol": "MSFT", "name": "Microsoft Corp.", "value": 38250.50, "change_percent": 0.8},
-                        {"symbol": "GOOG", "name": "Alphabet Inc.", "value": 41750.00, "change_percent": -0.3}
-                    ]
-                }
-                
-                market_data = {
-                    "status": "fallback",
-                    "indices": [
-                        {"name": "S&P 500", "value": 4752.75, "change_percent": 0.8},
-                        {"name": "NASDAQ", "value": 16234.50, "change_percent": 1.2},
-                        {"name": "DOW", "value": 35750.25, "change_percent": 0.5}
-                    ]
-                }
-                
-                transactions = [
-                    {"date": "2025-06-20", "type": "BUY", "symbol": "AAPL", "shares": 10, "price": 178.50, "total": 1785.00},
-                    {"date": "2025-06-19", "type": "SELL", "symbol": "MSFT", "shares": 5, "price": 360.25, "total": 1801.25}
-                ]
-            
+                raise HTTPException(
+                    status_code=503, detail="Unable to load dashboard data"
+                )
+
             # Combine all data
             dashboard_data = {
                 "portfolio": portfolio_data,
                 "market": market_data,
-                "transactions": transactions
+                "transactions": transactions,
             }
-            
+
             # Cache the dashboard data
             set_cached_data(cache_key, dashboard_data)
         else:
@@ -245,7 +219,7 @@ async def dashboard(
             portfolio_data = dashboard_data["portfolio"]
             market_data = dashboard_data["market"]
             transactions = dashboard_data["transactions"]
-        
+
         # Combine data for template
         context = {
             "request": request,
@@ -260,46 +234,53 @@ async def dashboard(
                 {"value": "week", "label": "This Week"},
                 {"value": "month", "label": "This Month"},
                 {"value": "year", "label": "This Year"},
-                {"value": "all", "label": "All Time"}
+                {"value": "all", "label": "All Time"},
             ],
             "last_updated": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC"),
             "is_cached": not refresh and dashboard_data is not None,
             # Ensure template filters are available directly in context
-            "get_asset_url": lambda path, version=None: f"/static/{path}?v={version or os.environ.get('APP_VERSION', 'v1.5.2')}&t={datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+            "get_asset_url": lambda path, version=None: f"/static/{path}?v={version or os.environ.get('APP_VERSION', 'v1.5.2')}&t={datetime.utcnow().strftime('%Y%m%d%H%M%S')}",
         }
-        
+
         # Record timing for metrics
         duration = time.time() - start_time
         http_request_duration_seconds.labels(
-            method="GET", 
-            endpoint="/dashboard"
+            method="GET", endpoint="/dashboard"
         ).observe(duration)
-        
+
         # Get correct templates object - check if app.state.templates exists
-        templates_obj = getattr(request.app.state, 'templates', templates)
-        
+        templates_obj = getattr(request.app.state, "templates", templates)
+
         # Ensure template filters are registered - with fallback implementations
         try:
             from ui.utils import template_filters
+
             template_filters.register_filters(request.app)
         except ImportError:
-            logger.warning("Could not import template_filters in dashboard - adding fallback filters")
+            logger.warning(
+                "Could not import template_filters in dashboard - adding fallback filters"
+            )
             # Add critical fallback filters directly to ensure dashboard works
-            if hasattr(request.app.state, 'templates') and hasattr(request.app.state.templates, 'env'):
+            if hasattr(request.app.state, "templates") and hasattr(
+                request.app.state.templates, "env"
+            ):
                 env = request.app.state.templates.env
-                
+
                 # Ensure critical filters exist
-                if 'format_currency' not in env.filters:
-                    def format_currency(value, symbol='$'):
+                if "format_currency" not in env.filters:
+
+                    def format_currency(value, symbol="$"):
                         if value is None:
                             return f"{symbol}0.00"
                         try:
                             return f"{symbol}{float(value):,.2f}"
                         except (ValueError, TypeError):
                             return f"{symbol}0.00"
-                    env.filters['format_currency'] = format_currency
-                
-                if 'format_percentage' not in env.filters:
+
+                    env.filters["format_currency"] = format_currency
+
+                if "format_percentage" not in env.filters:
+
                     def format_percentage(value, precision=2):
                         if value is None:
                             return f"0.{precision * '0'}%"
@@ -307,142 +288,123 @@ async def dashboard(
                             return f"{float(value) * 100:.{precision}f}%"
                         except (ValueError, TypeError):
                             return f"0.{precision * '0'}%"
-                    env.filters['format_percentage'] = format_percentage
-                    
+
+                    env.filters["format_percentage"] = format_percentage
+
                 logger.info("Added fallback template filters for dashboard")
-        
+
         return templates_obj.TemplateResponse("dashboard/index.html", context)
-    
+
     except httpx.RequestError as e:
         logger.error(f"Request error: {str(e)}")
-        
+
         # Get correct templates object
-        templates_obj = getattr(request.app.state, 'templates', templates)
-        
+        templates_obj = getattr(request.app.state, "templates", templates)
+
         # Add get_asset_url to context directly
         def get_asset_url(path, version=None):
             if not version:
-                version = os.environ.get('APP_VERSION', 'v1.5.2')
-            timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
+                version = os.environ.get("APP_VERSION", "v1.5.2")
+            timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
             return f"/static/{path}?v={version}&t={timestamp}"
-        
+
         return templates_obj.TemplateResponse(
-            "error.html", 
+            "error.html",
             {
                 "request": request,
                 "user": None,
                 "message": "Service temporarily unavailable. Please try again later.",
                 "error_code": "API_CONN_ERR",
-                "get_asset_url": get_asset_url  # Add function directly to context
+                "get_asset_url": get_asset_url,  # Add function directly to context
             },
-            status_code=503  # Changed from default to indicate service unavailable
+            status_code=503,  # Changed from default to indicate service unavailable
         )
     except HTTPException as e:
         # Re-raise HTTP exceptions
         raise e
     except Exception as e:
         logger.exception(f"Unexpected error: {str(e)}")
-        
+
         # Get correct templates object
-        templates_obj = getattr(request.app.state, 'templates', templates)
-        
+        templates_obj = getattr(request.app.state, "templates", templates)
+
         # Add get_asset_url to context directly
         def get_asset_url(path, version=None):
             if not version:
-                version = os.environ.get('APP_VERSION', 'v1.5.2')
-            timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
+                version = os.environ.get("APP_VERSION", "v1.5.2")
+            timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
             return f"/static/{path}?v={version}&t={timestamp}"
-        
+
         return templates_obj.TemplateResponse(
-            "error.html", 
+            "error.html",
             {
                 "request": request,
                 "user": None,
                 "message": "An unexpected error occurred while loading the dashboard.",
                 "error_code": "DASHBOARD_ERR",
-                "get_asset_url": get_asset_url  # Add function directly to context
-            }
+                "get_asset_url": get_asset_url,  # Add function directly to context
+            },
         )
+
 
 @router.get("/api/dashboard/data", response_model=Dict[str, Any])
 async def dashboard_data(
     request: Request,
     period: Optional[str] = Query("month"),
-    refresh: Optional[bool] = Query(False)
+    refresh: Optional[bool] = Query(False),
 ):
     """
     API endpoint to get dashboard data for the frontend.
     Used for AJAX requests to update the dashboard dynamically.
-    
+
     Args:
         request: FastAPI request object
         period: Time period for analysis
         refresh: Whether to force refresh data from API
-        
+
     Returns:
         Dict[str, Any]: Dashboard data in JSON format
     """
     try:
         # Demo mode - return mock data
-        mock_data = {
-            "portfolio_value": 50000.00,
-            "daily_change": 2.5,
-            "daily_change_percent": 0.05,
-            "active_positions": 5,
-            "total_return": 15.3,
-            "period": period,
-            "last_updated": datetime.now().isoformat()
-        }
-        return mock_data
+        raise HTTPException(
+            status_code=503, detail="Dashboard data endpoint not available"
+        )
     except Exception as e:
         logger.exception(f"Dashboard data error: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error retrieving dashboard data"
+            detail="Error retrieving dashboard data",
         )
+
 
 @router.get("/api/dashboard/insights", response_model=Dict[str, Any])
 async def dashboard_insights():
     """
     API endpoint to get AI-generated insights for the dashboard.
-    
+
     Returns:
         Dict[str, Any]: AI insights in JSON format
     """
     try:
         # Demo mode - return mock insights
-        mock_insights = {
-            "market_sentiment": "positive",
-            "recommended_actions": [
-                "Consider increasing tech allocation",
-                "Monitor dividend yields",
-                "Review portfolio diversification"
-            ],
-            "key_insights": [
-                "Market showing upward trend",
-                "Tech sector outperforming",
-                "Low volatility environment"
-            ],
-            "generated_at": datetime.now().isoformat()
-        }
-        return mock_insights
+        raise HTTPException(status_code=503, detail="Insights endpoint not available")
     except Exception as e:
         logger.exception(f"Insights error: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error retrieving AI insights"
+            detail="Error retrieving AI insights",
         )
 
+
 @router.get("/admin/dashboard", response_class=HTMLResponse)
-async def admin_dashboard(
-    request: Request
-):
+async def admin_dashboard(request: Request):
     """
     Admin dashboard view showing system metrics and user statistics.
-    
+
     Args:
         request: FastAPI request object
-        
+
     Returns:
         HTMLResponse: Rendered admin dashboard template
     """
@@ -454,19 +416,19 @@ async def admin_dashboard(
             "user_stats": {
                 "total_users": 150,
                 "active_users": 45,
-                "new_registrations": 12
+                "new_registrations": 12,
             },
             "system_stats": {
                 "uptime": "99.9%",
                 "api_calls": 15420,
-                "avg_response_time": "245ms"
-            }
+                "avg_response_time": "245ms",
+            },
         }
-        
+
         # Get correct templates object
-        templates_obj = getattr(request.app.state, 'templates', templates)
+        templates_obj = getattr(request.app.state, "templates", templates)
         return templates_obj.TemplateResponse("admin/dashboard.html", context)
-        
+
     except HTTPException:
         # Re-raise HTTP exceptions (like 403 from validate_admin_access)
         raise
@@ -474,5 +436,5 @@ async def admin_dashboard(
         logger.exception(f"Admin dashboard error: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error loading admin dashboard"
+            detail="Error loading admin dashboard",
         )

--- a/ai-stock-platform/ui/controllers/market_controller.py
+++ b/ai-stock-platform/ui/controllers/market_controller.py
@@ -12,8 +12,16 @@ from typing import Any, Dict, List, Optional, Union
 
 import httpx
 from core.http_client import safe_get_json
-from fastapi import (APIRouter, Depends, HTTPException, Path, Query, Request,
-                     Response, status)
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    Path,
+    Query,
+    Request,
+    Response,
+    status,
+)
 from fastapi.responses import HTMLResponse, JSONResponse
 
 API_URL = "http://quantumvestai-dev-api:8000"
@@ -22,22 +30,21 @@ try:
     from auth.dependencies import get_current_user, get_optional_current_user
 except ImportError:
     # Create mock auth functions if they don't exist
-    logging.getLogger(__name__).warning("Auth dependencies not found. Using mock functions.")
-    
+    logging.getLogger(__name__).warning(
+        "Auth dependencies not found. Using mock functions."
+    )
+
     async def get_current_user(request: Request, response: Response = None):
         """Mock function that returns None (demo mode)"""
         return None
-    
+
     async def get_optional_current_user(request: Request, response: Response = None):
         """Mock function that returns None (demo mode)"""
         return None
 
 
 # Set up router
-router = APIRouter(
-    prefix="/market",
-    tags=["market"]
-)
+router = APIRouter(prefix="/market", tags=["market"])
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -50,11 +57,12 @@ CACHE_ENABLED = os.getenv("CACHE_ENABLED", "true").lower() == "true"
 CACHE_TTL = int(os.getenv("CACHE_TTL", "300"))  # Default: 5 minutes
 cache_store = {}
 
+
 def get_cached_data(key: str) -> Union[Dict[str, Any], None]:
     """Get data from cache if it exists and is not expired."""
     if not CACHE_ENABLED:
         return None
-        
+
     if key in cache_store:
         entry = cache_store[key]
         if entry["expires"] > time.time():
@@ -63,123 +71,93 @@ def get_cached_data(key: str) -> Union[Dict[str, Any], None]:
         else:
             logger.debug(f"Cache expired for {key}")
             del cache_store[key]
-    
+
     logger.debug(f"Cache miss for {key}")
     return None
+
 
 def set_cached_data(key: str, data: Dict[str, Any], ttl: int = CACHE_TTL) -> None:
     """Store data in cache with expiration time."""
     if not CACHE_ENABLED:
         return
-        
+
     expires = time.time() + ttl
-    cache_store[key] = {
-        "data": data,
-        "expires": expires
-    }
+    cache_store[key] = {"data": data, "expires": expires}
     logger.debug(f"Cached data for {key}, expires in {ttl} seconds")
+
 
 def get_templates(request: Request):
     """Helper function to get templates from app state or create a new instance."""
-    templates = getattr(request.app.state, 'templates', None)
+    templates = getattr(request.app.state, "templates", None)
     if templates is None:
         from fastapi.templating import Jinja2Templates
+
         templates = Jinja2Templates(directory="templates")
     return templates
 
+
 @router.get("", response_class=HTMLResponse)
-async def market_overview(
-    request: Request,
-    response: Response
-):
-    """
-    Market overview page showing indices, trends, and top movers (demo mode).
-    This page is accessible without authentication.
-    """
+async def market_overview(request: Request, response: Response):
+    """Market overview page showing indices, trends, and top movers."""
     try:
         # Get API URL from app state or environment
-        api_url_base = getattr(request.app.state, 'settings', {}).get('API_URL', os.getenv('API_URL', 'http://quantumvestai-dev-api:8000'))
-        
-        # Create cache key for demo mode
-        cache_key = f"market_overview_demo"
-        
+        api_url_base = getattr(request.app.state, "settings", {}).get(
+            "API_URL", os.getenv("API_URL", "http://quantumvestai-dev-api:8000")
+        )
+
+        cache_key = "market_overview"
+
         # Try to get data from cache
         market_data = get_cached_data(cache_key)
-        
+
         if market_data is None:
             try:
                 # Get current user for authentication
                 user = await get_optional_current_user(request, response)
-                auth_token = user.get('token') if user else None
-                
+                auth_token = user.get("token") if user else None
+
                 # Fetch market data from API using centralized HTTP client
                 market_data = await safe_get_json(
-                    url=f"{api_url_base}/api/market/overview",
-                    auth_token=auth_token
+                    url=f"{api_url_base}/api/market/overview", auth_token=auth_token
                 )
-                
+
                 if market_data is None:
                     logger.error("Failed to fetch market data from API")
                     raise HTTPException(
-                        status_code=503,
-                        detail="Error fetching market data"
+                        status_code=503, detail="Error fetching market data"
                     )
-                
+
                 # Cache the data
                 set_cached_data(cache_key, market_data)
             except Exception as e:
                 logger.error(f"Market data fetch error: {str(e)}")
                 logger.error(f"API request error: {str(e)}")
-                # Use fallback data
-                market_data = {
-                    "indices": [
-                        {"name": "S&P 500", "value": 4752.75, "change_percent": 0.8},
-                        {"name": "NASDAQ", "value": 16234.50, "change_percent": 1.2},
-                        {"name": "DOW", "value": 35750.25, "change_percent": 0.5}
-                    ],
-                    "top_gainers": [
-                        {"symbol": "AAPL", "name": "Apple Inc.", "price": 178.50, "change_percent": 3.2},
-                        {"symbol": "MSFT", "name": "Microsoft Corp.", "price": 360.25, "change_percent": 2.5},
-                        {"symbol": "AMZN", "name": "Amazon.com Inc.", "price": 145.75, "change_percent": 1.8}
-                    ],
-                    "top_losers": [
-                        {"symbol": "META", "name": "Meta Platforms Inc.", "price": 425.80, "change_percent": -1.2},
-                        {"symbol": "NFLX", "name": "Netflix Inc.", "price": 615.25, "change_percent": -0.8},
-                        {"symbol": "TSLA", "name": "Tesla Inc.", "price": 215.40, "change_percent": -0.5}
-                    ],
-                    "sectors": [
-                        {"name": "Technology", "change_percent": 1.5},
-                        {"name": "Healthcare", "change_percent": 0.8},
-                        {"name": "Financials", "change_percent": 0.3},
-                        {"name": "Consumer Discretionary", "change_percent": -0.2},
-                        {"name": "Energy", "change_percent": -0.5}
-                    ]
-                }
-        
+                raise HTTPException(
+                    status_code=503, detail="Unable to fetch market data"
+                )
+
         # Get templates
         templates = get_templates(request)
-        
+
         # Render template
         return get_templates(request).TemplateResponse(
             "market/overview.html",
             {
                 "request": request,
                 "user": None,
-                "demo_mode": True,
-
                 "page_title": "Market Overview",
                 "market_data": market_data,
                 "last_updated": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC"),
-                "is_authenticated": False
-            }
+                "is_authenticated": False,
+            },
         )
-    
+
     except Exception as e:
         logger.exception(f"Market overview error: {str(e)}")
-        
+
         # Get templates
         templates = get_templates(request)
-        
+
         return get_templates(request).TemplateResponse(
             "error.html",
             {
@@ -187,16 +165,16 @@ async def market_overview(
                 "message": "An error occurred while loading market data.",
                 "error_code": "MARKET_ERR",
                 "user": None,
-                "demo_mode": True
             },
-            status_code=500
+            status_code=500,
         )
+
 
 @router.get("/stock/{symbol}", response_class=HTMLResponse)
 async def stock_details(
     request: Request,
     response: Response,
-    symbol: str = Path(..., description="Stock symbol")
+    symbol: str = Path(..., description="Stock symbol"),
 ):
     """
     Stock details page showing price, charts, news, and fundamentals for a specific stock (demo mode).
@@ -204,99 +182,84 @@ async def stock_details(
     """
     try:
         # Get API URL from app state or environment
-        api_url_base = getattr(request.app.state, 'settings', {}).get('API_URL', os.getenv('API_URL', 'http://quantumvestai-dev-api:8000'))
-        
+        api_url_base = getattr(request.app.state, "settings", {}).get(
+            "API_URL", os.getenv("API_URL", "http://quantumvestai-dev-api:8000")
+        )
+
         # Create cache key for demo mode
         cache_key = f"stock_details_{symbol.upper()}_demo"
-        
+
         # Try to get data from cache
         stock_data = get_cached_data(cache_key)
-        
+
         if stock_data is None:
             try:
                 # Get current user for authentication
                 user = await get_optional_current_user(request, response)
-                auth_token = user.get('token') if user else None
-                
+                auth_token = user.get("token") if user else None
+
                 # Fetch stock data from API using centralized HTTP client
                 stock_data = await safe_get_json(
                     url=f"{api_url_base}/api/stocks/{symbol.upper()}",
-                    auth_token=auth_token
+                    auth_token=auth_token,
                 )
-                
+
                 if stock_data is None:
                     logger.error(f"Failed to fetch stock data for {symbol}")
                     raise HTTPException(
-                        status_code=503,
-                        detail=f"Error fetching data for {symbol}"
+                        status_code=503, detail=f"Error fetching data for {symbol}"
                     )
-                
+
                 # Cache the data
                 set_cached_data(cache_key, stock_data)
             except Exception as e:
                 logger.error(f"Stock data fetch error: {str(e)}")
                 logger.error(f"API request error: {str(e)}")
-                # Use fallback data
-                stock_data = {
-                    "symbol": symbol.upper(),
-                    "name": f"{symbol.upper()} Corporation",
-                    "price": 178.50,
-                    "change": 5.25,
-                    "change_percent": 3.2,
-                    "market_cap": "2.5T",
-                    "pe_ratio": 28.5,
-                    "dividend_yield": 0.55,
-                    "volume": "25.3M",
-                    "chart_data": {
-                        "labels": ["9:30", "10:00", "10:30", "11:00", "11:30", "12:00", "12:30", "1:00", "1:30", "2:00", "2:30", "3:00", "3:30", "4:00"],
-                        "values": [175.25, 176.50, 177.00, 176.75, 177.25, 177.50, 178.00, 177.75, 178.25, 178.50, 178.75, 179.00, 178.75, 178.50]
-                    }
-                }
+                raise HTTPException(
+                    status_code=503, detail="Unable to fetch stock data"
+                )
 
         # Get current user for checking watchlist
         user = await get_optional_current_user(request, response)
-        
+
         # Check if user has this stock in watchlist
         is_in_watchlist = False
         if user:
             try:
                 watchlist_data = await safe_get_json(
                     url=f"{api_url_base}/api/watchlist/check/{symbol.upper()}",
-                    auth_token=user.get('token')
+                    auth_token=user.get("token"),
                 )
-                
+
                 if watchlist_data:
                     is_in_watchlist = watchlist_data.get("in_watchlist", False)
             except Exception as e:
                 logger.warning(f"Error checking watchlist status: {str(e)}")
                 is_in_watchlist = False
-        
 
         # Get templates
         templates = get_templates(request)
-        
+
         # Render template
         return get_templates(request).TemplateResponse(
             "market/stock_details.html",
             {
                 "request": request,
                 "user": None,
-                "demo_mode": True,
-
                 "page_title": f"{stock_data.get('name')} ({stock_data.get('symbol')})",
                 "stock": stock_data,
                 "last_updated": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC"),
                 "is_authenticated": False,
-                "is_in_watchlist": False
-            }
+                "is_in_watchlist": False,
+            },
         )
-    
+
     except Exception as e:
         logger.exception(f"Stock details error: {str(e)}")
-        
+
         # Get templates
         templates = get_templates(request)
-        
+
         return get_templates(request).TemplateResponse(
             "error.html",
             {
@@ -304,69 +267,58 @@ async def stock_details(
                 "message": f"An error occurred while loading data for {symbol}.",
                 "error_code": "STOCK_ERR",
                 "user": None,
-                "demo_mode": True
             },
-            status_code=500
+            status_code=500,
         )
+
 
 @router.get("/api/stocks/search", response_model=Dict[str, Any])
 async def search_stocks(
-    request: Request,
-    query: str = Query(..., description="Search query")
+    request: Request, query: str = Query(..., description="Search query")
 ):
-    """
-    API endpoint to search for stocks by name or symbol (demo mode).
-    Used for autocomplete functionality.
-    """
+    """API endpoint to search for stocks by name or symbol."""
     try:
         # Get API URL from app state or environment
-        api_url_base = getattr(request.app.state, 'settings', {}).get('API_URL', os.getenv('API_URL', 'http://quantumvestai-dev-api:8000'))
-        
-        # Create cache key for demo mode
-        cache_key = f"stock_search_{query.lower()}_demo"
-        
+        api_url_base = getattr(request.app.state, "settings", {}).get(
+            "API_URL", os.getenv("API_URL", "http://quantumvestai-dev-api:8000")
+        )
+
+        cache_key = f"stock_search_{query.lower()}"
+
         # Try to get data from cache
         search_results = get_cached_data(cache_key)
-        
+
         if search_results is None:
             try:
                 # Get current user for authentication
                 user = await get_optional_current_user(request)
-                auth_token = user.get('token') if user else None
-                
+                auth_token = user.get("token") if user else None
+
                 # Fetch search results from API using centralized HTTP client
                 search_results = await safe_get_json(
                     url=f"{api_url_base}/api/stocks/search",
                     params={"query": query},
-                    auth_token=auth_token
+                    auth_token=auth_token,
                 )
-                
+
                 if search_results is None:
                     logger.error("Failed to fetch search results from API")
                     raise HTTPException(
-                        status_code=503,
-                        detail="Error searching stocks"
+                        status_code=503, detail="Error searching stocks"
                     )
-                
+
                 # Cache the data
                 set_cached_data(cache_key, search_results)
             except Exception as e:
                 logger.error(f"Stock search error: {str(e)}")
                 logger.error(f"API request error: {str(e)}")
-                # Use fallback data based on query
-                search_results = {
-                    "results": [
-                        {"symbol": "AAPL", "name": "Apple Inc."},
-                        {"symbol": "AMZN", "name": "Amazon.com Inc."},
-                        {"symbol": "MSFT", "name": "Microsoft Corporation"}
-                    ]
-                }
-        
+                raise HTTPException(status_code=503, detail="Unable to search stocks")
+
         return search_results
-    
+
     except Exception as e:
         logger.exception(f"Stock search error: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error searching stocks"
+            detail="Error searching stocks",
         )

--- a/ai-stock-platform/ui/controllers/news_controller.py
+++ b/ai-stock-platform/ui/controllers/news_controller.py
@@ -5,9 +5,11 @@ Author: daparthi001
 """
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Dict, Any
+
+import httpx
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
@@ -21,107 +23,138 @@ templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 def get_templates(request: Request) -> Jinja2Templates:
     """Return app-level templates if available."""
     return getattr(request.app.state, "templates", templates)
+
+
 logger = logging.getLogger("quantumvestai.news_controller")
 
 # Get API URL from environment or use default
 API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000")
 API_V1_URL = f"{API_URL}/api/v1"
 
-# Demo news data removed
-DEMO_NEWS = []
+# External news API configuration
+NEWS_API_URL = os.environ.get("NEWS_API_URL", "https://newsapi.org/v2/top-headlines")
+NEWS_API_KEY = os.environ.get("NEWS_API_KEY")
+
+# Simple in-memory cache for fetched news
+_NEWS_CACHE: Dict[str, Dict[str, Any]] = {}
+
+
+async def fetch_news(category: str, page: int = 1, ttl: int = 600) -> Dict[str, Any]:
+    """Fetch news articles from the external API with basic caching."""
+    cache_key = f"{category}_{page}"
+    cached = _NEWS_CACHE.get(cache_key)
+    now = datetime.utcnow()
+    if cached and cached["expires"] > now:
+        return cached["data"]
+
+    if not NEWS_API_KEY:
+        raise HTTPException(status_code=503, detail="News API key not configured")
+
+    params = {"apiKey": NEWS_API_KEY, "page": page, "pageSize": 10}
+    if category != "market":
+        params["category"] = category
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(NEWS_API_URL, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+
+    _NEWS_CACHE[cache_key] = {"data": data, "expires": now + timedelta(seconds=ttl)}
+    return data
+
 
 @router.get("/news", response_class=HTMLResponse)
 async def news_page(
     request: Request,
     category: str = Query("market", regex="^(market|stocks|crypto|economy)$"),
-    page: int = Query(1, ge=1)
+    page: int = Query(1, ge=1),
 ):
-    """Display news page (demo mode)"""
+    """Display news page using live data."""
     try:
-        # Filter news by category
-        filtered_news = [article for article in DEMO_NEWS if article["category"] == category]
-        
-        # Pagination
-        items_per_page = 10
-        start_index = (page - 1) * items_per_page
-        end_index = start_index + items_per_page
-        paginated_news = filtered_news[start_index:end_index]
-        
-        # Calculate pagination info
-        total_articles = len(filtered_news)
-        total_pages = (total_articles + items_per_page - 1) // items_per_page
-        
+        data = await fetch_news(category, page)
+
+        articles = [
+            {
+                "id": idx,
+                "title": art.get("title"),
+                "summary": art.get("description"),
+                "source": art.get("source", {}).get("name"),
+                "published_at": art.get("publishedAt"),
+                "category": category,
+                "sentiment": "neutral",
+            }
+            for idx, art in enumerate(data.get("articles", []))
+        ]
+
         news_data = {
-            "articles": paginated_news,
+            "articles": articles,
             "category": category,
             "page": page,
-            "total_pages": total_pages,
-            "total_articles": total_articles,
-            "trending": ["AI", "Federal Reserve", "EV Market", "Cryptocurrency"]
+            "total_pages": 1,
+            "total_articles": data.get("totalResults", 0),
+            "trending": [],
         }
-        
+
         return get_templates(request).TemplateResponse(
             "news/index.html",
             {
-                "request": request, 
-                "data": news_data, 
-                "user": None, 
-                "demo_mode": True,
-                "page_title": f"News - {category.title()} - QuantumVestAI"
-            }
+                "request": request,
+                "data": news_data,
+                "user": None,
+                "page_title": f"News - {category.title()} - QuantumVestAI",
+            },
         )
     except Exception as e:
         logger.error(f"News page error: {str(e)}")
         return get_templates(request).TemplateResponse(
             "error.html",
             {
-                "request": request, 
-                "error": str(e), 
-                "user": None, 
-                "demo_mode": True,
-                "page_title": "News Error"
+                "request": request,
+                "error": str(e),
+                "user": None,
+                "page_title": "News Error",
             },
-            status_code=500
+            status_code=500,
         )
+
 
 @router.get("/news/article/{article_id}", response_class=HTMLResponse)
 async def news_article(
     request: Request,
-    article_id: str
+    article_id: int,
+    category: str = Query("market", regex="^(market|stocks|crypto|economy)$"),
+    page: int = Query(1, ge=1),
 ):
-    """Display specific news article (demo mode)"""
+    """Display a single news article retrieved from the external API."""
     try:
-        # Find article by ID
-        article = None
-        for item in DEMO_NEWS:
-            if str(item["id"]) == article_id:
-                article = item
-                break
-        
-        if not article:
+        data = await fetch_news(category, page)
+        articles = data.get("articles", [])
+        if article_id < 0 or article_id >= len(articles):
             raise HTTPException(status_code=404, detail="Article not found")
-        
-        # Get related articles (same category)
-        related_articles = [
-            item for item in DEMO_NEWS 
-            if item["category"] == article["category"] and item["id"] != article["id"]
-        ][:3]  # Limit to 3 related articles
-        
+
+        article = articles[article_id]
         article_data = {
-            "article": article,
-            "related": related_articles,
-            "sentiment": {"status": "available", "score": 0.7, "label": "positive"}
+            "article": {
+                "id": article_id,
+                "title": article.get("title"),
+                "summary": article.get("description"),
+                "source": article.get("source", {}).get("name"),
+                "published_at": article.get("publishedAt"),
+                "category": category,
+                "sentiment": "neutral",
+            },
+            "related": [],
+            "sentiment": {"status": "unavailable"},
         }
-        
+
         return get_templates(request).TemplateResponse(
             "news/article.html",
             {
-                "request": request, 
-                "data": article_data, 
-                "user": None, 
-                "demo_mode": True,
-                "page_title": f"{article['title']} - QuantumVestAI"
-            }
+                "request": request,
+                "data": article_data,
+                "user": None,
+                "page_title": f"{article.get('title')} - QuantumVestAI",
+            },
         )
     except HTTPException as e:
         raise e
@@ -130,10 +163,10 @@ async def news_article(
         return get_templates(request).TemplateResponse(
             "error.html",
             {
-                "request": request, 
-                "error": str(e), 
-                "user": None, 
-                "demo_mode": True,
-                "page_title": "Article Error"
+                "request": request,
+                "error": str(e),
+                "user": None,
+                "page_title": "Article Error",
             },
-            status_code=500        )
+            status_code=500,
+        )


### PR DESCRIPTION
## Summary
- drop demo data in News, Dashboard, and Market controllers
- require external news API
- fail fast when API data is missing

## Testing
- `pytest -q` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6882ae26820c832abc7f34c5a662d4e8