### PR TITLE
Fix docs router base dir detection

### DIFF
--- a/ai-stock-platform/api/routers/docs.py
+++ b/ai-stock-platform/api/routers/docs.py
@@ -5,7 +5,9 @@ from fastapi.responses import PlainTextResponse
 
 router = APIRouter(prefix="/docs", tags=["docs"])
 
-BASE_DIR = Path(__file__).resolve().parents[3]
+BASE_DIR = Path(__file__).resolve()
+while not (BASE_DIR / "README.md").exists() and BASE_DIR != BASE_DIR.parent:
+    BASE_DIR = BASE_DIR.parent
 README_FILE = BASE_DIR / "README.md"
 USAGE_FILE = BASE_DIR / "docs" / "API_USES.md"
 


### PR DESCRIPTION
## Summary
- handle docs router path more safely so README and docs are found even when app is relocated

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'models.orders')*

------
https://chatgpt.com/codex/tasks/task_e_68840f550558832ab2e1fd228b469959