### PR TITLE
Enforce WebSocket auth token

### DIFF
--- a/ai-stock-platform/api/routers/websocket.py
+++ b/ai-stock-platform/api/routers/websocket.py
@@ -10,7 +10,7 @@ from typing import Optional
 from core.security import get_current_user
 from core.middleware.cors import is_origin_allowed
 from db.models.user import User
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Query
 
 # Import the local websocket manager using a relative import to avoid package
 # resolution issues when the application is executed as a module
@@ -27,9 +27,9 @@ manager = ConnectionManager()
 
 @router.websocket("/ws/{client_id}")
 async def websocket_endpoint(
-    websocket: WebSocket, client_id: str, token: Optional[str] = None
+    websocket: WebSocket, client_id: str, token: Optional[str] = Query(None)
 ):
-    """WebSocket endpoint for real-time updates"""
+    """WebSocket endpoint for real-time updates."""
     try:
         origin = websocket.headers.get("origin")
         if not is_origin_allowed(origin):
@@ -37,14 +37,17 @@ async def websocket_endpoint(
             await websocket.close(code=1008)
             return
 
-        # Verify token if provided
+        # Require and verify token
+        if not token:
+            await websocket.close(code=4001, reason="Token required")
+            return
+
         user = None
-        if token:
-            try:
-                user = await get_current_user(token)
-            except Exception as e:
-                await websocket.close(code=4001, reason="Invalid token")
-                return
+        try:
+            user = await get_current_user(token)
+        except Exception:
+            await websocket.close(code=4001, reason="Invalid token")
+            return
 
         # Connect to WebSocket
         await manager.connect(websocket, client_id)

--- a/ai-stock-platform/api/tests/test_websocket_broadcast.py
+++ b/ai-stock-platform/api/tests/test_websocket_broadcast.py
@@ -11,12 +11,14 @@ import pytest
 pytest.importorskip("httpx")
 
 from api.main import app, ws_manager
+from core.security import create_access_token
 from fastapi.testclient import TestClient
 
 
 def test_websocket_broadcasts_updates():
     client = TestClient(app)
-    with client.websocket_connect("/ws/test-client") as ws:
+    token = create_access_token({"sub": "testuser"})
+    with client.websocket_connect(f"/ws/test-client?token={token}") as ws:
         ws.send_json({"type": "subscribe", "data": {"symbol": "AAPL"}})
         resp = ws.receive_json()
         assert resp["type"] == "subscribed"

--- a/ai-stock-platform/ui/static/js/quantum-charts.js
+++ b/ai-stock-platform/ui/static/js/quantum-charts.js
@@ -145,8 +145,10 @@ class QuantumCharts {
         try {
             const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
             const clientId = this.options.clientId || 'market-data';
-            const wsUrl = `${protocol}//${window.location.host}/ws/${clientId}`;
-            
+            const token = window.authUtils && window.authUtils.getToken();
+            const query = token ? `?token=${encodeURIComponent(token)}` : '';
+            const wsUrl = `${protocol}//${window.location.host}/ws/${clientId}${query}`;
+
             this.websocket = new WebSocket(wsUrl);
             
             this.websocket.onopen = () => {


### PR DESCRIPTION
## Summary
- require an auth token for the `/ws/{client_id}` endpoint
- propagate token in `QuantumCharts` WebSocket connection
- update WebSocket broadcast test to supply a JWT

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'models.orders')*

------
https://chatgpt.com/codex/tasks/task_e_6883cfd85664832a94586e4d8f01c993