### PR TITLE
Add WebSocket origin validation

### DIFF
--- a/ai-stock-platform/api/core/middleware/cors.py
+++ b/ai-stock-platform/api/core/middleware/cors.py
@@ -13,9 +13,10 @@ from fastapi.middleware.cors import CORSMiddleware
 # Try to import settings safely
 try:
     from core.config import settings
-    FRONTEND_URL = getattr(settings, 'FRONTEND_URL', 'http://ui-service:3000')
+
+    FRONTEND_URL = getattr(settings, "FRONTEND_URL", "http://ui-service:3000")
 except ImportError:
-    FRONTEND_URL = os.environ.get('FRONTEND_URL', 'http://ui-service:3000')
+    FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://ui-service:3000")
 
 
 def get_cors_origins() -> List[str]:
@@ -24,7 +25,7 @@ def get_cors_origins() -> List[str]:
     cors_origins_env = os.environ.get("CORS_ORIGINS")
     if cors_origins_env:
         return [origin.strip() for origin in cors_origins_env.split(",")]
-    
+
     # Default origins for development and production
     default_origins = [
         FRONTEND_URL,
@@ -40,46 +41,54 @@ def get_cors_origins() -> List[str]:
         "https://quantumvestai.com",
         "https://www.quantumvestai.com",
         "https://app.quantumvestai.com",
-        "https://api.quantumvestai.com"
+        "https://api.quantumvestai.com",
     ]
-    
+
     # Only allow wildcard in development
     if os.environ.get("ENVIRONMENT", "development").lower() == "development":
         default_origins.append("*")
-    
+
     return default_origins
+
+
+def is_origin_allowed(origin: str | None, allowed: List[str] | None = None) -> bool:
+    """Return True if the origin is allowed based on CORS settings."""
+    if allowed is None:
+        allowed = get_cors_origins()
+
+    if "*" in allowed:
+        # Wildcard allows any origin, but reject missing origin for security
+        return origin is not None
+
+    return bool(origin) and origin in allowed
 
 
 def configure_cors(app: FastAPI) -> FastAPI:
     """Configure CORS for the FastAPI application with enhanced security"""
-    
+
     origins = get_cors_origins()
-    
+
     # Log CORS configuration
     import logging
+
     logger = logging.getLogger("api")
     logger.info(f"Configuring CORS with origins: {origins}")
-    
+
     # Determine if we should allow credentials
     allow_credentials = True
-    
+
     # If wildcard is in origins, we cannot allow credentials
     if "*" in origins:
         allow_credentials = False
-        logger.warning("Wildcard (*) in CORS origins detected. Credentials will be disabled.")
-    
+        logger.warning(
+            "Wildcard (*) in CORS origins detected. Credentials will be disabled."
+        )
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=origins,
         allow_credentials=allow_credentials,
-        allow_methods=[
-            "GET",
-            "POST", 
-            "PUT",
-            "DELETE",
-            "OPTIONS",
-            "PATCH"
-        ],
+        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
         allow_headers=[
             "Content-Type",
             "Authorization",
@@ -88,7 +97,7 @@ def configure_cors(app: FastAPI) -> FastAPI:
             "Accept",
             "Accept-Language",
             "Cache-Control",
-            "User-Agent"
+            "User-Agent",
         ],
         expose_headers=[
             "X-Request-ID",
@@ -96,29 +105,29 @@ def configure_cors(app: FastAPI) -> FastAPI:
             "X-RateLimit-Limit",
             "X-RateLimit-Remaining",
             "X-RateLimit-Used",
-            "X-RateLimit-Window"
+            "X-RateLimit-Window",
         ],
         max_age=86400,  # Cache preflight requests for 24 hours
     )
-    
+
     return app
 
 
 def configure_cors_strict(app: FastAPI) -> FastAPI:
     """Configure CORS with strict settings for production"""
-    
+
     # Production-only origins (no wildcards)
     origins = [
         "https://quantumvestai.com",
         "https://www.quantumvestai.com",
-        "https://app.quantumvestai.com"
+        "https://app.quantumvestai.com",
     ]
-    
+
     # Add custom origins from environment
     custom_origins = os.environ.get("CORS_ORIGINS_STRICT")
     if custom_origins:
         origins.extend([origin.strip() for origin in custom_origins.split(",")])
-    
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=origins,
@@ -128,5 +137,5 @@ def configure_cors_strict(app: FastAPI) -> FastAPI:
         expose_headers=["X-Request-ID", "X-Process-Time"],
         max_age=86400,
     )
-    
+
     return app

--- a/ai-stock-platform/api/routers/websocket.py
+++ b/ai-stock-platform/api/routers/websocket.py
@@ -8,8 +8,10 @@ from datetime import datetime
 from typing import Optional
 
 from core.security import get_current_user
+from core.middleware.cors import is_origin_allowed
 from db.models.user import User
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
 # Import the local websocket manager using a relative import to avoid package
 # resolution issues when the application is executed as a module
 # Import the local websocket manager using an absolute path so the module works
@@ -22,14 +24,19 @@ router = APIRouter()
 
 manager = ConnectionManager()
 
+
 @router.websocket("/ws/{client_id}")
 async def websocket_endpoint(
-    websocket: WebSocket,
-    client_id: str,
-    token: Optional[str] = None
+    websocket: WebSocket, client_id: str, token: Optional[str] = None
 ):
     """WebSocket endpoint for real-time updates"""
     try:
+        origin = websocket.headers.get("origin")
+        if not is_origin_allowed(origin):
+            logger.warning(f"Rejected WebSocket connection from origin: {origin}")
+            await websocket.close(code=1008)
+            return
+
         # Verify token if provided
         user = None
         if token:
@@ -38,22 +45,22 @@ async def websocket_endpoint(
             except Exception as e:
                 await websocket.close(code=4001, reason="Invalid token")
                 return
-        
+
         # Connect to WebSocket
         await manager.connect(websocket, client_id)
         logger.info(f"WebSocket connected: {client_id}")
-        
+
         try:
             while True:
                 # Receive message
                 data = await websocket.receive_json()
-                
+
                 # Add metadata
                 data["timestamp"] = datetime.utcnow().isoformat()
                 data["client_id"] = client_id
                 if user:
                     data["user_id"] = user.id
-                
+
                 # Process message based on type
                 message_type = data.get("type")
                 if message_type == "subscribe":
@@ -64,19 +71,21 @@ async def websocket_endpoint(
                     await handle_unsubscription(websocket, data, user)
                 else:
                     # Handle unknown message type
-                    await websocket.send_json({
-                        "error": "Unknown message type",
-                        "timestamp": datetime.utcnow().isoformat()
-                    })
-        
+                    await websocket.send_json(
+                        {
+                            "error": "Unknown message type",
+                            "timestamp": datetime.utcnow().isoformat(),
+                        }
+                    )
+
         except WebSocketDisconnect:
             await manager.disconnect(websocket, client_id)
             logger.info(f"WebSocket disconnected: {client_id}")
-        
+
         except Exception as e:
             logger.error(f"WebSocket error for {client_id}: {str(e)}")
             await websocket.close(code=4000, reason="Internal server error")
-    
+
     except Exception as e:
         logger.error(f"WebSocket connection error: {str(e)}")
         try:
@@ -84,31 +93,36 @@ async def websocket_endpoint(
         except:
             pass
 
+
 async def handle_subscription(websocket: WebSocket, data: dict, user: Optional[User]):
     """Handle subscription requests"""
     try:
         payload = data.get("data", data)
         topic = payload.get("type") or payload.get("symbol") or payload.get("topic")
         if not topic:
-            await websocket.send_json({
-                "error": "Missing topic in subscription request",
-                "timestamp": datetime.utcnow().isoformat()
-            })
+            await websocket.send_json(
+                {
+                    "error": "Missing topic in subscription request",
+                    "timestamp": datetime.utcnow().isoformat(),
+                }
+            )
             return
 
         await manager.subscribe(websocket, topic)
-        await websocket.send_json({
-            "type": "subscribed",
-            "topic": topic,
-            "timestamp": datetime.utcnow().isoformat()
-        })
-        
+        await websocket.send_json(
+            {
+                "type": "subscribed",
+                "topic": topic,
+                "timestamp": datetime.utcnow().isoformat(),
+            }
+        )
+
     except Exception as e:
         logger.error(f"Subscription error: {str(e)}")
-        await websocket.send_json({
-            "error": "Subscription failed",
-            "timestamp": datetime.utcnow().isoformat()
-        })
+        await websocket.send_json(
+            {"error": "Subscription failed", "timestamp": datetime.utcnow().isoformat()}
+        )
+
 
 async def handle_unsubscription(websocket: WebSocket, data: dict, user: Optional[User]):
     """Handle unsubscription requests"""
@@ -116,21 +130,28 @@ async def handle_unsubscription(websocket: WebSocket, data: dict, user: Optional
         payload = data.get("data", data)
         topic = payload.get("type") or payload.get("symbol") or payload.get("topic")
         if not topic:
-            await websocket.send_json({
-                "error": "Missing topic in unsubscription request",
-                "timestamp": datetime.utcnow().isoformat()
-            })
+            await websocket.send_json(
+                {
+                    "error": "Missing topic in unsubscription request",
+                    "timestamp": datetime.utcnow().isoformat(),
+                }
+            )
             return
 
         await manager.unsubscribe(websocket, topic)
-        await websocket.send_json({
-            "type": "unsubscribed",
-            "topic": topic,
-            "timestamp": datetime.utcnow().isoformat()
-        })
-        
+        await websocket.send_json(
+            {
+                "type": "unsubscribed",
+                "topic": topic,
+                "timestamp": datetime.utcnow().isoformat(),
+            }
+        )
+
     except Exception as e:
         logger.error(f"Unsubscription error: {str(e)}")
-        await websocket.send_json({
-            "error": "Unsubscription failed",
-            "timestamp": datetime.utcnow().isoformat()        })
+        await websocket.send_json(
+            {
+                "error": "Unsubscription failed",
+                "timestamp": datetime.utcnow().isoformat(),
+            }
+        )


### PR DESCRIPTION
## Summary
- check websocket origin in router to reject unknown origins
- expose helper `is_origin_allowed` in CORS middleware

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688324b51ad4832a9420b2b4edbfabcb