### PR TITLE
Fix websocket 403 by expanding CORS

### DIFF
--- a/ai-stock-platform/api/core/middleware/cors.py
+++ b/ai-stock-platform/api/core/middleware/cors.py
@@ -31,6 +31,10 @@ def get_cors_origins() -> List[str]:
         # Local development
         "http://ui-service:3000",
         "http://quantumvestai-dev-api:8000",
+        "http://localhost:3000",
+        "http://localhost:8000",
+        "http://127.0.0.1:3000",
+        "http://127.0.0.1:8000",
         # Development and production domains
         "https://dev.quantumvestai.com",
         "https://quantumvestai.com",


### PR DESCRIPTION
## Summary
- allow localhost URLs in CORS middleware

## Testing
- `pytest -q` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6882e2348150832aa522d8f8d1678e68