### PR TITLE
Refine notification dropdown styles

### DIFF
--- a/ai-stock-platform/ui/static/css/quantum-enhancements.css
+++ b/ai-stock-platform/ui/static/css/quantum-enhancements.css
@@ -141,6 +141,14 @@ html {
 
 .mark-all-read-btn {
   margin-left: auto;
+  background: none;
+  border: none;
+  color: #60a5fa;
+  font-weight: 500;
+  font-size: 0.875rem;
+}
+.mark-all-read-btn:hover {
+  color: #bfdbfe;
 }
 
 body {
@@ -1214,20 +1222,23 @@ body {
 
 /* Notification Cards */
 .notification-card {
+  position: relative;
   display: flex;
   align-items: flex-start;
   gap: var(--space-sm);
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
+  border-radius: 1rem;
   width: 100%;
   padding: var(--space-md);
   margin-bottom: var(--space-sm);
   color: var(--text-primary, #e5e5e5);
-  }
+}
 
 .notification-card .notification-dismiss {
-  margin-left: auto;
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
   background: none;
   border: none;
   color: inherit;

--- a/ai-stock-platform/ui/templates/base.html
+++ b/ai-stock-platform/ui/templates/base.html
@@ -181,10 +181,10 @@
                     <div class="notifications-dropdown" id="notificationsDropdown">
                         <div class="dropdown-header">
                             <h6>Notifications</h6>
-                            <button type="button" class="mark-all-read-btn btn btn-sm">Mark all as read</button>
+                            <button type="button" class="mark-all-read-btn text-sm font-medium text-blue-400 hover:text-blue-200">Mark all as read</button>
                         </div>
                         <div class="notifications-list">
-                            <div class="notification-card unread">
+                            <div class="notification-card unread relative">
                                 <div class="notification-icon warning">
                                     <i class="bi bi-exclamation-triangle"></i>
                                 </div>
@@ -192,9 +192,9 @@
                                     <p class="notification-text">AAPL price alert triggered at $180</p>
                                     <p class="notification-time">Just now</p>
                                 </div>
-                                <button class="notification-dismiss" aria-label="Dismiss">&times;</button>
+                                <button class="notification-dismiss absolute top-2 right-2" aria-label="Dismiss">&times;</button>
                             </div>
-                            <div class="notification-card unread">
+                            <div class="notification-card unread relative">
                                 <div class="notification-icon info">
                                     <i class="bi bi-info-circle"></i>
                                 </div>
@@ -202,9 +202,9 @@
                                     <p class="notification-text">New forecast models available</p>
                                     <p class="notification-time">2 hours ago</p>
                                 </div>
-                                <button class="notification-dismiss" aria-label="Dismiss">&times;</button>
+                                <button class="notification-dismiss absolute top-2 right-2" aria-label="Dismiss">&times;</button>
                             </div>
-                            <div class="notification-card unread">
+                            <div class="notification-card unread relative">
                                 <div class="notification-icon success">
                                     <i class="bi bi-check-circle"></i>
                                 </div>
@@ -212,7 +212,7 @@
                                     <p class="notification-text">Weekly market report is ready</p>
                                     <p class="notification-time">Yesterday</p>
                                 </div>
-                                <button class="notification-dismiss" aria-label="Dismiss">&times;</button>
+                                <button class="notification-dismiss absolute top-2 right-2" aria-label="Dismiss">&times;</button>
                             </div>
                         </div>
                         <div class="dropdown-footer">


### PR DESCRIPTION
## Summary
- tweak markup for notifications dropdown cards and dismissal buttons
- style 'Mark all as read' link for better contrast
- apply rounded-xl card style and absolute close button in CSS

## Testing
- `pytest -q` *(fails: 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6884147f0e10832ab57ab54ccd58026a