### PR TITLE
Fix Twitter credential env vars

### DIFF
--- a/ai-stock-platform/.env.template
+++ b/ai-stock-platform/.env.template
@@ -37,10 +37,12 @@ ADMIN_EMAIL=admin@quantumvestai.com
 ALPHA_VANTAGE_API_KEY=your-alpha-vantage-api-key
 
 # Twitter API Settings
-TWITTER_CONSUMER_KEY=your-twitter-consumer-key
-TWITTER_CONSUMER_SECRET=your-twitter-consumer-secret
+# The application accepts both the modern variable names and the legacy
+# `TWITTER_CONSUMER_*` names. Using the API names is recommended.
+TWITTER_API_KEY=your-twitter-consumer-key
+TWITTER_API_SECRET=your-twitter-consumer-secret
 TWITTER_ACCESS_TOKEN=your-twitter-access-token
-TWITTER_ACCESS_SECRET=your-twitter-access-secret
+TWITTER_ACCESS_TOKEN_SECRET=your-twitter-access-secret
 
 # Redis Configuration
 REDIS_URL=redis://localhost:6379/0

--- a/ai-stock-platform/api/twitter_config.py
+++ b/ai-stock-platform/api/twitter_config.py
@@ -11,10 +11,19 @@ class TwitterConfig:
     
     def __init__(self):
         self.TWITTER_BEARER_TOKEN = os.getenv('TWITTER_BEARER_TOKEN')
-        self.TWITTER_API_KEY = os.getenv('TWITTER_API_KEY')
-        self.TWITTER_API_SECRET = os.getenv('TWITTER_API_SECRET')
+
+        # Support both new-style and legacy environment variable names so that
+        # deployments using either set will work correctly. The *.env.template*
+        # file uses the legacy `TWITTER_CONSUMER_*` names while the code expects
+        # `TWITTER_API_*`.  Here we check the API variables first and fall back
+        # to the consumer versions if they are present.
+        self.TWITTER_API_KEY = os.getenv('TWITTER_API_KEY') or os.getenv('TWITTER_CONSUMER_KEY')
+        self.TWITTER_API_SECRET = os.getenv('TWITTER_API_SECRET') or os.getenv('TWITTER_CONSUMER_SECRET')
         self.TWITTER_ACCESS_TOKEN = os.getenv('TWITTER_ACCESS_TOKEN')
-        self.TWITTER_ACCESS_TOKEN_SECRET = os.getenv('TWITTER_ACCESS_TOKEN_SECRET')
+        self.TWITTER_ACCESS_TOKEN_SECRET = (
+            os.getenv('TWITTER_ACCESS_TOKEN_SECRET')
+            or os.getenv('TWITTER_ACCESS_SECRET')
+        )
     
     def has_credentials(self) -> bool:
         """Check if any Twitter credentials are configured"""


### PR DESCRIPTION
## Summary
- load legacy TWITTER_CONSUMER_* variables for compatibility
- update `.env.template` to recommend API variable names

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ImportError in services.api_client)*

------
https://chatgpt.com/codex/tasks/task_e_6882e4b4dde8832aa1e2c304ebd0fe8f