### PR TITLE
Improve dark theme styling

### DIFF
--- a/ai-stock-platform/ui/src/styles/global.css
+++ b/ai-stock-platform/ui/src/styles/global.css
@@ -45,29 +45,24 @@
 }
 
 body {
-  font-family: var(--font-family);
+  font-family: 'Inter', sans-serif;
   line-height: 1.6;
   margin: 0;
   padding: 0;
-  background: var(--bg-primary);
-  color: var(--text-primary);
+  background-color: #0f172a;
+  color: #e2e8f0;
   transition: var(--transition);
   overflow-x: hidden;
-  
-  /* Apply quantum background effects */
-  background: linear-gradient(135deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
-  /* Prevent janky scrolling caused by fixed backgrounds */
-  background-attachment: scroll;
 }
 
 a {
-  color: var(--primary-color);
+  color: #60a5fa;
   text-decoration: none;
 }
 
 a:hover {
-  color: var(--secondary-color);
-  text-decoration: underline;
+  color: #38bdf8;
+  text-decoration: none;
 }
 
 /* Enhanced Loading States */
@@ -518,6 +513,8 @@ a:hover {
 
 /* Enhanced Dark Theme Support */
 .dark-theme {
+  background-color: #0f172a;
+  color: #e5e7eb;
   --bs-body-bg: var(--bg-primary);
   --bs-body-color: var(--text-primary);
   --bs-border-color: var(--border-color);
@@ -669,4 +666,60 @@ a:hover {
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+}
+/* Notification panel fix */
+.notification-panel {
+  padding: 1rem;
+  font-size: 0.9rem;
+  color: #cbd5e1;
+}
+
+.notification-panel a {
+  color: #93c5fd;
+  display: block;
+  margin-bottom: 0.6rem;
+}
+
+.notification-panel a:hover {
+  color: #38bdf8;
+}
+
+/* Navigation tab fix */
+.nav-tab {
+  background-color: #1e293b;
+  color: #cbd5e1;
+  border-radius: 0.5rem;
+  padding: 0.6rem 1.2rem;
+  margin: 0 6px;
+  transition: all 0.2s ease-in-out;
+}
+
+.nav-tab:hover {
+  background-color: #334155;
+  color: #ffffff;
+}
+
+.nav-tab.active {
+  background-color: #3b82f6;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+/* Search bar styling */
+.search-bar {
+  background-color: #334155;
+  color: #e2e8f0;
+  border-radius: 9999px;
+  padding: 0.6rem 1.2rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.search-bar input::placeholder {
+  color: #94a3b8;
+}
+
+.search-icon, .mic-icon, .filter-icon {
+  color: #cbd5e1;
 }

--- a/ai-stock-platform/ui/templates/admin/dashboard.html
+++ b/ai-stock-platform/ui/templates/admin/dashboard.html
@@ -271,16 +271,16 @@
             <div class="modal-body">
                 <ul class="nav nav-tabs" id="settingsTabs" role="tablist">
                     <li class="nav-item" role="presentation">
-                        <button class="nav-link active" id="general-tab" data-bs-toggle="tab" data-bs-target="#general" type="button" role="tab" aria-controls="general" aria-selected="true">General</button>
+                        <button class="nav-link nav-tab active" id="general-tab" data-bs-toggle="tab" data-bs-target="#general" type="button" role="tab" aria-controls="general" aria-selected="true">General</button>
                     </li>
                     <li class="nav-item" role="presentation">
-                        <button class="nav-link" id="api-tab" data-bs-toggle="tab" data-bs-target="#api" type="button" role="tab" aria-controls="api" aria-selected="false">API</button>
+                        <button class="nav-link nav-tab" id="api-tab" data-bs-toggle="tab" data-bs-target="#api" type="button" role="tab" aria-controls="api" aria-selected="false">API</button>
                     </li>
                     <li class="nav-item" role="presentation">
-                        <button class="nav-link" id="models-tab" data-bs-toggle="tab" data-bs-target="#models" type="button" role="tab" aria-controls="models" aria-selected="false">Models</button>
+                        <button class="nav-link nav-tab" id="models-tab" data-bs-toggle="tab" data-bs-target="#models" type="button" role="tab" aria-controls="models" aria-selected="false">Models</button>
                     </li>
                     <li class="nav-item" role="presentation">
-                        <button class="nav-link" id="notifications-tab" data-bs-toggle="tab" data-bs-target="#notifications" type="button" role="tab" aria-controls="notifications" aria-selected="false">Notifications</button>
+                        <button class="nav-link nav-tab" id="notifications-tab" data-bs-toggle="tab" data-bs-target="#notifications" type="button" role="tab" aria-controls="notifications" aria-selected="false">Notifications</button>
                     </li>
                 </ul>
                 <div class="tab-content p-3" id="settingsTabContent">

--- a/ai-stock-platform/ui/templates/admin/models.html
+++ b/ai-stock-platform/ui/templates/admin/models.html
@@ -109,22 +109,22 @@
 <!-- Tabs for model sections -->
 <ul class="nav nav-tabs mb-4" id="modelTabs" role="tablist">
     <li class="nav-item" role="presentation">
-        <button class="nav-link active" id="deployed-tab" data-bs-toggle="tab" data-bs-target="#deployed" type="button" role="tab" aria-controls="deployed" aria-selected="true">
+        <button class="nav-link nav-tab active" id="deployed-tab" data-bs-toggle="tab" data-bs-target="#deployed" type="button" role="tab" aria-controls="deployed" aria-selected="true">
             Deployed Models
         </button>
     </li>
     <li class="nav-item" role="presentation">
-        <button class="nav-link" id="training-tab" data-bs-toggle="tab" data-bs-target="#training" type="button" role="tab" aria-controls="training" aria-selected="false">
+        <button class="nav-link nav-tab" id="training-tab" data-bs-toggle="tab" data-bs-target="#training" type="button" role="tab" aria-controls="training" aria-selected="false">
             Training Jobs
         </button>
     </li>
     <li class="nav-item" role="presentation">
-        <button class="nav-link" id="accuracy-tab" data-bs-toggle="tab" data-bs-target="#accuracy" type="button" role="tab" aria-controls="accuracy" aria-selected="false">
+        <button class="nav-link nav-tab" id="accuracy-tab" data-bs-toggle="tab" data-bs-target="#accuracy" type="button" role="tab" aria-controls="accuracy" aria-selected="false">
             Accuracy Reports
         </button>
     </li>
     <li class="nav-item" role="presentation">
-        <button class="nav-link" id="settings-tab" data-bs-toggle="tab" data-bs-target="#settings" type="button" role="tab" aria-controls="settings" aria-selected="false">
+        <button class="nav-link nav-tab" id="settings-tab" data-bs-toggle="tab" data-bs-target="#settings" type="button" role="tab" aria-controls="settings" aria-selected="false">
             Model Settings
         </button>
     </li>

--- a/ai-stock-platform/ui/templates/forecast.html
+++ b/ai-stock-platform/ui/templates/forecast.html
@@ -80,16 +80,16 @@
     <div class="card-header">
         <ul class="nav nav-tabs card-header-tabs" id="stockTabs" role="tablist">
             <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="forecast-tab" data-bs-toggle="tab" data-bs-target="#forecast" type="button" role="tab" aria-controls="forecast" aria-selected="true">Forecast</button>
+                <button class="nav-link nav-tab active" id="forecast-tab" data-bs-toggle="tab" data-bs-target="#forecast" type="button" role="tab" aria-controls="forecast" aria-selected="true">Forecast</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="historical-tab" data-bs-toggle="tab" data-bs-target="#historical" type="button" role="tab" aria-controls="historical" aria-selected="false">Historical</button>
+                <button class="nav-link nav-tab" id="historical-tab" data-bs-toggle="tab" data-bs-target="#historical" type="button" role="tab" aria-controls="historical" aria-selected="false">Historical</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="technical-tab" data-bs-toggle="tab" data-bs-target="#technical" type="button" role="tab" aria-controls="technical" aria-selected="false">Technical</button>
+                <button class="nav-link nav-tab" id="technical-tab" data-bs-toggle="tab" data-bs-target="#technical" type="button" role="tab" aria-controls="technical" aria-selected="false">Technical</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="news-tab" data-bs-toggle="tab" data-bs-target="#news" type="button" role="tab" aria-controls="news" aria-selected="false">News</button>
+                <button class="nav-link nav-tab" id="news-tab" data-bs-toggle="tab" data-bs-target="#news" type="button" role="tab" aria-controls="news" aria-selected="false">News</button>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
## Summary
- tweak global dark theme colors
- style notification panels, nav tabs and search bar
- mark navigation tabs in templates with `nav-tab` class

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError, missing routes)*

------
https://chatgpt.com/codex/tasks/task_e_688383daafe4832a9831de6ae2bae7f9