### PR TITLE
Enable live market data

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ To disable the built-in mock responses and fetch live quotes you must also set
 unset (the default) will cause the services to fall back to generated demo data
 even if the API key is provided.
 
+For Kubernetes deployments, edit `ci-cd/k8s/api-deployment.yaml` and add
+`ENABLE_REAL_DATA=true` to the API container's environment variables so the
+service fetches live data.
+
 ## Database Setup
 
 The API uses asynchronous SQLAlchemy connections. Before running the server you must

--- a/ci-cd/k8s/api-deployment.yaml
+++ b/ci-cd/k8s/api-deployment.yaml
@@ -129,6 +129,8 @@ spec:
             secretKeyRef:
               name: app-secrets
               key: RAPIDAPI_KEY
+        - name: ENABLE_REAL_DATA
+          value: "true"
         envFrom:
         - configMapRef:
             name: api-configmap


### PR DESCRIPTION
## Summary
- enable real data by default in Kubernetes API deployment
- mention ENABLE_REAL_DATA in README for Kubernetes users

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: PytestCollectionWarning and 10 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688507092c40832aadc5f4c35b31c7af