### PR TITLE
Fix responsive nav layout

### DIFF
--- a/ai-stock-platform/ui/src/components/layout/Layout.tsx
+++ b/ai-stock-platform/ui/src/components/layout/Layout.tsx
@@ -178,7 +178,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
               <span className="quantum-text-gradient">QuantumVestAI</span>
             </Navbar.Brand>
 
-            <Nav className="ms-auto d-flex align-items-center">
+            <Nav className="ms-auto d-flex align-items-center gap-2">
               <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
                 <Button
                   variant="outline-secondary"
@@ -209,7 +209,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       <div className="d-flex">
         {/* Enhanced Desktop Sidebar */}
         <motion.div
-          className="quantum-sidebar d-none d-lg-block"
+          className="quantum-sidebar d-lg-none"
           variants={sidebarVariants}
           initial={{ x: -280, opacity: 0 }}
           animate={sidebarCollapsed ? 'collapsed' : 'expanded'}
@@ -321,7 +321,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           show={showSidebar}
           onHide={() => setShowSidebar(false)}
           placement="start"
-          className="quantum-mobile-sidebar"
+          className="quantum-mobile-sidebar d-lg-none"
         >
           <Offcanvas.Header closeButton className="quantum-card-header">
             <Offcanvas.Title className="quantum-text-gradient">

--- a/ai-stock-platform/ui/src/styles/quantum-components.css
+++ b/ai-stock-platform/ui/src/styles/quantum-components.css
@@ -164,6 +164,11 @@
   border-right: 1px solid var(--glass-border);
 }
 
+/* Ensure mobile sidebar overlays content properly */
+.quantum-mobile-sidebar {
+  z-index: 1055;
+}
+
 .quantum-mobile-icon {
   display: flex;
   align-items: center;
@@ -275,9 +280,15 @@
   .quantum-sidebar {
     transform: translateX(-100%);
   }
-  
+
   .quantum-sidebar.show {
     transform: translateX(0);
+  }
+}
+
+@media (min-width: 992px) {
+  .quantum-sidebar {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- hide the sidebar on larger screens with CSS rules
- show the mobile offcanvas only on small screens
- tweak navbar item spacing
- ensure offcanvas overlays content correctly

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q` *(fails: 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688329b9bfe8832a9618f00c962b1762