### PR TITLE
Disable demo mode by default

### DIFF
--- a/ai-stock-platform/core/config/settings.py
+++ b/ai-stock-platform/core/config/settings.py
@@ -43,7 +43,7 @@ class Settings(BaseSettings):
     BACKEND_CORS_ORIGINS: list[str] | str | None = None
 
     # Toggle demo mode for UI. When False the UI fetches live data.
-    DEMO_MODE: bool = Field(default=True, env="DEMO_MODE")
+    DEMO_MODE: bool = Field(default=False, env="DEMO_MODE")
 
     @field_validator("BACKEND_CORS_ORIGINS", mode="before")
     @classmethod

--- a/ai-stock-platform/ui/README.md
+++ b/ai-stock-platform/ui/README.md
@@ -90,4 +90,4 @@ This is a complete, production-ready web UI for the QuantumVestAI platform featu
 
 ## 🎉 Ready for Production Deployment!
 
-This application is fully functional and ready for immediate deployment. By default it runs in demo mode using sample data. Set `DEMO_MODE=false` and configure the database variables (`DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`) to enable live data for subscribed users. When live mode is enabled, market data is persisted to the configured PostgreSQL database and AI price predictions are displayed on the dashboard.
+This application is fully functional and ready for immediate deployment. Demo mode is disabled by default. Set `DEMO_MODE=true` to use sample data or configure the database variables (`DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`) to enable live data for subscribed users. When live mode is enabled, market data is persisted to the configured PostgreSQL database and AI price predictions are displayed on the dashboard.

--- a/ai-stock-platform/ui/routes/predictability.py
+++ b/ai-stock-platform/ui/routes/predictability.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
+from core.config import settings
 
 # Setup router
 router = APIRouter(prefix="/predictability", tags=["predictability"])
@@ -66,8 +67,9 @@ async def predictability_page(
                 "ticker": ticker,
                 "timeframe": timeframe,
                 "model": model,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "stock_data": stock_data,
+                "stock_info": stock_data,
                 "historical_scores": historical_scores,
                 "top_stocks": top_stocks,
                 "sector_data": SECTOR_PREDICTABILITY,
@@ -84,11 +86,12 @@ async def predictability_page(
                 "ticker": ticker,
                 "timeframe": timeframe,
                 "model": model,
-                "demo_mode": True,
-                "stock_data": {},
-                "historical_scores": [],
-                "top_stocks": [],
-                "sector_data": {},
+            "demo_mode": settings.DEMO_MODE,
+            "stock_data": {},
+            "stock_info": {},
+            "historical_scores": [],
+            "top_stocks": [],
+            "sector_data": {},
                 "error": f"Error loading predictability analysis: {str(e)}",
                 "page_title": "Predictability Error"
             },


### PR DESCRIPTION
## Summary
- disable DEMO_MODE by default in settings
- show configured demo mode in predictability page
- update README on how to enable demo mode

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6884f5665820832abf4b4ed400286e51