### PR TITLE
Add docs endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ For practice trading without risking capital, follow the [PaperMoney Setup](docs
 - **GET** `/api/v1/data/sectors/performance` - Get sector performance
 - **GET** `/api/v1/data/industries/performance` - Get industry performance
 
+## **Documentation APIs**
+- **GET** `/docs/readme` - Get repository README
+- **GET** `/docs/uses` - Get API usage guide
+
 ---
 Feel free to reach out for further assistance or to report issues!
 ## Environment Setup

--- a/ai-stock-platform/api/main.py
+++ b/ai-stock-platform/api/main.py
@@ -32,6 +32,7 @@ from routers.auth import router as auth_router
 from routers.websocket import manager as websocket_manager
 from routers.websocket import router as websocket_router
 from routers.social import router as social_router
+from routers.docs import router as docs_router
 import sentry_sdk
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 from fastapi import Response as FastAPIResponse
@@ -91,6 +92,7 @@ app.add_middleware(GZipMiddleware, minimum_size=500)
 app.include_router(websocket_router)
 app.include_router(auth_router, prefix="/api/v1/auth")
 app.include_router(social_router)
+app.include_router(docs_router)
 
 # Request logging middleware
 @app.middleware("http")

--- a/ai-stock-platform/api/routers/__init__.py
+++ b/ai-stock-platform/api/routers/__init__.py
@@ -5,5 +5,6 @@ Author: daparthi001
 """
 from routers.v1 import router as v1_router
 from routers.social import router as social_router
+from routers.docs import router as docs_router
 
-__all__ = ["v1_router", "social_router"]
+__all__ = ["v1_router", "social_router", "docs_router"]

--- a/ai-stock-platform/api/routers/docs.py
+++ b/ai-stock-platform/api/routers/docs.py
@@ -1,0 +1,24 @@
+"""Documentation Endpoints."""
+from pathlib import Path
+from fastapi import APIRouter, status
+from fastapi.responses import PlainTextResponse
+
+router = APIRouter(prefix="/docs", tags=["docs"])
+
+BASE_DIR = Path(__file__).resolve().parents[3]
+README_FILE = BASE_DIR / "README.md"
+USAGE_FILE = BASE_DIR / "docs" / "API_USES.md"
+
+
+@router.get("/readme", response_class=PlainTextResponse, status_code=status.HTTP_200_OK,
+            summary="Get README", description="Return the repository README file")
+async def get_readme() -> str:
+    return README_FILE.read_text()
+
+
+@router.get("/uses", response_class=PlainTextResponse, status_code=status.HTTP_200_OK,
+            summary="Get usage guide", description="Return documentation usage instructions")
+async def get_uses() -> str:
+    if USAGE_FILE.exists():
+        return USAGE_FILE.read_text()
+    return "Usage documentation not found."

--- a/ai-stock-platform/api/tests/test_docs.py
+++ b/ai-stock-platform/api/tests/test_docs.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "api"))
+
+import pytest
+pytest.importorskip("httpx")
+
+from api.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+
+def test_get_readme():
+    resp = client.get("/docs/readme")
+    assert resp.status_code == 200
+    assert "QuantumVestAI" in resp.text
+
+
+def test_get_uses():
+    resp = client.get("/docs/uses")
+    assert resp.status_code == 200
+    assert "Usage" in resp.text or "usage" in resp.text.lower()

--- a/docs/API_USES.md
+++ b/docs/API_USES.md
@@ -1,0 +1,8 @@
+# API Usage Guide
+
+This document provides usage information for the documentation endpoints.
+
+- **GET** `/docs/readme` returns the repository `README.md` content.
+- **GET** `/docs/uses` returns this usage guide.
+
+Use these endpoints to programmatically access QuantumVestAI documentation.


### PR DESCRIPTION
## Summary
- document new `/docs/readme` and `/docs/uses` API routes
- implement `docs` router with handlers to return README and usage guide
- expose the docs router from the main app
- include simple pytest coverage for docs endpoints

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ImportError: cannot import name 'APIClient' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6883dc67d53c832aaed13e477ec6a9ae