### PR TITLE
Fix market summary demo data

### DIFF
--- a/ai-stock-platform/ui/main.py
+++ b/ai-stock-platform/ui/main.py
@@ -646,14 +646,31 @@ async def enhanced_dashboard(request: Request):
         }
         
         # Demo data for dashboard
+        # The dashboard template expects each index entry to provide ``price``
+        # and ``change_percent`` fields.  Older demo data used ``value`` and
+        # ``change_pct`` which caused Jinja to fail with ``'dict object' has no
+        # attribute 'price'`` when rendering in demo mode.  Align the keys with
+        # the real service output to avoid template errors.
         market_summary = {
             "indices": {
-                "S&P 500": {"value": 4567.89, "change": 23.45, "change_pct": 0.52},
-                "NASDAQ": {"value": 14234.56, "change": -45.67, "change_pct": -0.32},
-                "DOW": {"value": 34567.12, "change": 156.78, "change_pct": 0.46}
+                "S&P 500": {
+                    "price": 4567.89,
+                    "change": 23.45,
+                    "change_percent": 0.52,
+                },
+                "NASDAQ": {
+                    "price": 14234.56,
+                    "change": -45.67,
+                    "change_percent": -0.32,
+                },
+                "DOW": {
+                    "price": 34567.12,
+                    "change": 156.78,
+                    "change_percent": 0.46,
+                },
             },
             "sectors": {},
-            "top_movers": {}
+            "top_movers": {},
         }
         
         return get_templates(request).TemplateResponse(

--- a/ai-stock-platform/ui/services/yahoo_finance.py
+++ b/ai-stock-platform/ui/services/yahoo_finance.py
@@ -14,7 +14,12 @@ from ui.config.constants import (
     TIMEFRAME_1Y,
     TIMEFRAME_MAX,
 )
-from ui.config.settings import settings
+# Import settings from the shared configuration module.
+# ``ui.config.settings`` was deprecated and no longer exposes a ``settings``
+# instance which caused runtime import errors when this service was imported
+# directly.  Using the shared ``core.config.settings`` ensures the service
+# always has access to the application settings object.
+from core.config.settings import settings
 
 
 class YahooFinanceService:


### PR DESCRIPTION
## Summary
- point `YahooFinanceService` at shared settings module
- adjust demo market data so dashboard renders `price` correctly

## Testing
- `./setup_env.sh`
- `source venv/bin/activate && pytest -q` *(fails: 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6882dbf1c7fc832a812a04794d252064