### PR TITLE
Fix websocket auth for market data

### DIFF
--- a/ai-stock-platform/api/routers/websocket.py
+++ b/ai-stock-platform/api/routers/websocket.py
@@ -37,17 +37,20 @@ async def websocket_endpoint(
             await websocket.close(code=1008)
             return
 
-        # Require and verify token
-        if not token:
-            await websocket.close(code=4001, reason="Token required")
-            return
-
+        # Require and verify token, except for public market data stream
         user = None
-        try:
-            user = await get_current_user(token)
-        except Exception:
-            await websocket.close(code=4001, reason="Invalid token")
-            return
+        if not token:
+            if client_id == "market-data":
+                logger.info("Allowing anonymous WebSocket connection for market-data")
+            else:
+                await websocket.close(code=4001, reason="Token required")
+                return
+        if token:
+            try:
+                user = await get_current_user(token)
+            except Exception:
+                await websocket.close(code=4001, reason="Invalid token")
+                return
 
         # Connect to WebSocket
         await manager.connect(websocket, client_id)


### PR DESCRIPTION
## Summary
- allow anonymous connections to the `/ws/market-data` endpoint
- run project tests (they currently fail due to missing dependencies)

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.data_loader')*

------
https://chatgpt.com/codex/tasks/task_e_6884de0915c4832abddca0424f505328