### PR TITLE
Fix dashboard to display API data

### DIFF
--- a/ai-stock-platform/ui/templates/dashboard/index.html
+++ b/ai-stock-platform/ui/templates/dashboard/index.html
@@ -69,9 +69,9 @@
                         <span class="badge quantum-badge">{% if idx.change >= 0 %}📈{% else %}📉{% endif %}</span>
                     </div>
                     <div class="mb-2">
-                        <div class="h3 mb-1 price-display">{{ format_currency(idx.value) }}</div>
+                        <div class="h3 mb-1 price-display">{{ format_currency(idx.price) }}</div>
                         <div class="fw-bold {% if idx.change >= 0 %}text-success{% else %}text-danger{% endif %}">
-                            {{ format_change_value(idx.change) }} ({{ format_percentage(idx.change_pct/100) }})
+                            {{ format_change_value(idx.change) }} ({{ format_percentage((idx.change_percent or idx.change_pct)/100) }})
                         </div>
                     </div>
                 </div>
@@ -148,11 +148,11 @@
                         {% for stock in popular_stocks %}
                         <div class="top-mover-item d-flex justify-content-between align-items-center mb-2">
                             <div>
-                                <div class="fw-bold">{{ stock.ticker }}</div>
+                                <div class="fw-bold">{{ stock.symbol or stock.ticker }}</div>
                                 <div class="text-muted small">{{ format_currency(stock.price) }}</div>
                             </div>
                             <div class="text-end {% if stock.change >= 0 %}text-success{% else %}text-danger{% endif %}">
-                                <div class="fw-bold">{{ format_percentage(stock.change_percent/100) }}</div>
+                                <div class="fw-bold">{{ format_percentage((stock.change_percent or stock.change_pct)/100) }}</div>
                                 <div class="small">{{ format_change_value(stock.change) }}</div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- show index price and change percentage using API fields
- support both symbol and ticker in top movers

## Testing
- `pytest -q` *(fails: PytestCollectionWarning and 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6882c1485b48832aa08fa11111e77f13