### PR TITLE
Add unified secrets manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ production deployments. Instead, create a Kubernetes `Secret` and mount it as an
 environment variable or file. Both the API and UI startup scripts will read a
 `SECRET_KEY_FILE` path if provided to load the key securely.
 
+All Kubernetes secrets for the application are consolidated in
+`ci-cd/k8s/all-secrets.yaml`. Populate this file with your base64-encoded values
+and apply it once using:
+
+```bash
+kubectl apply -f ci-cd/k8s/all-secrets.yaml
+```
+
+This single file avoids managing multiple secret manifests across environments.
+
 **Important:** The UI and API must use the same `SECRET_KEY` value. If these values differ, the UI cannot verify JWT tokens issued by the API and users may be redirected back to the login page repeatedly.
 
 ### Generating Test JWT Tokens

--- a/TWITTER_API_SETUP.md
+++ b/TWITTER_API_SETUP.md
@@ -73,22 +73,14 @@ TWITTER_ACCESS_TOKEN_SECRET=your_access_token_secret
 
 #### For Production (Kubernetes)
 
-1. Create a Kubernetes secret with your Twitter credentials:
+1. Add your Twitter credentials to `ci-cd/k8s/all-secrets.yaml` and apply the
+   file. This consolidated manifest stores all application secrets in one place:
 
 ```bash
-# Using the provided script
-cd ci-cd/k8s/
-echo "TWITTER_BEARER_TOKEN=your_bearer_token" >> .env.secrets
-echo "TWITTER_API_KEY=your_api_key" >> .env.secrets
-echo "TWITTER_API_SECRET=your_api_secret" >> .env.secrets
-echo "TWITTER_ACCESS_TOKEN=your_access_token" >> .env.secrets
-echo "TWITTER_ACCESS_TOKEN_SECRET=your_access_token_secret" >> .env.secrets
-
-# Create the secret
-./create-secrets.sh
+kubectl apply -f ci-cd/k8s/all-secrets.yaml
 ```
 
-2. Or create the secret manually:
+2. If you prefer to create a standalone secret you can still run:
 
 ```bash
 kubectl create secret generic twitter-secrets \

--- a/ci-cd/k8s/all-secrets.yaml
+++ b/ci-cd/k8s/all-secrets.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets
+  namespace: dev
+  labels:
+    app: quantumvestai
+    component: application
+    environment: dev
+type: Opaque
+data:
+  JWT_SECRET: e6kke6hxSVAF5DBiiLb7oD7uQIjG40DLL2QnTKu8uw4=
+  ADMIN_USERNAME: YWRtaW4=
+  ADMIN_PASSWORD: YWRtaW4=
+  ADMIN_EMAIL: ZGFwYXJ0aGkuZ2F5YXRyaUBnbWFpbC5jb20=
+  ALPHA_VANTAGE_API_KEY: YWxwaGEtdGVzdA==
+  RAPIDAPI_KEY: MjVhOTc4MTE3OG1zaDQ1ZjkyODllZWVlYzE4MXAxNDEwZGZqc25jMzFlMmFmMjE5Mzc=
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: twitter-secrets
+  namespace: dev
+  labels:
+    app: quantumvestai
+    component: twitter
+    environment: dev
+type: Opaque
+data:
+  TWITTER_CONSUMER_KEY: YVhLWGxVcHVidDNRQ3piM0tITm5PVVBibw==
+  TWITTER_CONSUMER_SECRET: aVdFZlV6YU85TmJWT0lXNk05M2ZBZkFSTWJ2cTJrd2VmdVp6aDYzMUF6bXFLdFIwZTA=
+  TWITTER_ACCESS_TOKEN: MTkxOTU4NjU1ODY2OTQyMjU5Mi16QkpQVGVLYW9xaVgxTjUyM1liWFJHR25QcWJjZnc=
+  TWITTER_ACCESS_SECRET: STlIODkzbm1sRkpzdkwwWXVNdFYweHpKN0FYbG1LUEVYNHlXWkpSb1Fad2Vl
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: quantumvestai-cluster-rds-credentials
+  namespace: dev
+  labels:
+    app: quantumvestai
+    component: database
+    environment: dev
+type: Opaque
+data:
+  database: cXVhbnR1bXZlc3RhaWRi
+  dbname: cXVhbnR1bXZlc3RhaWRi
+  endpoint: cXVhbnR1bXZlc3RhaS1kZXYuY3dic3FzaXl3d2FhLnVzLWVhc3QtMS5yZHMuYW1hem9uYXdzLmNvbTo1NDMy
+  host: cXVhbnR1bXZlc3RhaS1kZXYuY3dic3FzaXl3d2FhLnVzLWVhc3QtMS5yZHMuYW1hem9uYXdzLmNvbQ==
+  password: NzVMZXJLJTBfSjx0JEh9Wg==
+  port: NTQzMg==
+  username: ZGJhZG1pbg==
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ui-secrets
+  namespace: dev
+  labels:
+    app: quantumvestai
+    component: ui
+    environment: dev
+type: Opaque
+data:
+  JWT_SECRET_KEY: e6kke6hxSVAF5DBiiLb7oD7uQIjG40DLL2QnTKu8uw4=
+  YAHOO_FINANCE_API_KEY:
+  TWITTER_API_KEY: YVhLWGxVcHVidDNRQ3piM0tITm5PVVBibw==
+  TWITTER_API_SECRET: aVdFZlV6YU85TmJWT0lXNk05M2ZBZkFSTWJ2cTJrd2VmdVp6aDYzMUF6bXFLdFIwZTA=
+  TWITTER_ACCESS_TOKEN: MTkxOTU4NjU1ODY2OTQyMjU5Mi16QkpQVGVLYW9xaVgxTjUyM1liWFJHR25QcWJjZnc=
+  TWITTER_ACCESS_SECRET: STlIODkzbm1sRkpzdkwwWXVNdFYweHpKN0FYbG1LUEVYNHlXWkpSb1Fad2Vl
+  ALPHA_VANTAGE_API_KEY: WkFUN1pJN0VHUzhWREEyQQ==
+  RAPIDAPI_KEY: <base64-encoded-rapidapi-key>


### PR DESCRIPTION
## Summary
- document new consolidated Kubernetes secrets manifest
- simplify Twitter API production setup instructions
- create `all-secrets.yaml` with all EKS secrets

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ImportError in api tests)*

------
https://chatgpt.com/codex/tasks/task_e_688316329458832aa9a77053dee25932