### PR TITLE
Fix settings and service imports

### DIFF
--- a/ai-stock-platform/api/core/config/settings.py
+++ b/ai-stock-platform/api/core/config/settings.py
@@ -107,13 +107,20 @@ class Settings(BaseSettings):
         return self.database.get_db_url()
 
 def get_settings() -> Settings:
+    """Return an initialized :class:`Settings` instance.
+
+    The hosting environment may define an environment variable named
+    ``DATABASE`` which conflicts with Pydantic's handling of the nested
+    ``database`` model.  Temporarily removing this variable prevents JSON
+    decoding errors during instantiation.
     """
-    Initialize and return application settings
-    
-    Returns:
-        Settings: Configured application settings
-    """
-    return Settings()
+
+    removed = os.environ.pop("DATABASE", None)
+    try:
+        return Settings()
+    finally:
+        if removed is not None:
+            os.environ["DATABASE"] = removed
 
 # Global settings instance
 settings = get_settings()

--- a/ai-stock-platform/api/services/api_client.py
+++ b/ai-stock-platform/api/services/api_client.py
@@ -7,14 +7,24 @@ correctly even when Python loads the ``services`` package from the
 """
 from __future__ import annotations
 
+from importlib import util
 from pathlib import Path
 import sys
 
 # Ensure repository root is on ``sys.path``
-_root = Path(__file__).resolve().parents[2]
-if str(_root) not in sys.path:
-    sys.path.insert(0, str(_root))
 
-from services.api_client import APIClient  # type: ignore[F401]
+_root = Path(__file__).resolve().parents[3]
+root_module = _root / "services" / "api_client.py"
+
+if __name__ == "services.api_client":
+    spec = util.spec_from_file_location("_root_services_api_client", root_module)
+    module = util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    APIClient = module.APIClient  # type: ignore[attr-defined]
+else:
+    if str(_root) not in sys.path:
+        sys.path.insert(0, str(_root))
+    from services.api_client import APIClient  # type: ignore[F401]
 
 __all__ = ["APIClient"]

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -10,6 +10,8 @@ _api_services = _here.parent / "ai-stock-platform" / "api" / "services"
 # Include both this directory (for test stubs) and the real UI services path
 __path__ = [str(_here), str(_api_services), str(_ui_services)]
 
-for p in __path__:
+# Insert paths so that the repository root services take precedence.
+# Add paths in reverse order so ``_here`` ends up first.
+for p in reversed(__path__):
     if p not in sys.path:
         sys.path.insert(0, p)


### PR DESCRIPTION
## Summary
- avoid DATABASE env var issue in API settings
- load root services first and fix API client wrapper

## Testing
- `pytest -q` *(fails: 48 failed, 71 passed, 7 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68841abac870832a925108244374712b