### PR TITLE
Implement UI improvements

### DIFF
--- a/ai-stock-platform/main.py
+++ b/ai-stock-platform/main.py
@@ -502,7 +502,7 @@ async def index(request: Request):
                 <body>
                     <h1>Error rendering page</h1>
                     <p>{str(e)}</p>
-                    <a href="/">Try again</a>
+                    <button onclick="location.href='/'" style="background:none;border:none;color:#0d6efd;text-decoration:underline;cursor:pointer;">Try again</button>
                 </body>
             </html>
             """,
@@ -533,7 +533,7 @@ async def register_page(request: Request, msg: str = None):
                 <body>
                     <h1>Error rendering registration page</h1>
                     <p>{str(e)}</p>
-                    <a href="/">Go to home</a>
+                    <button onclick="location.href='/'" style="background:none;border:none;color:#0d6efd;text-decoration:underline;cursor:pointer;">Go to home</button>
                 </body>
             </html>
             """,
@@ -666,7 +666,7 @@ async def login_page(request: Request, msg: str = None):
                 <body>
                     <h1>Error rendering login page</h1>
                     <p>{str(e)}</p>
-                    <a href="/">Go to home</a>
+                    <button onclick="location.href='/'" style="background:none;border:none;color:#0d6efd;text-decoration:underline;cursor:pointer;">Go to home</button>
                 </body>
             </html>
             """,
@@ -962,12 +962,12 @@ async def dashboard(request: Request):
                             </div>
                             
                             <div class="d-grid gap-2 d-md-flex justify-content-md-center">
-                                <a href="/dashboard" class="btn btn-primary">
+                                <button onclick="location.href='/dashboard'" class="btn btn-primary">
                                     🔄 Try Again
-                                </a>
-                                <a href="/login" class="btn btn-outline-secondary">
+                                </button>
+                                <button onclick="location.href='/login'" class="btn btn-outline-secondary">
                                     🏠 Back to Login
-                                </a>
+                                </button>
                             </div>
                             
                             <div class="mt-4 text-muted small">

--- a/ai-stock-platform/ui/src/components/Stocks.tsx
+++ b/ai-stock-platform/ui/src/components/Stocks.tsx
@@ -3,13 +3,15 @@
  * Stock listing and search functionality with API integration
  */
 import React, { useState, useEffect } from 'react';
-import { Container, Row, Col, Card, Form, Button, Table, Spinner, Alert, Badge } from 'react-bootstrap';
+import { Container, Row, Col, Card, Form, Button, Table, Spinner, Alert, Badge, Placeholder } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { ROUTES } from '../config/constants';
 import apiService, { Stock } from '../services/api-service';
+import useDebounce from '../hooks/useDebounce';
 
 const Stocks: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearch = useDebounce(searchTerm, 300);
   const [stocks, setStocks] = useState<Stock[]>([]);
   const [filteredStocks, setFilteredStocks] = useState<Stock[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
@@ -22,7 +24,7 @@ const Stocks: React.FC = () => {
 
   useEffect(() => {
     filterStocks();
-  }, [searchTerm, selectedSector, stocks]);
+  }, [debouncedSearch, selectedSector, stocks]);
 
   const fetchStocks = async () => {
     try {
@@ -41,10 +43,10 @@ const Stocks: React.FC = () => {
   const filterStocks = () => {
     let filtered = stocks;
 
-    if (searchTerm) {
+    if (debouncedSearch) {
       filtered = filtered.filter(stock =>
-        stock.symbol.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        stock.name.toLowerCase().includes(searchTerm.toLowerCase())
+        stock.symbol.toLowerCase().includes(debouncedSearch.toLowerCase()) ||
+        stock.name.toLowerCase().includes(debouncedSearch.toLowerCase())
       );
     }
 
@@ -100,7 +102,7 @@ const Stocks: React.FC = () => {
           <Form.Group>
             <Form.Control
               type="text"
-              placeholder="Search stocks by symbol or name..."
+              placeholder="\u{1F50D} Search stocks by symbol or name"
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
             />
@@ -132,12 +134,19 @@ const Stocks: React.FC = () => {
         </Card.Header>
         <Card.Body>
           {loading ? (
-            <div className="text-center">
-              <Spinner animation="border" role="status">
-                <span className="visually-hidden">Loading...</span>
-              </Spinner>
-              <p className="mt-2">Loading stocks...</p>
-            </div>
+            <Table responsive hover>
+              <tbody>
+                {Array.from({ length: 5 }).map((_, idx) => (
+                  <tr key={idx}>
+                    {Array.from({ length: 8 }).map((__, i) => (
+                      <td key={i}>
+                        <Placeholder animation="wave" className="w-100" />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
           ) : (
             <Table responsive hover>
               <thead>

--- a/ai-stock-platform/ui/src/components/advanced/PredictionAnalysis.tsx
+++ b/ai-stock-platform/ui/src/components/advanced/PredictionAnalysis.tsx
@@ -9,6 +9,7 @@ import { mlService, PredictionResult, ModelInfo } from '../../services/ml-servic
 import { stockService } from '../../services/api';
 import { useError } from '../../contexts/ErrorContext';
 import PredictionChart from './charts/PredictionChart';
+import useDebounce from '../../hooks/useDebounce';
 
 const PredictionAnalysis: React.FC = () => {
   const [symbol, setSymbol] = useState<string>('AAPL');
@@ -19,6 +20,7 @@ const PredictionAnalysis: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(false);
   const [stockOptions, setStockOptions] = useState<Array<{symbol: string, name: string}>>([]);
   const [searchTerm, setSearchTerm] = useState<string>('');
+  const debouncedSearch = useDebounce(searchTerm, 300);
   const { showErrorMessage } = useError();
   
   // Fetch available models
@@ -50,9 +52,9 @@ const PredictionAnalysis: React.FC = () => {
   }, []);
   
   // Filter stocks based on search term
-  const filteredStocks = stockOptions.filter(stock => 
-    stock.symbol.toLowerCase().includes(searchTerm.toLowerCase()) || 
-    stock.name.toLowerCase().includes(searchTerm.toLowerCase())
+  const filteredStocks = stockOptions.filter(stock =>
+    stock.symbol.toLowerCase().includes(debouncedSearch.toLowerCase()) ||
+    stock.name.toLowerCase().includes(debouncedSearch.toLowerCase())
   ).slice(0, 10); // Limit to 10 results
   
   // Generate prediction
@@ -114,7 +116,7 @@ const PredictionAnalysis: React.FC = () => {
                 <div className="search-select">
                   <Form.Control
                     type="text"
-                    placeholder="Search stocks..."
+                    placeholder="\u{1F50D} Search stocks..."
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
                     autoComplete="off"

--- a/ai-stock-platform/ui/src/components/layout/Layout.tsx
+++ b/ai-stock-platform/ui/src/components/layout/Layout.tsx
@@ -3,7 +3,7 @@
  * Features floating sidebar, glass morphism, and quantum animations
  */
 import React, { useState, useEffect } from 'react';
-import { Navbar, Nav, Container, Offcanvas, Button } from 'react-bootstrap';
+import { Navbar, Nav, Container, Offcanvas, Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../providers/ThemeProvider';
@@ -180,16 +180,17 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
             <Nav className="ms-auto d-flex align-items-center gap-2">
               <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-                <Button
-                  variant="outline-secondary"
-                  size="sm"
-                  className="me-3 quantum-btn-outline"
-                  onClick={toggleTheme}
-                  title="Toggle theme"
-                  aria-label="Toggle theme"
-                >
-                  {theme === 'dark' ? '☀️' : '🌙'}
-                </Button>
+                <OverlayTrigger placement="bottom" overlay={<Tooltip id="theme-tip">Toggle theme</Tooltip>}>
+                  <Button
+                    variant="outline-secondary"
+                    size="sm"
+                    className="me-3 quantum-btn-outline"
+                    onClick={toggleTheme}
+                    aria-label="Toggle theme"
+                  >
+                    {theme === 'dark' ? '☀️' : '🌙'}
+                  </Button>
+                </OverlayTrigger>
               </motion.div>
               
               <Nav.Link as={Link} to={ROUTES.PROFILE} className="text-white me-3">

--- a/ai-stock-platform/ui/src/hooks/useDebounce.ts
+++ b/ai-stock-platform/ui/src/hooks/useDebounce.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * useDebounce hook
+ * Delays updating the returned value until after the specified delay.
+ */
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebounce;

--- a/ai-stock-platform/ui/src/styles/global.css
+++ b/ai-stock-platform/ui/src/styles/global.css
@@ -27,6 +27,9 @@
   --border-radius: 0.75rem;
   --box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
   --transition: all 0.3s ease-out;
+
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
   
   --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
@@ -45,7 +48,7 @@
 }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-sans);
   line-height: 1.6;
   margin: 0;
   padding: 0;
@@ -724,4 +727,8 @@ a:hover {
 
 .search-icon, .mic-icon, .filter-icon {
   color: #cbd5e1;
+}
+
+code, pre {
+  font-family: var(--font-mono);
 }


### PR DESCRIPTION
## Summary
- add a reusable `useDebounce` hook
- debounce stock and prediction search inputs
- show skeleton table while stock list loads
- add tooltip for theme toggle
- expose font variables in global styles
- convert anchor tags in fallback pages to buttons

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError in test collection)*

------
https://chatgpt.com/codex/tasks/task_e_6884080113a4832ab8cf4757f4920669