### PR TITLE
Fix ENABLE_REAL_DATA default

### DIFF
--- a/ai-stock-platform/api/core/config/settings.py
+++ b/ai-stock-platform/api/core/config/settings.py
@@ -84,7 +84,8 @@ class Settings(BaseSettings):
 
     # Cache settings
     CACHE_TTL_TRENDING_STOCKS: int = Field(default=300, env='CACHE_TTL_TRENDING_STOCKS')
-    ENABLE_REAL_DATA: bool = Field(default=True, env='ENABLE_REAL_DATA')
+    # Default to False so real API calls are only made when explicitly enabled
+    ENABLE_REAL_DATA: bool = Field(default=False, env='ENABLE_REAL_DATA')
     
     # Logging
     LOG_LEVEL: str = Field(default="INFO", env='LOG_LEVEL')


### PR DESCRIPTION
## Summary
- default ENABLE_REAL_DATA to False so the API uses mock data unless explicitly enabled

## Testing
- `pytest -q` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68841c33a724832a9ab764a1dbb0db27