### PR TITLE
Fix theme and language toggle placement

### DIFF
--- a/ai-stock-platform/ui/static/js/quantum-i18n.js
+++ b/ai-stock-platform/ui/static/js/quantum-i18n.js
@@ -269,9 +269,9 @@ class QuantumI18n {
         if (existingSelector) return;
 
         const selector = document.createElement('div');
-        selector.className = 'quantum-language-selector';
+        selector.className = 'nav-item quantum-language-selector';
         selector.innerHTML = `
-            <button class="quantum-language-button quantum-btn quantum-btn-secondary" aria-label="Select Language">
+            <button class="quantum-language-button quantum-btn quantum-btn-secondary" aria-label="Select Language" title="Change Language" data-tooltip="Change Language">
                 <span class="language-flag">${this.supportedLanguages[this.currentLanguage].flag}</span>
                 <span class="language-code">${this.currentLanguage.toUpperCase()}</span>
                 <span class="language-arrow">▼</span>
@@ -291,7 +291,7 @@ class QuantumI18n {
         this.addLanguageSelectorStyles();
 
         // Add to navigation
-        const nav = document.querySelector('.quantum-nav-container, .navbar');
+        const nav = document.querySelector('.nav-right');
         if (nav) {
             nav.appendChild(selector);
         } else {

--- a/ai-stock-platform/ui/templates/base.html
+++ b/ai-stock-platform/ui/templates/base.html
@@ -185,7 +185,7 @@
 
             <div class="nav-right">
                 <div class="nav-item">
-                    <button class="theme-toggle" id="themeToggle" title="Dark Mode">
+                    <button class="theme-toggle" id="themeToggle" title="Toggle Dark Mode" data-tooltip="Toggle Dark Mode">
                         <i class="bi bi-moon-fill"></i>
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
- attach theme toggle tooltip
- add nav styling when injecting language selector
- position language selector inside header

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ERROR ai-stock-platform/api/tests/test_order_management.py, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6884111b2110832a86e24fa93849f576