### PR TITLE
Fix scheduler and service imports

### DIFF
--- a/ai-stock-platform/api/db/session.py
+++ b/ai-stock-platform/api/db/session.py
@@ -146,7 +146,11 @@ except Exception as e:
         Base.metadata.create_all(bind=engine)
         logger.info("Initialized fallback SQLite database")
     except Exception as init_err:
-        logger.error("Failed to initialize fallback database: %s", str(init_err))
+        logger.warning(
+            "Fallback SQLite database initialization failed: %s. "
+            "Continuing without precreated tables.",
+            str(init_err),
+        )
 
 def get_db() -> Generator:
     """Get database session"""

--- a/ai-stock-platform/api/services/api_client.py
+++ b/ai-stock-platform/api/services/api_client.py
@@ -1,0 +1,20 @@
+"""Compatibility wrapper for APIClient.
+
+This module allows imports of ``services.api_client`` to resolve
+correctly even when Python loads the ``services`` package from the
+``ai-stock-platform/api`` directory first. It simply forwards the
+``APIClient`` class from the repository root ``services`` package.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+# Ensure repository root is on ``sys.path``
+_root = Path(__file__).resolve().parents[2]
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+from services.api_client import APIClient  # type: ignore[F401]
+
+__all__ = ["APIClient"]

--- a/ai-stock-platform/api/services/data_fetch_scheduler.py
+++ b/ai-stock-platform/api/services/data_fetch_scheduler.py
@@ -38,7 +38,14 @@ async def fetch_and_analyze() -> None:
 
 def start_data_fetch_scheduler() -> AsyncIOScheduler:
     """Start scheduler to fetch market and sentiment data every 15 minutes."""
-    scheduler = AsyncIOScheduler()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # Create a loop if none is running (e.g. during unit tests)
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    scheduler = AsyncIOScheduler(event_loop=loop)
     scheduler.add_job(
         fetch_and_analyze,
         trigger=IntervalTrigger(minutes=15),

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -3,10 +3,12 @@ from pathlib import Path
 import sys
 
 _here = Path(__file__).resolve().parent
+# Paths to the actual service implementations used by the UI and API
 _ui_services = _here.parent / "ai-stock-platform" / "ui" / "services"
+_api_services = _here.parent / "ai-stock-platform" / "api" / "services"
 
 # Include both this directory (for test stubs) and the real UI services path
-__path__ = [str(_here), str(_ui_services)]
+__path__ = [str(_here), str(_api_services), str(_ui_services)]
 
 for p in __path__:
     if p not in sys.path:


### PR DESCRIPTION
## Summary
- ensure fallback DB setup doesn't fail hard
- create wrapper services/api_client in API package
- improve scheduler loop handling
- expose api services path via root services package

## Testing
- `pytest ai-stock-platform/api/tests/test_order_management.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6882c12e0f24832a98c5c2c05cb4791b