### PR TITLE
Add interactive news topic badges

### DIFF
--- a/ai-stock-platform/ui/static/css/quantum-enhancements.css
+++ b/ai-stock-platform/ui/static/css/quantum-enhancements.css
@@ -780,6 +780,31 @@ body {
   background: var(--quantum-electric);
 }
 
+/* News topic pill style */
+.topic-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: #ffffff;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  box-shadow: var(--quantum-shadow-soft);
+  cursor: pointer;
+  transition: var(--transition-smooth);
+  margin-right: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.topic-pill:hover {
+  box-shadow: var(--quantum-shadow-medium);
+  transform: translateY(-2px);
+}
+
+.topic-pill.active {
+  background: linear-gradient(135deg, #8b5cf6 0%, #00d2ff 100%);
+}
+
 /* Enhanced Dropdown Menus */
 .quantum-dropdown {
   position: relative;

--- a/ai-stock-platform/ui/templates/news/index.html
+++ b/ai-stock-platform/ui/templates/news/index.html
@@ -34,7 +34,7 @@
                 <div class="card-body">
                     {% if data.articles %}
                         {% for article in data.articles %}
-                        <div class="border-bottom pb-3 mb-3">
+                        <div class="border-bottom pb-3 mb-3 article-item" data-title="{{ article.title | lower }}">
                             <div class="row">
                                 <div class="col-md-8">
                                     <h5 class="card-title">
@@ -105,7 +105,7 @@
                 <div class="card-body">
                     {% if data.trending %}
                         {% for topic in data.trending %}
-                        <span class="badge bg-primary me-2 mb-2">{{ topic }}</span>
+                        <span class="topic-pill quantum-tooltip" data-topic="{{ topic }}" data-tooltip="Filter by {{ topic }}">{{ topic }}</span>
                         {% endfor %}
                     {% endif %}
                 </div>
@@ -143,6 +143,30 @@ document.addEventListener('DOMContentLoaded', function() {
     setInterval(function() {
         location.reload();
     }, 5 * 60 * 1000);
+
+    const topics = document.querySelectorAll('.topic-pill');
+    const articles = document.querySelectorAll('.article-item');
+
+    topics.forEach(tag => {
+        tag.addEventListener('click', () => {
+            const isActive = tag.classList.contains('active');
+            topics.forEach(t => t.classList.remove('active'));
+            if (isActive) {
+                articles.forEach(a => a.style.display = '');
+                return;
+            }
+            tag.classList.add('active');
+            const topic = tag.dataset.topic.toLowerCase();
+            articles.forEach(article => {
+                const title = article.dataset.title || '';
+                if (title.includes(topic)) {
+                    article.style.display = '';
+                } else {
+                    article.style.display = 'none';
+                }
+            });
+        });
+    });
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- style topic pills with gradient backgrounds
- display interactive trending topics
- filter news articles on topic click

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6884110eae90832a8c330a711b59dcd5