### PR TITLE
Add JWT generation utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,17 @@ production deployments. Instead, create a Kubernetes `Secret` and mount it as an
 environment variable or file. Both the API and UI startup scripts will read a
 `SECRET_KEY_FILE` path if provided to load the key securely.
 
+**Important:** The UI and API must use the same `SECRET_KEY` value. If these values differ, the UI cannot verify JWT tokens issued by the API and users may be redirected back to the login page repeatedly.
+
+### Generating Test JWT Tokens
+For manual testing you can generate a signed JWT from the command line:
+
+```bash
+python utils/generate_jwt.py --username alice --secret "$SECRET_KEY"
+```
+
+The script outputs a token signed with the provided secret (or `SECRET_KEY` environment variable) that expires in 60 minutes by default. Adjust the `--expire` flag to change the expiration window.
+
 ### Offline UI Docker Builds
 The UI Dockerfile installs Node.js dependencies at build time. In environments
 without internet access this step may fail. The build now logs a warning and

--- a/ai-stock-platform/ui/.env.example
+++ b/ai-stock-platform/ui/.env.example
@@ -3,7 +3,8 @@
 # Application Settings
 ENV=development
 DEBUG=true
-SECRET_KEY=change_this_to_a_random_secure_string
+# This key must match the API SECRET_KEY for JWT validation
+SECRET_KEY=your-secret-key-here
 PORT=8000
 HOST=0.0.0.0
 WORKERS=4

--- a/utils/generate_jwt.py
+++ b/utils/generate_jwt.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Simple utility to generate a JWT token for testing.
+
+Usage:
+  python utils/generate_jwt.py --username alice --secret mysecret --expire 60
+
+If --secret is omitted, the script uses the SECRET_KEY environment variable or
+falls back to the example key from the repository.
+"""
+import argparse
+import os
+from datetime import datetime, timedelta
+
+import jwt
+
+DEFAULT_SECRET = os.getenv("SECRET_KEY", "your-secret-key-here")
+ALGORITHM = "HS256"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a JWT token")
+    parser.add_argument("--username", required=True, help="Username for the token (stored in 'sub')")
+    parser.add_argument("--secret", help="Secret key used to sign the token")
+    parser.add_argument("--expire", type=int, default=60, help="Expiration time in minutes")
+    args = parser.parse_args()
+
+    secret = args.secret or DEFAULT_SECRET
+    payload = {
+        "sub": args.username,
+        "exp": datetime.utcnow() + timedelta(minutes=args.expire),
+    }
+
+    token = jwt.encode(payload, secret, algorithm=ALGORITHM)
+    print(token)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `utils/generate_jwt.py` for quick token creation
- document how to use the script in README

## Testing
- `pytest -q` *(fails: 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6882f369389c832a84b1027f374347eb