### PR TITLE
Fix docs route base directory error

### DIFF
--- a/ai-stock-platform/api/routers/docs.py
+++ b/ai-stock-platform/api/routers/docs.py
@@ -5,7 +5,9 @@ from fastapi.responses import PlainTextResponse
 
 router = APIRouter(prefix="/docs", tags=["docs"])
 
-BASE_DIR = Path(__file__).resolve().parents[3]
+_current = Path(__file__).resolve()
+parents = _current.parents
+BASE_DIR = parents[min(3, len(parents) - 1)]
 README_FILE = BASE_DIR / "README.md"
 USAGE_FILE = BASE_DIR / "docs" / "API_USES.md"
 


### PR DESCRIPTION
## Summary
- prevent IndexError when determining BASE_DIR in docs router
- run project tests

## Testing
- `pytest -q` *(fails: 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688407bae670832aa9bbfd8a0e2be5bd