### PR TITLE
Address lint issues in UI startup and services

### DIFF
--- a/ai-stock-platform/ui/app_startup.py
+++ b/ai-stock-platform/ui/app_startup.py
@@ -6,7 +6,6 @@ Last updated: 2025-01-18
 Updated by: daparthi001
 """
 
-import asyncio
 import logging
 from contextlib import asynccontextmanager
 
@@ -14,73 +13,79 @@ from fastapi import FastAPI
 
 logger = logging.getLogger(__name__)
 
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """
-    Application lifespan manager for proper HTTP client initialization and cleanup.
-    """
+    """Manage HTTP client setup and cleanup for application lifecycle."""
     # Startup
     logger.info("Starting QuantumVestAI UI application...")
-    
+
     try:
         # Initialize HTTP client configuration
-        from core.http_client import HTTPClientConfig, get_http_client
+        from core.http_client import get_http_client
 
         # Test HTTP client initialization
         async with get_http_client() as client:
             logger.info("HTTP client initialized successfully")
-            logger.info(f"Connection pooling: max_connections={client.config.limits.max_connections}, "
-                       f"max_keepalive={client.config.limits.max_keepalive_connections}")
-            logger.info(f"Timeouts: connect={client.config.timeout.connect}s, "
-                       f"read={client.config.timeout.read}s")
-            logger.info(f"Retries: max_retries={client.config.max_retries}")
-        
+            logger.info(
+                "Connection pooling: max_connections=%s, max_keepalive=%s",
+                client.config.limits.max_connections,
+                client.config.limits.max_keepalive_connections,
+            )
+            logger.info(
+                "Timeouts: connect=%ss, read=%s",
+                client.config.timeout.connect,
+                client.config.timeout.read,
+            )
+            logger.info("Retries: max_retries=%s", client.config.max_retries)
+
         logger.info("Application startup completed successfully")
-        
+
     except Exception as e:
         logger.error(f"Failed to initialize application: {e}")
         raise
-    
+
     yield
-    
+
     # Shutdown
     logger.info("Shutting down QuantumVestAI UI application...")
-    
+
     try:
         # Cleanup HTTP clients
         from core.http_client import cleanup_http_clients
         await cleanup_http_clients()
         logger.info("HTTP clients cleaned up successfully")
-        
+
     except Exception as e:
         logger.error(f"Error during application shutdown: {e}")
-    
+
     logger.info("Application shutdown completed")
+
 
 def configure_logging():
     """Configure application logging."""
     import os
-    
+
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     debug_mode = os.getenv("DEBUG", "false").lower() == "true"
-    
+
     if debug_mode:
         log_level = "DEBUG"
-    
+
     # Configure logging format
     logging.basicConfig(
         level=getattr(logging, log_level, logging.INFO),
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S"
     )
-    
+
     # Set httpx logging level (it can be quite verbose)
     httpx_logger = logging.getLogger("httpx")
     if log_level == "DEBUG":
         httpx_logger.setLevel(logging.DEBUG)
     else:
         httpx_logger.setLevel(logging.WARNING)
-    
+
     # Set httpcore logging level
     httpcore_logger = logging.getLogger("httpcore")
     if log_level == "DEBUG":
@@ -88,13 +93,14 @@ def configure_logging():
     else:
         httpcore_logger.setLevel(logging.WARNING)
 
+
 def create_app() -> FastAPI:
     """
     Create and configure the FastAPI application.
     """
     # Configure logging first
     configure_logging()
-    
+
     # Create FastAPI app with lifespan
     app = FastAPI(
         title="QuantumVestAI UI",
@@ -102,7 +108,7 @@ def create_app() -> FastAPI:
         version="1.0.0",
         lifespan=lifespan
     )
-    
+
     # Add HTTP client configuration to app state
     try:
         from core.http_client import HTTPClientConfig
@@ -110,10 +116,12 @@ def create_app() -> FastAPI:
         logger.info("HTTP client configuration added to app state")
     except Exception as e:
         logger.warning(f"Could not add HTTP config to app state: {e}")
-    
+
     return app
 
 # Health check endpoint for monitoring
+
+
 async def health_check():
     """
     Health check endpoint that verifies HTTP client functionality.
@@ -122,16 +130,16 @@ async def health_check():
         from core.http_client import get_http_client
 
         # Test HTTP client
-        async with get_http_client() as client:
+        async with get_http_client():
             # Basic health check - just verify client creation
             health_status = {
                 "status": "healthy",
                 "http_client": "operational",
                 "timestamp": "2025-01-18T12:00:00Z"
             }
-            
+
         return health_status
-        
+
     except Exception as e:
         logger.error(f"Health check failed: {e}")
         return {
@@ -141,27 +149,30 @@ async def health_check():
         }
 
 # Example of how to add the health check to your FastAPI app
+
+
 def add_health_endpoints(app: FastAPI):
     """Add health check endpoints to the FastAPI app."""
-    
+
     @app.get("/health")
     async def get_health():
         """Basic health check endpoint."""
         return await health_check()
-    
+
     @app.get("/health/http")
     async def get_http_health():
         """HTTP client specific health check."""
         try:
             from core.http_client import HTTPClientConfig, get_http_client
-            
+
             config = HTTPClientConfig()
-            async with get_http_client() as client:
+            limits = config.limits
+            async with get_http_client():
                 return {
                     "status": "healthy",
                     "http_client": {
-                        "max_connections": config.limits.max_connections,
-                        "max_keepalive": config.limits.max_keepalive_connections,
+                        "max_connections": limits.max_connections,
+                        "max_keepalive": limits.max_keepalive_connections,
                         "connect_timeout": config.timeout.connect,
                         "read_timeout": config.timeout.read,
                         "max_retries": config.max_retries,
@@ -176,15 +187,16 @@ def add_health_endpoints(app: FastAPI):
                 "timestamp": "2025-01-18T12:00:00Z"
             }
 
+
 if __name__ == "__main__":
     # Example of how to run the application
     import os
 
     import uvicorn
-    
+
     app = create_app()
     add_health_endpoints(app)
-    
+
     # Run the application
     uvicorn.run(
         app,

--- a/ai_stock_platform/ui/services/chatgpt_service.py
+++ b/ai_stock_platform/ui/services/chatgpt_service.py
@@ -1,12 +1,15 @@
 """ChatGPT integration service."""
 
+from __future__ import annotations
+
 import logging
 import os
-from typing import Optional
 
 import openai
 
+
 logger = logging.getLogger(__name__)
+
 
 class ChatGPTService:
     """Wrapper for the OpenAI Chat Completion API."""
@@ -25,7 +28,6 @@ class ChatGPTService:
                 temperature=0.7,
             )
             return response.choices[0].message.content.strip()
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             logger.error("ChatGPT request failed: %s", exc)
             return "Unable to fetch response from ChatGPT."
-


### PR DESCRIPTION
## Summary
- clean up ChatGPT integration service
- streamline startup routines in FastAPI UI app
- ensure Python code passes flake8 checks

## Testing
- `pytest -q`
- `flake8 ai_stock_platform/ui/services/chatgpt_service.py ai-stock-platform/ui/app_startup.py`


------
https://chatgpt.com/codex/tasks/task_e_6884d578aa28832a961620dde4f3d2b9