### PR TITLE
Add Tailwind mobile drawer

### DIFF
--- a/ai-stock-platform/ui/src/components/layout/Layout.tsx
+++ b/ai-stock-platform/ui/src/components/layout/Layout.tsx
@@ -3,12 +3,13 @@
  * Features floating sidebar, glass morphism, and quantum animations
  */
 import React, { useState, useEffect } from 'react';
-import { Navbar, Nav, Container, Offcanvas, Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { Navbar, Nav, Container, Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../providers/ThemeProvider';
 import { ROUTES } from '../../config/constants';
 import { motion, AnimatePresence } from 'framer-motion';
+import MobileDrawer from './MobileDrawer';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -319,55 +320,12 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           </div>
         </motion.div>
 
-        {/* Enhanced Mobile Sidebar */}
-        <Offcanvas
-          show={showSidebar}
-          onHide={() => setShowSidebar(false)}
-          placement="start"
-          className="quantum-mobile-sidebar d-lg-none"
-        >
-          <Offcanvas.Header closeButton className="quantum-card-header">
-            <Offcanvas.Title className="quantum-text-gradient">
-              ⚛️ QuantumVestAI
-            </Offcanvas.Title>
-          </Offcanvas.Header>
-          <Offcanvas.Body className="quantum-card-body">
-            <Nav className="flex-column">
-              {navigationItems.map((item, index) => (
-                <motion.div
-                  key={item.path}
-                  initial={{ opacity: 0, x: -50 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ duration: 0.3, delay: index * 0.1 }}
-                >
-                  <Nav.Link
-                    as={Link}
-                    to={item.path}
-                    className={`quantum-nav-item ${
-                      location.pathname === item.path ? 'active' : ''
-                    }`}
-                    onClick={() => setShowSidebar(false)}
-                    style={{
-                      '--item-color': item.color
-                    } as React.CSSProperties}
-                  >
-                    <motion.div 
-                      className="me-3 quantum-mobile-icon"
-                      whileHover={{ scale: 1.2, rotate: 360 }}
-                      transition={{ duration: 0.5 }}
-                    >
-                      <i className={`bi ${item.modernIcon}`} style={{ color: item.color, fontSize: '1.2rem' }}></i>
-                    </motion.div>
-                    <div>
-                      <div className="fw-semibold">{item.label}</div>
-                      <small className="text-muted">{item.description}</small>
-                    </div>
-                  </Nav.Link>
-                </motion.div>
-              ))}
-            </Nav>
-          </Offcanvas.Body>
-        </Offcanvas>
+        {/* Mobile Drawer */}
+        <MobileDrawer
+          open={showSidebar}
+          onClose={() => setShowSidebar(false)}
+          items={navigationItems}
+        />
 
         {/* Enhanced Main Content */}
         <motion.div

--- a/ai-stock-platform/ui/src/components/layout/MobileDrawer.tsx
+++ b/ai-stock-platform/ui/src/components/layout/MobileDrawer.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
+interface DrawerItem {
+  path: string;
+  label: string;
+  description?: string;
+  modernIcon?: string;
+  color?: string;
+}
+
+interface MobileDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  items: DrawerItem[];
+}
+
+const MobileDrawer: React.FC<MobileDrawerProps> = ({ open, onClose, items }) => {
+  const location = useLocation();
+
+  return (
+    <>
+      <div
+        className={`fixed inset-0 bg-black/50 transition-opacity z-40 ${open ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+        onClick={onClose}
+      />
+      <div
+        className={`fixed inset-y-0 left-0 w-64 bg-dark-bg-secondary overflow-y-auto shadow-quantum-md transform transition-transform z-50 ${open ? 'translate-x-0' : '-translate-x-full'}`}
+      >
+        <div className="p-4 border-b border-gray-700 flex items-center justify-between">
+          <span className="font-bold text-lg text-white">QuantumVestAI</span>
+          <button className="text-white" onClick={onClose} aria-label="Close menu">
+            ✕
+          </button>
+        </div>
+        <nav className="p-4 space-y-2">
+          {items.map((item) => (
+            <Link
+              key={item.path}
+              to={item.path}
+              onClick={onClose}
+              className={`flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-gray-700 transition-colors ${location.pathname === item.path ? 'bg-gray-700' : ''}`}
+              style={{ color: item.color || undefined }}
+            >
+              {item.modernIcon && <i className={`bi ${item.modernIcon}`} />}
+              <span className="text-white">{item.label}</span>
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </>
+  );
+};
+
+export default MobileDrawer;


### PR DESCRIPTION
## Summary
- add responsive `MobileDrawer` component for Tailwind-based sliding menu
- integrate `MobileDrawer` into main layout

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError in test_order_management.py)*

------
https://chatgpt.com/codex/tasks/task_e_688424dce834832aa7668b4c64665aca