### PR TITLE
Fix sticky top nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This document provides a comprehensive list of API and UI endpoints for the QuantumVestAI application.
 For screenshots and icons used in the interface, see [UI Visuals](docs/UI_IMAGES.md).
 For instructions on integrating ChatGPT into the UI, see [ChatGPT Guide](docs/CHATGPT_UI_INTEGRATION.md).
+For an overview of the React-based UI and layout, see [React UI Overview](docs/REACT_UI_OVERVIEW.md).
 For strategies to gather social sentiment without a paid Twitter plan, see [Sentiment Workarounds](docs/SENTIMENT_WORKAROUNDS.md).
 For practice trading without risking capital, follow the [PaperMoney Setup](docs/PAPERMONEY_TRADING.md).
 

--- a/ai-stock-platform/ui/src/components/layout/Layout.tsx
+++ b/ai-stock-platform/ui/src/components/layout/Layout.tsx
@@ -145,7 +145,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   }, []);
 
   return (
-    <div className="quantum-bg min-vh-100">
+    <div className="quantum-bg min-vh-100" style={{ paddingTop: '76px' }}>
       {/* Enhanced Top Navigation */}
       <motion.div
         className="quantum-nav"

--- a/ai-stock-platform/ui/src/styles/quantum-components.css
+++ b/ai-stock-platform/ui/src/styles/quantum-components.css
@@ -181,8 +181,10 @@
   backdrop-filter: var(--glass-blur);
   border-bottom: 1px solid var(--glass-border);
   box-shadow: var(--quantum-shadow-soft);
-  position: sticky !important;
+  position: fixed !important;
   top: 0;
+  left: 0;
+  width: 100%;
   /* Keep navigation above expanding sidebar */
   z-index: 1050;
 }

--- a/docs/REACT_UI_OVERVIEW.md
+++ b/docs/REACT_UI_OVERVIEW.md
@@ -1,0 +1,33 @@
+# React UI Overview
+
+QuantumVestAI uses a React-based frontend located under `ai-stock-platform/ui`. The UI relies on **React Router** for page navigation rather than a Python `mainloop`.
+
+## Top Navigation Layout
+
+The persistent menu is implemented in `src/components/layout/Layout.tsx`. It renders a `Navbar` at the top of every page and houses the navigation links. The Layout component wraps all route components so the menu is always visible.
+
+```tsx
+// simplified snippet from Layout.tsx
+<Navbar expand="lg" className="px-4 py-3">
+  <Container fluid>
+    <Navbar.Brand as={Link} to={ROUTES.DASHBOARD}>QuantumVestAI</Navbar.Brand>
+    <Nav className="ms-auto">
+      {/* navigation links */}
+    </Nav>
+  </Container>
+</Navbar>
+```
+
+Pages are registered with `react-router-dom` inside `src/main.tsx` and rendered inside `Layout`.
+
+```tsx
+<Routes>
+  <Route element={<Layout />}>
+    <Route path={ROUTES.DASHBOARD} element={<Dashboard />} />
+    {/* other routes */}
+  </Route>
+</Routes>
+```
+
+Because React handles the routing and rendering cycle, there is no main loop function. The top menu persists across pages automatically.
+


### PR DESCRIPTION
## Summary
- keep the main navigation bar fixed at the top
- offset page content so it doesn't hide under the nav

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: errors collecting order management tests)*

------
https://chatgpt.com/codex/tasks/task_e_68846799dee4832a82d24fc38617349a