### PR TITLE
Improve card styling and add skeleton loader

### DIFF
--- a/ai-stock-platform/ui/src/components/QuantumDashboard.tsx
+++ b/ai-stock-platform/ui/src/components/QuantumDashboard.tsx
@@ -4,6 +4,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import { Container, Row, Col, Card, Button } from 'react-bootstrap';
+import Skeleton from '@mui/material/Skeleton';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { ROUTES } from '../config/constants';
@@ -37,6 +38,8 @@ const Dashboard: React.FC = () => {
   const [marketData, setMarketData] = useState<MarketData[]>([]);
   const [news, setNews] = useState<NewsItem[]>([]);
   const [portfolioMetrics, setPortfolioMetrics] = useState<PortfolioMetric[]>([]);
+  const [highlightMarket, setHighlightMarket] = useState(false);
+  const [highlightNews, setHighlightNews] = useState(false);
 
   useEffect(() => {
     // Simulate data loading
@@ -64,6 +67,12 @@ const Dashboard: React.FC = () => {
       ]);
 
       setIsLoading(false);
+      setHighlightMarket(true);
+      setHighlightNews(true);
+      setTimeout(() => {
+        setHighlightMarket(false);
+        setHighlightNews(false);
+      }, 1500);
     }, 1000);
   }, []);
 
@@ -90,16 +99,24 @@ const Dashboard: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div className="loading-container">
-        <div className="loading-spinner"></div>
-        <motion.p
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.5 }}
-        >
-          Loading your quantum dashboard...
-        </motion.p>
-      </div>
+      <Container fluid className="py-4">
+        <Row className="g-4">
+          <Col lg={8}>
+            <Card className="quantum-card rounded-2xl shadow-lg p-4">
+              <Card.Body>
+                <Skeleton variant="rectangular" height={300} animation="wave" />
+              </Card.Body>
+            </Card>
+          </Col>
+          <Col lg={4}>
+            <Card className="quantum-card rounded-2xl shadow-lg p-4">
+              <Card.Body>
+                <Skeleton variant="rectangular" height={300} animation="wave" />
+              </Card.Body>
+            </Card>
+          </Col>
+        </Row>
+      </Container>
     );
   }
 
@@ -276,7 +293,7 @@ const Dashboard: React.FC = () => {
           {/* Top Performing Stocks */}
           <Col lg={6} className="mb-4">
             <motion.div variants={itemVariants}>
-              <Card className="quantum-card">
+              <Card className={`quantum-card ${highlightMarket ? 'quantum-animate-pulse' : ''}`}>
                 <Card.Header className="quantum-card-header">
                   <h5 className="mb-0">🚀 Top Performers</h5>
                 </Card.Header>
@@ -321,7 +338,7 @@ const Dashboard: React.FC = () => {
           {/* AI News & Sentiment */}
           <Col lg={6} className="mb-4">
             <motion.div variants={itemVariants}>
-              <Card className="quantum-card">
+              <Card className={`quantum-card ${highlightNews ? 'quantum-animate-pulse' : ''}`}>
                 <Card.Header className="quantum-card-header">
                   <div className="d-flex align-items-center">
                     <h5 className="mb-0">📰 AI News Sentiment</h5>

--- a/ai-stock-platform/ui/src/components/TrendingStocks.tsx
+++ b/ai-stock-platform/ui/src/components/TrendingStocks.tsx
@@ -89,7 +89,7 @@ const TrendingStocks: React.FC<TrendingStocksProps> = ({
 
   if (loading) {
     return (
-      <Card sx={{ minHeight: compact ? 300 : 400 }}>
+      <Card className="quantum-card rounded-2xl shadow-lg p-4" sx={{ minHeight: compact ? 300 : 400 }}>
         <CardContent>
           {showHeader && (
             <Box display="flex" alignItems="center" mb={2}>
@@ -119,7 +119,7 @@ const TrendingStocks: React.FC<TrendingStocksProps> = ({
 
   if (error) {
     return (
-      <Card sx={{ minHeight: compact ? 300 : 400 }}>
+      <Card className="quantum-card rounded-2xl shadow-lg p-4" sx={{ minHeight: compact ? 300 : 400 }}>
         <CardContent>
           {showHeader && (
             <Box display="flex" alignItems="center" mb={2}>
@@ -143,7 +143,7 @@ const TrendingStocks: React.FC<TrendingStocksProps> = ({
   }
 
   return (
-    <Card sx={{ minHeight: compact ? 300 : 400 }}>
+    <Card className="quantum-card rounded-2xl shadow-lg p-4" sx={{ minHeight: compact ? 300 : 400 }}>
       <CardContent>
         {showHeader && (
           <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>

--- a/ai-stock-platform/ui/src/styles/stock-flow.css
+++ b/ai-stock-platform/ui/src/styles/stock-flow.css
@@ -1,7 +1,8 @@
 /* Stock Flow Visualization Styles */
 .stock-flow-visualization {
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 100%);
-  backdrop-filter: blur(10px);
+  /* Lighter blur for performance */
+  backdrop-filter: blur(4px);
   border: 1px solid rgba(255, 255, 255, 0.2);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
   transition: all 0.3s ease;
@@ -17,7 +18,7 @@
   overflow: hidden;
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.02);
-  backdrop-filter: blur(5px);
+  backdrop-filter: blur(3px);
 }
 
 .flow-control-panel {
@@ -69,12 +70,12 @@
   background: rgba(255, 255, 255, 0.05);
   border-radius: 8px;
   padding: 12px;
-  backdrop-filter: blur(5px);
+  backdrop-filter: blur(3px);
 }
 
 .visualization-toggle {
   background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(4px);
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 8px;
 }
@@ -197,7 +198,7 @@
   height: 200px;
   background: linear-gradient(45deg, rgba(59, 130, 246, 0.1), rgba(147, 51, 234, 0.1));
   border-radius: 12px;
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(4px);
 }
 
 .flow-loading::after {
@@ -245,7 +246,7 @@
   justify-content: center;
   cursor: pointer;
   transition: all 0.3s ease;
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(4px);
 }
 
 .chart-control-btn:hover {

--- a/ai-stock-platform/ui/static/css/quantum-enhancements.css
+++ b/ai-stock-platform/ui/static/css/quantum-enhancements.css
@@ -24,7 +24,8 @@
   /* Glass Morphism Effects Enhanced */
   --glass-bg: rgba(255, 255, 255, 0.1);
   --glass-border: rgba(255, 255, 255, 0.2);
-  --glass-blur: blur(16px);
+  /* Use a lighter blur for better clarity */
+  --glass-blur: blur(4px);
   --glass-dark: rgba(0, 0, 0, 0.2);
   --glass-strong: rgba(255, 255, 255, 0.25);
   --glass-subtle: rgba(255, 255, 255, 0.05);
@@ -336,8 +337,10 @@ body {
   background: var(--glass-bg);
   backdrop-filter: var(--glass-blur);
   border: 1px solid var(--glass-border);
-  border-radius: 20px;
-  padding: var(--space-lg);
+  /* Consistent rounded card styling */
+  border-radius: 1rem;
+  padding: 1rem;
+  box-shadow: var(--quantum-shadow-soft);
   transition: var(--transition-quantum);
   position: relative;
   overflow: hidden;

--- a/ai-stock-platform/ui/static/css/quantum-glow.css
+++ b/ai-stock-platform/ui/static/css/quantum-glow.css
@@ -15,7 +15,8 @@ body.glow-theme {
 
 .glow-card {
   background: rgba(255, 255, 255, 0.05);
-  backdrop-filter: blur(8px);
+  /* Reduce heavy blur for better performance */
+  backdrop-filter: blur(4px);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.37);
   border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 16px;

--- a/ai-stock-platform/ui/static/css/realtime-dashboard.css
+++ b/ai-stock-platform/ui/static/css/realtime-dashboard.css
@@ -41,9 +41,10 @@
 .quantum-card {
   background: rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 16px;
-  backdrop-filter: blur(10px);
-  box-shadow: 
+  border-radius: 1rem;
+  /* Use lighter blur via opacity instead of heavy filter */
+  backdrop-filter: blur(4px);
+  box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.3),
     0 2px 8px rgba(0, 210, 255, 0.1);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
## Summary
- lighten glass blur in global styles and dashboard styles
- standardize card styling with consistent rounded, shadowed padding
- add shimmer skeletons while dashboard data loads
- pulse cards briefly when market/news data updates
- apply base card classes in TrendingStocks

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688414b30bc8832a85308927dd02432b