### PR TITLE
Add stock flow route

### DIFF
--- a/ai-stock-platform/ui/controllers/stock_controller.py
+++ b/ai-stock-platform/ui/controllers/stock_controller.py
@@ -226,6 +226,27 @@ async def stock_detail(
             status_code=500
         )
 
+
+@router.get("/stocks/flow", response_class=HTMLResponse)
+async def stock_flow_page(request: Request):
+    """Display interactive stock flow visualization page."""
+    try:
+        return get_templates(request).TemplateResponse(
+            "stocks/flow.html",
+            {
+                "request": request,
+                "user": None,
+                "demo_mode": True,
+            },
+        )
+    except Exception as e:  # pragma: no cover - template errors
+        logger.error(f"Error loading stock flow page: {str(e)}")
+        return get_templates(request).TemplateResponse(
+            "error.html",
+            {"request": request, "error": "Unable to load stock flow page"},
+            status_code=500,
+        )
+
 @router.post("/stock/{ticker}/add-to-watchlist")
 async def add_to_watchlist(
     request: Request,

--- a/ai-stock-platform/ui/tests/test_routes/test_stock_flow.py
+++ b/ai-stock-platform/ui/tests/test_routes/test_stock_flow.py
@@ -1,0 +1,6 @@
+"""Tests for the stock flow route."""
+
+def test_stock_flow_page(client):
+    response = client.get("/stocks/flow")
+    assert response.status_code == 200
+    assert "Stock Flow Visualization" in response.text


### PR DESCRIPTION
## Summary
- serve `/stocks/flow` template from stock controller
- test new stock flow route

## Testing
- `pytest ai-stock-platform/ui/tests/test_routes/test_stock_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68832fb4bd28832a992e84eae38a8968