### PR TITLE
Handle DATABASE environment variable in settings

### DIFF
--- a/ai-stock-platform/core/config/settings.py
+++ b/ai-stock-platform/core/config/settings.py
@@ -3,6 +3,7 @@ Centralized Application Configuration Settings
 This module provides the canonical settings and configuration for all QuantumVestAI services.
 """
 from typing import Optional
+import os
 from pydantic import BaseModel, Field, PostgresDsn, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -58,9 +59,24 @@ class Settings(BaseSettings):
     def get_db_url(self) -> str:
         return self.database.get_db_url()
 
-settings = Settings()
+def get_settings() -> Settings:
+    """Return an initialized :class:`Settings` instance.
 
-def get_settings():
-    return settings
+    The Kubernetes deployment defines an environment variable named ``DATABASE``
+    which conflicts with Pydantic's handling of the nested ``database`` model.
+    Removing this variable before instantiation prevents JSON decoding errors
+    when the settings object is created.
+    """
+
+    removed = os.environ.pop("DATABASE", None)
+    try:
+        return Settings()
+    finally:
+        if removed is not None:
+            os.environ["DATABASE"] = removed
+
+
+settings = get_settings()
 
 __all__ = ["settings", "Settings", "get_settings"]
+


### PR DESCRIPTION
## Summary
- avoid parsing Kubernetes `DATABASE` env var
- document removal of env var before creating settings

## Testing
- `pytest -q` *(fails: ERROR collecting ai-stock-platform/api/tests/test_order_management.py, ERROR collecting ai-stock-platform/api/tests/integration/test_order_flow.py, ERROR collecting tests/test_data_fetch_scheduler.py)*

------
https://chatgpt.com/codex/tasks/task_e_6882c9e645b8832a927123f9bd854fb7