### PR TITLE
Add pre-market prediction endpoint

### DIFF
--- a/ai-stock-platform/api/main.py
+++ b/ai-stock-platform/api/main.py
@@ -36,6 +36,7 @@ from routers.docs import router as docs_router
 import sentry_sdk
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 from fastapi import Response as FastAPIResponse
+from utils.data_loader import load_stock_data
 
 REQUEST_COUNT = Counter(
     'api_requests_total',
@@ -625,6 +626,38 @@ async def get_stock(request: Request, symbol: str):
         )
     else:
         raise NotFoundError(f"Stock with symbol {validated_symbol} not found")
+
+
+@app.get("/api/v1/predictions/pre-market/{symbol}")
+async def pre_market_prediction(request: Request, symbol: str) -> Response:
+    """Generate a simple pre-market prediction based on recent closing prices."""
+    logger.info("Pre-market prediction endpoint accessed")
+    try:
+        df = await load_stock_data(symbol, period="5d")
+        if df.empty or "close" not in df.columns:
+            raise ValueError("No historical data available")
+
+        predicted_open = float(df["close"].tail(5).mean())
+        current_price = float(df["close"].iloc[-1])
+
+        data = {
+            "symbol": symbol,
+            "current_price": current_price,
+            "predicted_open": predicted_open,
+        }
+
+        return create_success_response(
+            data=data,
+            message="Pre-market prediction generated",
+            request_id=getattr(request.state, 'request_id', None),
+        )
+    except Exception as e:
+        logger.error(f"Error generating pre-market prediction: {e}")
+        return create_error_response(
+            message="Failed to generate pre-market prediction",
+            error_code="INTERNAL_SERVER_ERROR",
+            request_id=getattr(request.state, 'request_id', None),
+        )
 
 
 async def trending_stock_broadcaster() -> None:

--- a/ai-stock-platform/ui/src/config/constants.ts
+++ b/ai-stock-platform/ui/src/config/constants.ts
@@ -43,6 +43,7 @@ export const API_ENDPOINTS = {
     COMPARISON: '/api/v1/predictions/comparison',
     ACCURACY: '/api/v1/predictions/accuracy',
     MODELS: '/api/v1/predictions/models',
+    PRE_MARKET: (symbol: string) => `/api/v1/predictions/pre-market/${symbol}`,
   },
   // Watchlist endpoints
   WATCHLISTS: {

--- a/ai-stock-platform/ui/src/services/api-service.ts
+++ b/ai-stock-platform/ui/src/services/api-service.ts
@@ -234,6 +234,13 @@ class ApiService {
     return response.data.data;
   }
 
+  async getPreMarketPrediction(symbol: string): Promise<StockPrediction> {
+    const response = await apiClient.get<StandardResponse<StockPrediction>>(
+      API_ENDPOINTS.PREDICTIONS.PRE_MARKET(symbol)
+    );
+    return response.data.data;
+  }
+
   // Sentiment methods
   async getStockSentiment(symbol: string): Promise<StockSentiment> {
     const response = await apiClient.get<StandardResponse<StockSentiment>>(

--- a/tests/test_pre_market_endpoint.py
+++ b/tests/test_pre_market_endpoint.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+ROOT = os.path.join(os.path.dirname(__file__), "..", "ai-stock-platform")
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "api"))
+
+from api.main import app
+
+
+def test_pre_market_prediction_endpoint():
+    client = TestClient(app)
+    resp = client.get("/api/v1/predictions/pre-market/TEST")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["status"] == "success"
+    assert "predicted_open" in payload["data"]


### PR DESCRIPTION
## Summary
- implement simple pre‑market prediction route
- expose new endpoint in frontend constants and service
- add test for the new API route

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884d5ec7fbc832aa1aa16dc1f0822ed