### PR TITLE
Enhance UI design with notifications & skeleton loaders

### DIFF
--- a/ai-stock-platform/ui/static/css/quantum-enhancements.css
+++ b/ai-stock-platform/ui/static/css/quantum-enhancements.css
@@ -1126,3 +1126,25 @@ body {
   width: 120px;
   border-radius: var(--radius-md);
 }
+
+/* Notification Cards */
+.notification-card {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: var(--space-sm) var(--space-md);
+  margin-bottom: var(--space-sm);
+  color: var(--text-primary, #e5e5e5);
+}
+
+.notification-card .notification-dismiss {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+}

--- a/ai-stock-platform/ui/static/js/quantum-dashboard.js
+++ b/ai-stock-platform/ui/static/js/quantum-dashboard.js
@@ -294,7 +294,15 @@ class QuantumDashboard {
 
     loadMarketData(widget) {
         const container = widget.querySelector('#market-indices');
-        
+
+        container.innerHTML = `
+            <div class="quantum-loading-skeleton">
+                <div class="quantum-skeleton quantum-skeleton-text"></div>
+                <div class="quantum-skeleton quantum-skeleton-text"></div>
+                <div class="quantum-skeleton quantum-skeleton-text"></div>
+            </div>`;
+
+        setTimeout(() => {
         const mockIndices = [
             { name: 'S&P 500', value: 4150.25, change: 1.25 },
             { name: 'NASDAQ', value: 12750.80, change: -0.85 },
@@ -310,11 +318,21 @@ class QuantumDashboard {
                 </div>
             </div>
         `).join('');
+        }, 500);
     }
 
     loadWatchlistData(widget) {
         const container = widget.querySelector('#watchlist-items');
-        
+
+        container.innerHTML = `
+            <div class="quantum-loading-skeleton">
+                <div class="quantum-skeleton quantum-skeleton-text"></div>
+                <div class="quantum-skeleton quantum-skeleton-text"></div>
+                <div class="quantum-skeleton quantum-skeleton-text"></div>
+            </div>`;
+
+        setTimeout(() => {
+
         const mockStocks = [
             { symbol: 'AAPL', name: 'Apple Inc.', price: 175.25, change: 2.15 },
             { symbol: 'GOOGL', name: 'Alphabet Inc.', price: 2650.80, change: -1.25 },
@@ -336,6 +354,7 @@ class QuantumDashboard {
                 </div>
             </div>
         `).join('');
+        }, 500);
     }
 
     loadNewsData(widget) {

--- a/ai-stock-platform/ui/templates/base.html
+++ b/ai-stock-platform/ui/templates/base.html
@@ -185,7 +185,7 @@
 
             <div class="nav-right">
                 <div class="nav-item">
-                    <button class="theme-toggle" id="themeToggle">
+                    <button class="theme-toggle" id="themeToggle" title="Dark Mode">
                         <i class="bi bi-moon-fill"></i>
                     </button>
                 </div>
@@ -200,7 +200,7 @@
                             <a href="#" class="mark-all-read">Mark all as read</a>
                         </div>
                         <div class="notifications-list">
-                            <a href="#" class="notification-item unread">
+                            <div class="notification-card unread">
                                 <div class="notification-icon warning">
                                     <i class="bi bi-exclamation-triangle"></i>
                                 </div>
@@ -208,8 +208,9 @@
                                     <p class="notification-text">AAPL price alert triggered at $180</p>
                                     <p class="notification-time">Just now</p>
                                 </div>
-                            </a>
-                            <a href="#" class="notification-item unread">
+                                <button class="notification-dismiss" aria-label="Dismiss">&times;</button>
+                            </div>
+                            <div class="notification-card unread">
                                 <div class="notification-icon info">
                                     <i class="bi bi-info-circle"></i>
                                 </div>
@@ -217,8 +218,9 @@
                                     <p class="notification-text">New forecast models available</p>
                                     <p class="notification-time">2 hours ago</p>
                                 </div>
-                            </a>
-                            <a href="#" class="notification-item unread">
+                                <button class="notification-dismiss" aria-label="Dismiss">&times;</button>
+                            </div>
+                            <div class="notification-card unread">
                                 <div class="notification-icon success">
                                     <i class="bi bi-check-circle"></i>
                                 </div>
@@ -226,7 +228,8 @@
                                     <p class="notification-text">Weekly market report is ready</p>
                                     <p class="notification-time">Yesterday</p>
                                 </div>
-                            </a>
+                                <button class="notification-dismiss" aria-label="Dismiss">&times;</button>
+                            </div>
                         </div>
                         <div class="dropdown-footer">
                             <a href="/notifications">View all notifications</a>


### PR DESCRIPTION
## Summary
- style notifications as cards and add dismiss button
- give dark mode toggle a tooltip
- add CSS for notification cards
- show skeletons before market data loads

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q` *(fails: 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6883e0bbba00832ab89f8c37d90add35