### PR TITLE
Add RapidAPI service & env vars

### DIFF
--- a/ai-stock-platform/.env.template
+++ b/ai-stock-platform/.env.template
@@ -54,3 +54,6 @@ BACKEND_CORS_ORIGINS=["http://ui-service:3000","http://quantumvestai-dev-api:800
 # Storage Settings
 UPLOAD_DIR=/app/uploads
 TEMP_DIR=/tmp
+# Yahoo Finance via RapidAPI
+RAPIDAPI_HOST=apidojo-yahoo-finance-v1.p.rapidapi.com
+RAPIDAPI_KEY=your-rapidapi-key

--- a/ai-stock-platform/api/.env.example
+++ b/ai-stock-platform/api/.env.example
@@ -26,6 +26,8 @@ CORS_ORIGINS=http://quantumvestai-dev-api:8000,http://ui-service:3000
 # External APIs
 ALPHA_VANTAGE_API_KEY=your_alpha_vantage_api_key
 YAHOO_FINANCE_API_KEY=your_yahoo_finance_api_key
+RAPIDAPI_HOST=apidojo-yahoo-finance-v1.p.rapidapi.com
+RAPIDAPI_KEY=your_rapidapi_key
 
 # Feature toggles
 ENABLE_BACKTESTING=true

--- a/ai-stock-platform/api/config/.env.example
+++ b/ai-stock-platform/api/config/.env.example
@@ -26,6 +26,8 @@ CORS_ORIGINS=http://quantumvestai-dev-api:8000,http://ui-service:3000
 # External APIs
 ALPHA_VANTAGE_API_KEY=your_alpha_vantage_api_key
 YAHOO_FINANCE_API_KEY=your_yahoo_finance_api_key
+RAPIDAPI_HOST=apidojo-yahoo-finance-v1.p.rapidapi.com
+RAPIDAPI_KEY=your_rapidapi_key
 
 # Feature toggles
 ENABLE_BACKTESTING=true

--- a/ai-stock-platform/api/services/__init__.py
+++ b/ai-stock-platform/api/services/__init__.py
@@ -38,6 +38,14 @@ except ImportError as e:
     ForecastService = None
     FORECAST_SERVICE_AVAILABLE = False
 
+try:
+    from services.yahoo_rapidapi_service import YahooRapidAPIService
+    YAHOO_RAPIDAPI_SERVICE_AVAILABLE = True
+except ImportError as e:
+    print(f"Warning: YahooRapidAPIService not available - {e}")
+    YahooRapidAPIService = None
+    YAHOO_RAPIDAPI_SERVICE_AVAILABLE = False
+
 # Only include available services in __all__
 __all__ = []
 if STOCK_SERVICE_AVAILABLE:
@@ -48,3 +56,5 @@ if TRENDING_STOCKS_SERVICE_AVAILABLE:
     __all__.append('TrendingStocksService')
 if FORECAST_SERVICE_AVAILABLE:
     __all__.append('ForecastService')
+if YAHOO_RAPIDAPI_SERVICE_AVAILABLE:
+    __all__.append('YahooRapidAPIService')

--- a/ai-stock-platform/api/services/yahoo_rapidapi_service.py
+++ b/ai-stock-platform/api/services/yahoo_rapidapi_service.py
@@ -1,0 +1,40 @@
+"""Yahoo Finance RapidAPI Service.
+
+Provides access to Yahoo Finance data via RapidAPI using environment variables.
+"""
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class YahooRapidAPIService:
+    """Fetch data from Yahoo Finance through RapidAPI."""
+
+    @classmethod
+    def get_timeseries(cls, symbol: str, region: str = "US") -> Optional[Dict[str, Any]]:
+        """Return timeseries data for a symbol.
+
+        If the RAPIDAPI_KEY environment variable is not set the method
+        returns ``None`` without making a network request.
+        """
+        host = os.getenv("RAPIDAPI_HOST", "apidojo-yahoo-finance-v1.p.rapidapi.com")
+        api_key = os.getenv("RAPIDAPI_KEY")
+        if not api_key:
+            logger.warning("RAPIDAPI_KEY not configured")
+            return None
+
+        url = f"https://{host}/stock/v2/get-timeseries"
+        headers = {"x-rapidapi-host": host, "x-rapidapi-key": api_key}
+        params = {"symbol": symbol, "region": region}
+        try:
+            resp = requests.get(url, headers=headers, params=params, timeout=10)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.error("Failed to fetch timeseries: %s", exc)
+            return None
+

--- a/tests/test_yahoo_rapidapi_service.py
+++ b/tests/test_yahoo_rapidapi_service.py
@@ -1,0 +1,31 @@
+import os
+from services.yahoo_rapidapi_service import YahooRapidAPIService
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._data
+
+
+def test_no_api_key(monkeypatch):
+    monkeypatch.delenv("RAPIDAPI_KEY", raising=False)
+    assert YahooRapidAPIService.get_timeseries("IBM") is None
+
+
+def test_success(monkeypatch):
+    monkeypatch.setenv("RAPIDAPI_KEY", "test")
+    monkeypatch.setenv("RAPIDAPI_HOST", "example.com")
+
+    def fake_get(url, headers, params, timeout):
+        assert url == "https://example.com/stock/v2/get-timeseries"
+        assert headers["x-rapidapi-key"] == "test"
+        assert params["symbol"] == "IBM"
+        return DummyResp({"ok": True})
+
+    monkeypatch.setattr("requests.get", fake_get)
+    result = YahooRapidAPIService.get_timeseries("IBM")
+    assert result == {"ok": True}


### PR DESCRIPTION
## Summary
- implement `YahooRapidAPIService` to pull timeseries data from RapidAPI using environment variables
- expose new service through the `services` package
- document `RAPIDAPI_HOST` and `RAPIDAPI_KEY` in example `.env` files
- test service behaviour when env vars are present or missing

## Testing
- `pytest tests/test_yahoo_rapidapi_service.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'APIClient' from partially initialized module)*

------
https://chatgpt.com/codex/tasks/task_e_6883036fb0a4832a9ef54502600b321a