### PR TITLE
Fix theme toggle consistency

### DIFF
--- a/ai-stock-platform/ui/static/js/navigation.js
+++ b/ai-stock-platform/ui/static/js/navigation.js
@@ -160,14 +160,17 @@ class NavigationController {
         if (!themeToggle) return;
         
         // Get saved theme or default to light
-        const savedTheme = localStorage.getItem('theme') || 'light';
+        // Keep theme consistent with the rest of the application by using the
+        // "quantum-theme" localStorage key (also referenced in base.html and
+        // quantum-enhancements.js). Fallback to light mode when not set.
+        const savedTheme = localStorage.getItem('quantum-theme') || 'light';
         this.setTheme(savedTheme);
-        
+
         themeToggle.addEventListener('click', () => {
             const currentTheme = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
             const newTheme = currentTheme === 'light' ? 'dark' : 'light';
             this.setTheme(newTheme);
-            localStorage.setItem('theme', newTheme);
+            localStorage.setItem('quantum-theme', newTheme);
         });
     }
     


### PR DESCRIPTION
## Summary
- fix theme toggle localStorage key in navigation script to match base template

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ImportError in API tests)*

------
https://chatgpt.com/codex/tasks/task_e_6883dd340258832abcb7411c5c6b8685