### PR TITLE
Fix DEMO_MODE import for predictability route

### DIFF
--- a/ai-stock-platform/ui/routes/predictability.py
+++ b/ai-stock-platform/ui/routes/predictability.py
@@ -11,7 +11,10 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
-from core.config import settings
+# Import the settings instance directly from the configuration module. Importing
+# via ``core.config`` can sometimes resolve to the module object rather than the
+# ``settings`` instance which leads to missing attributes like ``DEMO_MODE``.
+from core.config.settings import settings
 
 # Setup router
 router = APIRouter(prefix="/predictability", tags=["predictability"])


### PR DESCRIPTION
## Summary
- ensure predictability route loads the settings instance from `core.config.settings`
- run setup and tests

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.data_loader')*

------
https://chatgpt.com/codex/tasks/task_e_6884fc2dc0a4832ab299bb691bf16c87