### PR TITLE
Improve header utilities layout

### DIFF
--- a/ai-stock-platform/ui/static/css/quantum-enhancements.css
+++ b/ai-stock-platform/ui/static/css/quantum-enhancements.css
@@ -235,6 +235,12 @@ body {
   gap: var(--space-md);
 }
 
+.nav-utilities {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
 .quantum-search {
   flex: 1;
   max-width: 300px;

--- a/ai-stock-platform/ui/static/js/quantum-i18n.js
+++ b/ai-stock-platform/ui/static/js/quantum-i18n.js
@@ -291,8 +291,11 @@ class QuantumI18n {
         this.addLanguageSelectorStyles();
 
         // Add to navigation
+        const utilities = document.querySelector('.nav-utilities');
         const nav = document.querySelector('.nav-right');
-        if (nav) {
+        if (utilities) {
+            utilities.appendChild(selector);
+        } else if (nav) {
             nav.appendChild(selector);
         } else {
             // Fallback: add to body
@@ -315,6 +318,7 @@ class QuantumI18n {
             .quantum-language-selector {
                 position: relative;
                 display: inline-block;
+                margin-right: var(--space-md);
             }
 
             .quantum-language-button {

--- a/ai-stock-platform/ui/templates/base.html
+++ b/ai-stock-platform/ui/templates/base.html
@@ -168,17 +168,18 @@
                 <a href="/login" class="quantum-nav-link {% if '/login' in request.url.path %}active{% endif %}" data-i18n="nav.login">Login</a>
                 <a href="/auth/register" class="quantum-nav-link {% if '/auth/register' in request.url.path %}active{% endif %}" data-i18n="nav.register">Register</a>
                 {% endif %}
-                <div class="nav-item">
-                    <button class="theme-toggle" id="themeToggle" title="Toggle Dark Mode" data-tooltip="Toggle Dark Mode">
-                        <i class="bi bi-moon-fill"></i>
-                    </button>
-                </div>
-                <div class="nav-item">
-                    <button class="notifications-toggle" id="notificationsToggle">
-                        <i class="bi bi-bell"></i>
-                        <span class="badge bg-danger notification-badge">3</span>
-                    </button>
-                    <div class="notifications-dropdown" id="notificationsDropdown">
+                <div class="nav-utilities">
+                    <div class="nav-item">
+                        <button class="theme-toggle" id="themeToggle" title="Toggle Dark Mode" data-tooltip="Toggle Dark Mode">
+                            <i class="bi bi-moon-fill"></i>
+                        </button>
+                    </div>
+                    <div class="nav-item">
+                        <button class="notifications-toggle" id="notificationsToggle">
+                            <i class="bi bi-bell"></i>
+                            <span class="badge bg-danger notification-badge">3</span>
+                        </button>
+                        <div class="notifications-dropdown" id="notificationsDropdown">
                         <div class="dropdown-header">
                             <h6>Notifications</h6>
                             <button type="button" class="mark-all-read-btn btn btn-sm">Mark all as read</button>


### PR DESCRIPTION
## Summary
- group utility buttons in a new flex container
- ensure dark mode toggle has tooltip text
- allow language selector placement in header

## Testing
- `pytest -q` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688415221f4c832aa636165f28cf54f6