### PR TITLE
Fix missing TrendingStocksService in UI

### DIFF
--- a/ai-stock-platform/ui/services/trending_stocks_service.py
+++ b/ai-stock-platform/ui/services/trending_stocks_service.py
@@ -1,0 +1,29 @@
+"""Async wrapper around the API trending stocks endpoint."""
+
+import asyncio
+import logging
+from typing import Any, Dict, Optional
+
+from .api_client import APIClient
+
+logger = logging.getLogger(__name__)
+
+class TrendingStocksService:
+    """Fetch trending stocks by calling the backend API."""
+
+    def __init__(self, token: Optional[str] = None) -> None:
+        self.client = APIClient(token=token)
+
+    async def get_trending_stocks(self, page: int = 1, limit: int = 10) -> Dict[str, Any]:
+        """Return trending stocks data from the API."""
+
+        def _fetch() -> Dict[str, Any]:
+            return self.client.get("/stocks/trending", params={"page": page, "limit": limit})
+
+        try:
+            return await asyncio.to_thread(_fetch)
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.warning("Failed to fetch trending stocks: %s", exc)
+            return {"stocks": [], "pagination": None}
+
+__all__ = ["TrendingStocksService"]

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,11 @@
+"""Compatibility wrapper so ``import api`` works in tests."""
+from pathlib import Path
+import sys
+
+root = Path(__file__).resolve().parent.parent
+_pkg = root / "ai-stock-platform" / "api"
+__path__ = [str(_pkg)]
+if str(_pkg) not in sys.path:
+    sys.path.insert(0, str(_pkg))
+if str(_pkg.parent) not in sys.path:
+    sys.path.insert(0, str(_pkg.parent))


### PR DESCRIPTION
## Summary
- add a lightweight TrendingStocksService implementation so UI can fetch trending stocks
- add compatibility `api` package for tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_688500f1ed70832abf70ec1fa15b61a4