### PR TITLE
Fix CORS origin wildcard

### DIFF
--- a/ai-stock-platform/api/core/middleware/cors.py
+++ b/ai-stock-platform/api/core/middleware/cors.py
@@ -57,8 +57,11 @@ def is_origin_allowed(origin: str | None, allowed: List[str] | None = None) -> b
         allowed = get_cors_origins()
 
     if "*" in allowed:
-        # Wildcard allows any origin, but reject missing origin for security
-        return origin is not None
+        # Wildcard allows any origin. In development environments we may not
+        # receive an Origin header (e.g., when connecting from non-browser
+        # clients). Accept the connection even if the header is missing to
+        # prevent unnecessary 403 errors during local testing.
+        return True
 
     return bool(origin) and origin in allowed
 


### PR DESCRIPTION
## Summary
- relax origin check when wildcard is allowed to avoid 403 errors for WebSockets

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'APIClient' from partially initialized module `services.api_client`)*

------
https://chatgpt.com/codex/tasks/task_e_688395d5b874832a8435ef0e18ddf176