### PR TITLE
Improve stock forecast model

### DIFF
--- a/ai-stock-platform/api/services/forecast_service.py
+++ b/ai-stock-platform/api/services/forecast_service.py
@@ -5,7 +5,11 @@ from typing import Any, Dict, Optional
 import pandas as pd
 
 from services.stock_service import StockService
-from ml.ensemble_model import EnsemblePredictor, linear_regression_predict
+from ml.ensemble_model import (
+    EnsemblePredictor,
+    linear_regression_predict,
+    random_forest_predict,
+)
 
 class ForecastService:
     """Provide basic forecast functionality for demo purposes."""
@@ -43,6 +47,7 @@ class ForecastService:
 
         predictor = EnsemblePredictor()
         predictor.add_model(linear_regression_predict)
+        predictor.add_model(random_forest_predict)
         preds = predictor.predict(ticker, history[['adjusted_close']], days_ahead=days)
 
         current = float(history['adjusted_close'].iloc[-1])

--- a/ai_stock_platform/api/ml/ensemble_model.py
+++ b/ai_stock_platform/api/ml/ensemble_model.py
@@ -54,3 +54,23 @@ def linear_regression_predict(ticker: str, historical_data: pd.DataFrame, days_a
     preds = model.predict(future_index)
     dates = pd.date_range(start=df.index[-1], periods=days_ahead+1)[1:]
     return pd.DataFrame({'date': dates, 'predicted_close': preds}).set_index('date')
+
+
+def random_forest_predict(ticker: str, historical_data: pd.DataFrame, days_ahead: int = 5) -> pd.DataFrame:
+    """Random forest regressor for stronger predictions."""
+    from sklearn.ensemble import RandomForestRegressor
+
+    df = historical_data.dropna()
+    if len(df) < 2:
+        raise ValueError("Not enough data for regression")
+
+    X = np.arange(len(df)).reshape(-1, 1)
+    y = df['adjusted_close'].values
+
+    model = RandomForestRegressor(n_estimators=100, random_state=42)
+    model.fit(X, y)
+
+    future_index = np.arange(len(df), len(df) + days_ahead).reshape(-1, 1)
+    preds = model.predict(future_index)
+    dates = pd.date_range(start=df.index[-1], periods=days_ahead+1)[1:]
+    return pd.DataFrame({'date': dates, 'predicted_close': preds}).set_index('date')

--- a/tests/test_random_forest.py
+++ b/tests/test_random_forest.py
@@ -1,0 +1,10 @@
+import pandas as pd
+from ai_stock_platform.api.ml.ensemble_model import random_forest_predict
+
+
+def test_random_forest_prediction_shape():
+    dates = pd.date_range(end="2024-01-10", periods=30)
+    df = pd.DataFrame({'adjusted_close': range(30)}, index=dates)
+    result = random_forest_predict('TEST', df, days_ahead=3)
+    assert len(result) == 3
+    assert 'predicted_close' in result.columns


### PR DESCRIPTION
## Summary
- enhance EnsemblePredictor with a random forest model
- integrate new model into the forecast service
- add regression test for random forest predictor

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: models.orders)*

------
https://chatgpt.com/codex/tasks/task_e_6882b90a4c30832a80dade0a80c21b76