### PR TITLE
Add demo fallback for News API key

### DIFF
--- a/ai-stock-platform/ui/controllers/news_controller.py
+++ b/ai-stock-platform/ui/controllers/news_controller.py
@@ -9,6 +9,9 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional, Dict, Any
 
+from core.config import get_settings
+from ui.routes.content_api import get_news as get_demo_news
+
 import httpx
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -35,6 +38,8 @@ API_V1_URL = f"{API_URL}/api/v1"
 NEWS_API_URL = os.environ.get("NEWS_API_URL", "https://newsapi.org/v2/top-headlines")
 NEWS_API_KEY = os.environ.get("NEWS_API_KEY")
 
+settings = get_settings()
+
 # Simple in-memory cache for fetched news
 _NEWS_CACHE: Dict[str, Dict[str, Any]] = {}
 
@@ -48,6 +53,22 @@ async def fetch_news(category: str, page: int = 1, ttl: int = 600) -> Dict[str, 
         return cached["data"]
 
     if not NEWS_API_KEY:
+        if settings.DEMO_MODE:
+            logger.warning("NEWS_API_KEY not set, returning demo news data")
+            demo_list = await get_demo_news()
+            demo_articles = [
+                {
+                    "title": item["title"],
+                    "description": item["summary"],
+                    "url": item["url"],
+                    "source": {"name": item["source"]},
+                    "publishedAt": item.get("timestamp"),
+                }
+                for item in demo_list
+            ]
+            data = {"articles": demo_articles, "totalResults": len(demo_articles)}
+            _NEWS_CACHE[cache_key] = {"data": data, "expires": now + timedelta(seconds=ttl)}
+            return data
         raise HTTPException(status_code=503, detail="News API key not configured")
 
     params = {"apiKey": NEWS_API_KEY, "page": page, "pageSize": 10}


### PR DESCRIPTION
## Summary
- gracefully handle missing `NEWS_API_KEY` in `news_controller`
- load demo news data when running in demo mode

## Testing
- `pytest -q` *(fails: OperationalError during DB connection)*

------
https://chatgpt.com/codex/tasks/task_e_6882f633dc38832a89cd2ab28196f676