### PR TITLE
Fix trending fallback

### DIFF
--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -185,10 +185,27 @@ class TrendingStocksService:
 
                     if result:
                         stocks_data.append(result)
-        
+
+            # If all real-data fetches failed, fall back to mock data
+            if not stocks_data:
+                logger.warning("All real data fetches failed; falling back to mock data")
+                for symbol in self.trending_symbols:
+                    random.seed(symbol)
+                    stocks_data.append(
+                        {
+                            "symbol": symbol,
+                            "name": f"{symbol} Corp.",
+                            "price": round(random.uniform(100, 500), 2),
+                            "change": round(random.uniform(-5, 5), 2),
+                            "change_percent": round(random.uniform(-5, 5), 2),
+                            "volume": random.randint(1_000_000, 5_000_000),
+                            "last_updated": datetime.now().isoformat(),
+                        }
+                    )
+
         # Sort by change percentage (descending) for trending effect
         stocks_data.sort(key=lambda x: x.get("change_percent", 0), reverse=True)
-        
+
         return stocks_data
     
     async def _fetch_stock_quote(self, session, symbol: str) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- add fallback to trending stock service when real API calls fail

## Testing
- `pytest ai-stock-platform/api/tests/test_trending_stocks.py::test_get_trending_stocks -q`
- `pytest -q` *(fails: ModuleNotFoundError in test_order_management.py)*

------
https://chatgpt.com/codex/tasks/task_e_6883d99ef868832aaf153a0bab42efaf