### PR TITLE
Fix nav menu auto scroll

### DIFF
--- a/ai-stock-platform/ui/static/js/navigation.js
+++ b/ai-stock-platform/ui/static/js/navigation.js
@@ -22,7 +22,9 @@ class NavigationController {
         this.setupSearchFunctionality();
         this.setupDropdownMenus();
         this.setupTooltips();
-        this.setupScrollEffects();
+        // Scroll-based nav hiding caused unexpected jumping on some pages.
+        // Temporarily disable scroll effects to keep the main menu fixed.
+        // this.setupScrollEffects();
         this.setupKeyboardNavigation();
     }
     


### PR DESCRIPTION
## Summary
- stop calling scroll effects in navigation.js to keep menu fixed

## Testing
- `pytest -q` *(fails: 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68839640198c832a8be38764bdf92c02