### PR TITLE
Add links to sentiment workaround guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This document provides a comprehensive list of API and UI endpoints for the QuantumVestAI application.
 For screenshots and icons used in the interface, see [UI Visuals](docs/UI_IMAGES.md).
 For instructions on integrating ChatGPT into the UI, see [ChatGPT Guide](docs/CHATGPT_UI_INTEGRATION.md).
+For strategies to gather social sentiment without a paid Twitter plan, see [Sentiment Workarounds](docs/SENTIMENT_WORKAROUNDS.md).
 
 ---
 

--- a/TWITTER_API_SETUP.md
+++ b/TWITTER_API_SETUP.md
@@ -2,6 +2,10 @@
 
 This guide explains how to set up and configure the Twitter API integration for real-time social sentiment analysis in the QuantumVestAI application.
 
+If you do not have a paid Twitter plan or prefer free alternatives, see
+[Stock Sentiment Workarounds](docs/SENTIMENT_WORKAROUNDS.md) for ways to gather
+sentiment data without official API access.
+
 ## Overview
 
 The Twitter integration provides:

--- a/ai-stock-platform/ui/src/components/TwitterSentiment.tsx
+++ b/ai-stock-platform/ui/src/components/TwitterSentiment.tsx
@@ -62,7 +62,7 @@ const TwitterSentiment: React.FC<TwitterSentimentProps> = ({ ticker }) => {
       } catch (err: any) {
         // Check if this is a configuration error (HTTP 503)
         if (err.response && err.response.status === 503) {
-          setError('Twitter integration not configured. Please set up Twitter API credentials.');
+          setError('Twitter integration not configured. See docs/SENTIMENT_WORKAROUNDS.md for alternatives.');
         } else if (err.response && err.response.status === 429) {
           setError('Twitter API rate limit exceeded. Please try again later.');
         } else {

--- a/ai-stock-platform/ui/src/components/TwitterTrendingStocks.tsx
+++ b/ai-stock-platform/ui/src/components/TwitterTrendingStocks.tsx
@@ -56,7 +56,7 @@ const TwitterTrendingStocks: React.FC = () => {
       } catch (err: any) {
         console.error('Error fetching trending stocks:', err);
         if (err.response && err.response.status === 503) {
-          setError('Twitter integration not configured. Using demo data.');
+          setError('Twitter integration not configured. Using demo data. See docs/SENTIMENT_WORKAROUNDS.md for options.');
         } else {
           setError('Failed to load trending stocks');
         }

--- a/docs/SENTIMENT_WORKAROUNDS.md
+++ b/docs/SENTIMENT_WORKAROUNDS.md
@@ -1,0 +1,48 @@
+# Stock Sentiment Workarounds Without a Twitter Pro Plan
+
+This guide summarizes alternative approaches for collecting sentiment data when a paid Twitter plan is not available.
+
+## 1. Reddit & News APIs
+- Use [NewsAPI.org](https://newsapi.org) for financial headlines.
+- Query the Reddit API for subreddits such as `r/stocks` and `r/investing`.
+- Analyze text with models like **FinBERT** to obtain sentiment scores.
+
+These sources provide rich, real sentiment data without relying on Twitter.
+
+## 2. Public Twitter Search via Web Scraping
+Tools such as [`snscrape`](https://github.com/JustAnotherArchivist/snscrape) can fetch tweets without using the official API:
+
+```bash
+pip install snscrape
+```
+
+```python
+import snscrape.modules.twitter as sntwitter
+
+query = "$AAPL since:2024-07-01 until:2024-07-25"
+for tweet in sntwitter.TwitterSearchScraper(query).get_items():
+    print(f"{tweet.date} - @{tweet.user.username}: {tweet.content}")
+```
+
+⚠️ **Use cautiously.** Web scraping may conflict with Twitter's Terms of Service and should be limited to prototyping or personal experimentation.
+
+## 3. Financial News Providers
+Services like **Finviz**, **Yahoo Finance**, and **Alpha Vantage** offer:
+- Stock news and trending tickers
+- Market sentiment indicators
+- Additional financial data feeds
+
+## 4. Recommended Basic-Plan Architecture
+A possible setup without a paid Twitter subscription:
+
+```
+[Reddit API]         [NewsAPI]        [Twitter (limited)]
+      ↓                   ↓                    ↓
+ [Text Pipeline + FinBERT/NLTK sentiment model]
+      ↓
+ [QuantumVestAI Backend API] — Python/FastAPI
+      ↓
+ [Frontend UI] — React/Next.js
+```
+
+This approach keeps the application functional even on the basic plan while still delivering social sentiment insights.


### PR DESCRIPTION
## Summary
- cross-link sentiment workaround docs from Twitter setup guide
- surface the doc link in UI when Twitter integration is missing

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68833b07fd7c832a9ebc9f3e31b90494