### PR TITLE
Improve news error logging

### DIFF
--- a/ai-stock-platform/ui/controllers/news_controller.py
+++ b/ai-stock-platform/ui/controllers/news_controller.py
@@ -105,7 +105,8 @@ async def news_page(
             },
         )
     except Exception as e:
-        logger.error(f"News page error: {str(e)}")
+        detail = getattr(e, "detail", str(e))
+        logger.error(f"News page error: {detail}")
         return get_templates(request).TemplateResponse(
             "error.html",
             {
@@ -159,7 +160,8 @@ async def news_article(
     except HTTPException as e:
         raise e
     except Exception as e:
-        logger.error(f"News article error for {article_id}: {str(e)}")
+        detail = getattr(e, "detail", str(e))
+        logger.error(f"News article error for {article_id}: {detail}")
         return get_templates(request).TemplateResponse(
             "error.html",
             {


### PR DESCRIPTION
## Summary
- improve logging in `news_controller` to include error details

## Testing
- `pytest -q` *(fails: 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6882bcc22bb8832ab3ff25fbdcbeef51