### PR TITLE
Fix market data websocket path

### DIFF
--- a/ai-stock-platform/ui/static/js/quantum-charts.js
+++ b/ai-stock-platform/ui/static/js/quantum-charts.js
@@ -144,7 +144,8 @@ class QuantumCharts {
     setupWebSocketConnection() {
         try {
             const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-            const wsUrl = `${protocol}//${window.location.host}/ws/market-data`;
+            const clientId = this.options.clientId || 'market-data';
+            const wsUrl = `${protocol}//${window.location.host}/ws/${clientId}`;
             
             this.websocket = new WebSocket(wsUrl);
             


### PR DESCRIPTION
## Summary
- use a configurable client ID when building the QuantumCharts websocket URL

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6882c6ae505c832a94f8578bddc59868