### PR TITLE
Fix nav overlap and improve notification contrast

### DIFF
--- a/ai-stock-platform/ui/src/components/layout/Layout.tsx
+++ b/ai-stock-platform/ui/src/components/layout/Layout.tsx
@@ -185,6 +185,8 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                   size="sm"
                   className="me-3 quantum-btn-outline"
                   onClick={toggleTheme}
+                  title="Toggle theme"
+                  aria-label="Toggle theme"
                 >
                   {theme === 'dark' ? '☀️' : '🌙'}
                 </Button>

--- a/ai-stock-platform/ui/src/styles/global.css
+++ b/ai-stock-platform/ui/src/styles/global.css
@@ -668,20 +668,22 @@ a:hover {
   }
 }
 /* Notification panel fix */
+
 .notification-panel {
   padding: 1rem;
   font-size: 0.9rem;
-  color: #cbd5e1;
+  /* Improved contrast for readability */
+  color: #e2e8f0;
 }
 
 .notification-panel a {
-  color: #93c5fd;
+  color: #bfdbfe;
   display: block;
   margin-bottom: 0.6rem;
 }
 
 .notification-panel a:hover {
-  color: #38bdf8;
+  color: #60a5fa;
 }
 
 /* Navigation tab fix */

--- a/ai-stock-platform/ui/src/styles/quantum-components.css
+++ b/ai-stock-platform/ui/src/styles/quantum-components.css
@@ -183,7 +183,8 @@
   box-shadow: var(--quantum-shadow-soft);
   position: sticky !important;
   top: 0;
-  z-index: 1030;
+  /* Keep navigation above expanding sidebar */
+  z-index: 1050;
 }
 
 .quantum-nav .navbar-brand {


### PR DESCRIPTION
## Summary
- keep navbar above sidebar
- improve notification panel text contrast
- add accessibility tooltip for theme toggle

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q` *(fails: ModuleNotFoundError for models.orders)*

------
https://chatgpt.com/codex/tasks/task_e_6883ce2beb78832aaa60be3dd9feb36f