### PR TITLE
Integrate PaperMoney trading service

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This document provides a comprehensive list of API and UI endpoints for the Quan
 For screenshots and icons used in the interface, see [UI Visuals](docs/UI_IMAGES.md).
 For instructions on integrating ChatGPT into the UI, see [ChatGPT Guide](docs/CHATGPT_UI_INTEGRATION.md).
 For strategies to gather social sentiment without a paid Twitter plan, see [Sentiment Workarounds](docs/SENTIMENT_WORKAROUNDS.md).
+For practice trading without risking capital, follow the [PaperMoney Setup](docs/PAPERMONEY_TRADING.md).
 
 ---
 

--- a/ai-stock-platform/api/services/paper_money_execution.py
+++ b/ai-stock-platform/api/services/paper_money_execution.py
@@ -1,0 +1,13 @@
+"""Compatibility wrapper for PaperMoneyExecutionService."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+_root = Path(__file__).resolve().parents[2]
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+from services.paper_money_execution import PaperMoneyExecutionService  # type: ignore[F401]
+
+__all__ = ["PaperMoneyExecutionService"]

--- a/docs/PAPERMONEY_TRADING.md
+++ b/docs/PAPERMONEY_TRADING.md
@@ -1,0 +1,27 @@
+# PaperMoney Paper Trading Setup
+
+This guide explains how to connect QuantumVestAI's order management system to the TD Ameritrade **paperMoney** environment for risk‑free practice trading.
+
+## 1. Create a TD Ameritrade Developer Account
+- Register at [developer.tdameritrade.com](https://developer.tdameritrade.com/).
+- Under **My Apps**, create a new application and note the _Consumer Key_.
+
+## 2. Configure OAuth Redirect URI
+- Set your application's redirect URI to `https://localhost` or a secure endpoint of your choosing.
+- Save the configuration so paperMoney can redirect back after user authorization.
+
+## 3. Obtain an Access Token
+- Direct the user to the TD Ameritrade OAuth URL with your Consumer Key and redirect URI.
+- After login, TD Ameritrade will redirect to the URI with an authorization code.
+- Exchange this code for an access token using the token endpoint. The token grants access to paperMoney order APIs.
+
+## 4. Use the paperMoney Endpoints
+- All trading requests should include the access token in the `Authorization` header.
+- Use the `/accounts/{accountId}/orders` endpoint for placing practice orders.
+- Responses from paperMoney mimic live trading but do not execute real trades.
+
+## 5. Integrate with OrderManagementService
+- Use the provided `PaperMoneyExecutionService` (found in `services/paper_money_execution.py`) which implements the same interface as `TradingExecutionService`.
+- Replace the dummy execution layer with this service when paper trading is enabled.
+
+With these steps, QuantumVestAI can send simulated trades to the paperMoney environment, allowing users to test strategies without risking capital.

--- a/services/paper_money_execution.py
+++ b/services/paper_money_execution.py
@@ -1,0 +1,84 @@
+"""TD Ameritrade paperMoney execution service for tests.
+
+This lightweight service posts orders to the TD Ameritrade paperMoney
+API so users can practice trading without risking capital.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import requests
+
+from ai-stock-platform.api.models.orders import Order, OrderStatus
+
+
+class PaperMoneyExecutionService:
+    """Simple HTTP client for the paperMoney order endpoints."""
+
+    def __init__(self, access_token: str, account_id: str):
+        self.base_url = os.getenv("TD_API_BASE_URL", "https://api.tdameritrade.com/v1")
+        self.access_token = access_token
+        self.account_id = account_id
+        self.logger = logging.getLogger(__name__)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json",
+        }
+
+    def _order_url(self, order_id: str | None = None) -> str:
+        url = f"{self.base_url}/accounts/{self.account_id}/orders"
+        if order_id:
+            return f"{url}/{order_id}"
+        return url
+
+    async def submit_order(self, order: Order) -> dict:
+        payload = {
+            "orderType": order.order_type.value,
+            "session": "NORMAL",
+            "duration": order.time_in_force.value,
+            "orderStrategyType": "SINGLE",
+            "orderLegCollection": [
+                {
+                    "instruction": "BUY" if order.side.upper() == "BUY" else "SELL",
+                    "quantity": order.quantity,
+                    "instrument": {"symbol": order.symbol, "assetType": "EQUITY"},
+                }
+            ],
+        }
+        if order.price is not None:
+            payload["price"] = order.price
+        try:
+            resp = requests.post(self._order_url(), json=payload, headers=self._headers(), timeout=10)
+            resp.raise_for_status()
+            self.logger.debug("Submitted paperMoney order %s", order.id)
+            return {"status": OrderStatus.ACCEPTED, "order_id": order.id}
+        except Exception as exc:  # pragma: no cover - network issues
+            self.logger.error("paperMoney order failed: %s", exc)
+            return {"status": "error", "reason": str(exc)}
+
+    async def cancel_order(self, order_id: str) -> dict:
+        try:
+            resp = requests.delete(self._order_url(order_id), headers=self._headers(), timeout=10)
+            resp.raise_for_status()
+            return {"success": True}
+        except Exception as exc:  # pragma: no cover - network issues
+            self.logger.error("paperMoney cancel failed: %s", exc)
+            return {"success": False, "error": str(exc)}
+
+    async def modify_order(self, order_id: str, new_quantity: int | None = None, new_price: float | None = None) -> dict:
+        payload: dict[str, object] = {}
+        if new_quantity is not None:
+            payload["quantity"] = new_quantity
+        if new_price is not None:
+            payload["price"] = new_price
+        try:
+            resp = requests.put(self._order_url(order_id), json=payload, headers=self._headers(), timeout=10)
+            resp.raise_for_status()
+            return {"success": True, "details": payload}
+        except Exception as exc:  # pragma: no cover - network issues
+            self.logger.error("paperMoney modify failed: %s", exc)
+            return {"success": False, "error": str(exc)}
+
+__all__ = ["PaperMoneyExecutionService"]


### PR DESCRIPTION
## Summary
- document how to enable paperMoney practice trading
- provide a PaperMoneyExecutionService for interacting with TD Ameritrade

## Testing
- `./setup_env.sh` *(install dependencies)*
- `source venv/bin/activate && pytest -q` *(fails: 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68837605a280832a8bab769cfee8d88b