### PR TITLE
Allow Vite env vars for UI services

### DIFF
--- a/ai-stock-platform/ui/src/config/constants.ts
+++ b/ai-stock-platform/ui/src/config/constants.ts
@@ -5,7 +5,11 @@
  */
 
 // API configuration
-export const API_BASE_URL = process.env.REACT_APP_API_URL || 'https://dev.quantumvestai.com';
+const viteEnv: Record<string, string> = (typeof import.meta !== 'undefined' && import.meta.env) || {};
+export const API_BASE_URL =
+  viteEnv.VITE_API_URL ||
+  (typeof process !== 'undefined' ? process.env.REACT_APP_API_URL : undefined) ||
+  'https://dev.quantumvestai.com';
 
 // Authentication
 export const ACCESS_TOKEN_KEY = 'qvai_token';

--- a/ai-stock-platform/ui/src/config/index.ts
+++ b/ai-stock-platform/ui/src/config/index.ts
@@ -9,7 +9,10 @@ export * from './constants';
 // Export a default configuration object
 export default {
     api: {
-        baseUrl: process.env.REACT_APP_API_URL || 'http://quantumvestai-dev-api:8000',
+        baseUrl:
+            (typeof import.meta !== 'undefined' && import.meta.env.VITE_API_URL) ||
+            (typeof process !== 'undefined' ? process.env.REACT_APP_API_URL : undefined) ||
+            'http://quantumvestai-dev-api:8000',
         timeout: 30000
     },
     cache: {

--- a/ai-stock-platform/ui/src/providers/FeatureProvider.tsx
+++ b/ai-stock-platform/ui/src/providers/FeatureProvider.tsx
@@ -48,7 +48,11 @@ export const FeatureProvider: React.FC<FeatureProviderProps> = ({ children }) =>
     const loadFeatureFlags = async () => {
       try {
         // Try to load feature flags from API
-        const endpoint = process.env.REACT_APP_FEATURE_FLAGS_ENDPOINT || '/api/v1/feature-flags';
+        const viteEnv: Record<string, string> = (typeof import.meta !== 'undefined' && import.meta.env) || {};
+        const endpoint =
+          viteEnv.VITE_FEATURE_FLAGS_ENDPOINT ||
+          (typeof process !== 'undefined' ? process.env.REACT_APP_FEATURE_FLAGS_ENDPOINT : undefined) ||
+          '/api/v1/feature-flags';
         const response = await apiClient.get(endpoint);
         
         if (response.data && response.data.data) {

--- a/ai-stock-platform/ui/src/services/OrderWebSocket.ts
+++ b/ai-stock-platform/ui/src/services/OrderWebSocket.ts
@@ -28,9 +28,12 @@ export class OrderWebSocket {
                 throw new Error('Authentication required');
             }
 
-            this.ws = new WebSocket(
-                `${process.env.REACT_APP_WS_URL}/orders/${userId}?token=${token}`
-            );
+            const viteEnv: Record<string, string> = (typeof import.meta !== 'undefined' && import.meta.env) || {};
+            const wsBase =
+                viteEnv.VITE_WS_URL ||
+                (typeof process !== 'undefined' ? process.env.REACT_APP_WS_URL : undefined) ||
+                'ws://quantumvestai-dev-api:8000/ws';
+            this.ws = new WebSocket(`${wsBase}/orders/${userId}?token=${token}`);
 
             this.ws.onopen = this.handleOpen.bind(this);
             this.ws.onmessage = this.handleMessage;

--- a/ai-stock-platform/ui/src/services/analytics/OrderAnalytics.ts
+++ b/ai-stock-platform/ui/src/services/analytics/OrderAnalytics.ts
@@ -16,7 +16,9 @@ export class OrderAnalytics {
             app: 'order-management-ui',
             plugins: [
                 googleAnalytics({
-                    measurementId: process.env.REACT_APP_GA_MEASUREMENT_ID
+                    measurementId:
+                        (typeof import.meta !== 'undefined' && import.meta.env.VITE_GA_MEASUREMENT_ID) ||
+                        (typeof process !== 'undefined' ? process.env.REACT_APP_GA_MEASUREMENT_ID : undefined)
                 })
             ]
         });

--- a/ai-stock-platform/ui/src/services/api.service.ts
+++ b/ai-stock-platform/ui/src/services/api.service.ts
@@ -5,15 +5,17 @@
  */
 import axios, { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
 import authService from './auth.service';
+import { API_BASE_URL } from '../config/constants';
 
 class ApiService {
   private apiClient: AxiosInstance;
   
   constructor() {
     // Get API base URL from environment or derive from window location
-    const apiBaseUrl = process.env.REACT_APP_API_URL || 
-                      window.location.protocol + '//' + window.location.hostname + 
-                      (window.location.hostname === 'localhost' ? ':8000' : '');
+    const apiBaseUrl =
+      API_BASE_URL ||
+      window.location.protocol + '//' + window.location.hostname +
+      (window.location.hostname === 'localhost' ? ':8000' : '');
     
     // Create axios instance
     this.apiClient = axios.create({

--- a/ai-stock-platform/ui/src/services/monitoring/PerformanceMonitor.ts
+++ b/ai-stock-platform/ui/src/services/monitoring/PerformanceMonitor.ts
@@ -29,8 +29,11 @@ export class PerformanceMonitor {
     }
 
     private initializeSentry() {
+        const viteEnv: Record<string, string> = (typeof import.meta !== 'undefined' && import.meta.env) || {};
         Sentry.init({
-            dsn: process.env.REACT_APP_SENTRY_DSN,
+            dsn:
+                viteEnv.VITE_SENTRY_DSN ||
+                (typeof process !== 'undefined' ? process.env.REACT_APP_SENTRY_DSN : undefined),
             integrations: [new BrowserTracing() as any],
             tracesSampleRate: 0.2,
             environment: process.env.NODE_ENV

--- a/ai-stock-platform/ui/src/services/websocket.service.ts
+++ b/ai-stock-platform/ui/src/services/websocket.service.ts
@@ -15,7 +15,11 @@ class WebSocketService {
   private readonly baseUrl: string;
 
   constructor() {
-    this.baseUrl = process.env.REACT_APP_WS_URL || 'ws://quantumvestai-dev-api:8000/ws';
+    const viteEnv: Record<string, string> = (typeof import.meta !== 'undefined' && import.meta.env) || {};
+    this.baseUrl =
+      viteEnv.VITE_WS_URL ||
+      (typeof process !== 'undefined' ? process.env.REACT_APP_WS_URL : undefined) ||
+      'ws://quantumvestai-dev-api:8000/ws';
     const token = localStorage.getItem('qvai_token') || '';
     if (token) {
       this.connect(token);


### PR DESCRIPTION
## Summary
- enable Vite-style environment variables for API and websocket configuration
- adjust OrderWebSocket, feature flag provider, monitoring, and analytics to use new env variables
- use shared API_BASE_URL in ApiService

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q` *(fails: ModuleNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6882b5c7b030832a9ead4545651b611c