### PR TITLE
Improve dashboard update styling

### DIFF
--- a/ai-stock-platform/ui/static/css/quantum-dashboard.css
+++ b/ai-stock-platform/ui/static/css/quantum-dashboard.css
@@ -431,12 +431,8 @@
 
 /* Value Update Animation */
 .value-updated {
-  animation: valueFlash 1s ease-in-out;
-}
-
-@keyframes valueFlash {
-  0%, 100% { background: transparent; }
-  50% { background: rgba(79, 172, 254, 0.3); }
+  background-color: rgba(79, 172, 254, 0.3);
+  transition: background-color 0.6s ease-in-out;
 }
 
 /* Widget Feedback */
@@ -570,7 +566,6 @@ canvas {
   }
   
   @keyframes livePulse,
-  @keyframes valueFlash,
   @keyframes spin {
     animation: none !important;
   }

--- a/ai-stock-platform/ui/static/js/quantum-dashboard.js
+++ b/ai-stock-platform/ui/static/js/quantum-dashboard.js
@@ -512,7 +512,7 @@ class QuantumDashboard {
                     metric.textContent = newValue.toFixed(2);
                 }
                 
-                // Add flash animation
+                // Highlight updated value
                 metric.classList.add('value-updated');
                 setTimeout(() => metric.classList.remove('value-updated'), 1000);
             }


### PR DESCRIPTION
## Summary
- tone down animation on dashboard metric updates by using a color fade
- clarify comment in JS

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6882afb1ab30832aa013edb0f8c79bd3