### PR TITLE
Ensure JWT secret from environment

### DIFF
--- a/ai-stock-platform/api/core/security/tokens.py
+++ b/ai-stock-platform/api/core/security/tokens.py
@@ -12,7 +12,8 @@ from core.config import get_settings
 config = get_settings()
 
 class TokenHandler:
-    SECRET_KEY = config.SECRET_KEY
+    # Use JWT_SECRET value if provided, falling back to SECRET_KEY
+    SECRET_KEY = config.JWT_SECRET.get_secret_value() if hasattr(config, "JWT_SECRET") else config.SECRET_KEY
     ALGORITHM = config.ALGORITHM
     ACCESS_TOKEN_EXPIRE_MINUTES = config.ACCESS_TOKEN_EXPIRE_MINUTES
 

--- a/ai-stock-platform/ui/auth/dependencies.py
+++ b/ai-stock-platform/ui/auth/dependencies.py
@@ -21,7 +21,8 @@ oauth2_scheme = HTTPBearer(auto_error=False)
 logger = logging.getLogger(__name__)
 
 # JWT Configuration
-JWT_SECRET_KEY = os.getenv("SECRET_KEY", "default-dev-key")
+# Prefer JWT_SECRET but fall back to SECRET_KEY for backward compatibility
+JWT_SECRET_KEY = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "default-dev-key")
 JWT_ALGORITHM = "HS256"
 TOKEN_EXPIRE_MINUTES = int(os.getenv("TOKEN_EXPIRE_MINUTES", "60"))
 

--- a/ai-stock-platform/ui/config/auth.dependencies.py
+++ b/ai-stock-platform/ui/config/auth.dependencies.py
@@ -13,7 +13,8 @@ import jwt
 logger = logging.getLogger(__name__)
 
 # JWT Configuration
-JWT_SECRET_KEY = os.getenv("SECRET_KEY", "default-dev-key")
+# Prefer JWT_SECRET but fall back to SECRET_KEY for backward compatibility
+JWT_SECRET_KEY = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "default-dev-key")
 JWT_ALGORITHM = "HS256"
 TOKEN_EXPIRE_MINUTES = int(os.getenv("TOKEN_EXPIRE_MINUTES", "60"))
 

--- a/ai-stock-platform/ui/middleware/auth_middleware.py
+++ b/ai-stock-platform/ui/middleware/auth_middleware.py
@@ -7,6 +7,7 @@ API requests receive a 401 JSON response.
 """
 
 import logging
+import os
 from typing import Any, Dict, Optional
 from datetime import timedelta, datetime
 
@@ -24,7 +25,7 @@ try:
     from core.config import settings
 except Exception:  # pragma: no cover - fallback for demo mode
     class Settings:
-        SECRET_KEY = "supersecretkey123456789abcdef"
+        SECRET_KEY = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "supersecretkey123456789abcdef")
         JWT_ALGORITHM = "HS256"
         ACCESS_TOKEN_EXPIRE_MINUTES = 30
 

--- a/ai-stock-platform/ui/templates/auth/dependencies.py
+++ b/ai-stock-platform/ui/templates/auth/dependencies.py
@@ -14,7 +14,8 @@ from fastapi import HTTPException, status
 logger = logging.getLogger(__name__)
 
 # JWT Configuration
-JWT_SECRET_KEY = os.getenv("SECRET_KEY", "default-dev-key")
+# Prefer JWT_SECRET but fall back to SECRET_KEY for backward compatibility
+JWT_SECRET_KEY = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "default-dev-key")
 JWT_ALGORITHM = "HS256"
 TOKEN_EXPIRE_MINUTES = int(os.getenv("TOKEN_EXPIRE_MINUTES", "60"))
 


### PR DESCRIPTION
## Summary
- prefer `JWT_SECRET` env variable in UI dependencies
- load fallback JWT secret from env in auth middleware
- use JWT_SECRET in token handler

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ImportError in test modules)*

------
https://chatgpt.com/codex/tasks/task_e_68831c5fa4ec832a838882c5eca5a71b