### PR TITLE
Fix default API base URL for UI

### DIFF
--- a/ai-stock-platform/ui/src/config/constants.ts
+++ b/ai-stock-platform/ui/src/config/constants.ts
@@ -9,7 +9,7 @@ const viteEnv: Record<string, string> = (typeof import.meta !== 'undefined' && i
 export const API_BASE_URL =
   viteEnv.VITE_API_URL ||
   (typeof process !== 'undefined' ? process.env.REACT_APP_API_URL : undefined) ||
-  'https://dev.quantumvestai.com';
+  'http://quantumvestai-dev-api:8000';
 
 // Authentication
 export const ACCESS_TOKEN_KEY = 'qvai_token';


### PR DESCRIPTION
## Summary
- point `API_BASE_URL` to the dev API service by default

## Testing
- `pytest -q` *(fails: 8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884e030ede0832ab4cd8bf1fb7af479