### PR TITLE
Add stocks page route

### DIFF
--- a/ai-stock-platform/ui/controllers/stock_controller.py
+++ b/ai-stock-platform/ui/controllers/stock_controller.py
@@ -13,6 +13,7 @@ from ui.config.constants import AVAILABLE_MODELS, MODEL_ENSEMBLE
 
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
+from services.trending_stocks_service import TrendingStocksService
 
 router = APIRouter()
 templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent.parent / "templates"))
@@ -26,6 +27,39 @@ logger = logging.getLogger("quantumvestai.stock_controller")
 # Get API URL from environment or use default
 API_URL = os.environ.get("API_URL", "http://quantumvestai-dev-api:8000")
 API_V1_URL = f"{API_URL}/api/v1"
+
+
+@router.get("/stocks", response_class=HTMLResponse)
+async def stocks_list(
+    request: Request,
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+):
+    """Display a list of trending stocks."""
+    try:
+        trending = await TrendingStocksService().get_trending_stocks(page=page, limit=limit)
+        stocks = trending.get("stocks", [])
+        return get_templates(request).TemplateResponse(
+            "stocks/index.html",
+            {
+                "request": request,
+                "stocks": stocks,
+                "pagination": trending.get("pagination"),
+                "demo_mode": True,
+                "page_title": "Stocks - QuantumVestAI",
+            },
+        )
+    except Exception as e:
+        logger.error(f"Error loading stocks list: {e}")
+        return get_templates(request).TemplateResponse(
+            "error.html",
+            {
+                "request": request,
+                "error": "Unable to load stocks",
+                "page_title": "Stocks Error",
+            },
+            status_code=500,
+        )
 
 @router.get("/stock/search", response_class=HTMLResponse)
 async def stock_search(

--- a/ai-stock-platform/ui/templates/stocks/index.html
+++ b/ai-stock-platform/ui/templates/stocks/index.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+
+{% block title %}Stocks - QuantumVestAI{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="/">Home</a></li>
+<li class="breadcrumb-item active">Stocks</li>
+{% endblock %}
+
+{% block content %}
+<div class="page-header mb-4">
+    <div class="header-content">
+        <h1 class="page-title">Trending Stocks</h1>
+        <p class="text-muted">Browse currently trending stocks</p>
+    </div>
+</div>
+
+{% if error %}
+<div class="alert alert-danger" role="alert">
+    {{ error }}
+</div>
+{% endif %}
+
+<div class="card">
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th>Symbol</th>
+                        <th>Name</th>
+                        <th>Price</th>
+                        <th>Change</th>
+                        <th>% Change</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for stock in stocks %}
+                    <tr>
+                        <td><a href="/stock/{{ stock.symbol }}">{{ stock.symbol }}</a></td>
+                        <td>{{ stock.name }}</td>
+                        <td>${{ stock.price | round(2) }}</td>
+                        <td class="{% if stock.change > 0 %}text-success{% elif stock.change < 0 %}text-danger{% endif %}">
+                            {{ stock.change | round(2) }}
+                        </td>
+                        <td class="{% if stock.change_percent > 0 %}text-success{% elif stock.change_percent < 0 %}text-danger{% endif %}">
+                            {{ stock.change_percent | round(2) }}%
+                        </td>
+                        <td><a class="btn btn-sm btn-primary" href="/stock/{{ stock.symbol }}">Details</a></td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- serve trending stock list at `/stocks`
- add Jinja template rendering trending stocks

## Testing
- `./setup_env.sh`
- `source venv/bin/activate && pytest -q` *(fails: 8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884ebd07c28832a9f59738cf19ab66c