### PR TITLE
Fix demo mode flag in UI

### DIFF
--- a/ai-stock-platform/ui/controllers/auth_controller.py
+++ b/ai-stock-platform/ui/controllers/auth_controller.py
@@ -13,6 +13,7 @@ import requests
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
+from core.config import settings
 
 router = APIRouter()
 logger = logging.getLogger("quantumvestai.auth_controller")
@@ -406,9 +407,6 @@ async def password_reset_post(request: Request, email: str = Form(...)):
 
 @router.get("/auth/whoami")
 async def whoami(request: Request):
-    """Test route to show current user info (demo mode)"""
-    
-    # Demo mode - always return unauthenticated
-    return JSONResponse({"authenticated": False, "demo_mode": True}, status_code=401)
-    """Test route to show current user info"""
-    return JSONResponse({"authenticated": False}, status_code=401)
+    """Test route to show current user info."""
+
+    return JSONResponse({"authenticated": False, "demo_mode": settings.DEMO_MODE}, status_code=401)

--- a/ai-stock-platform/ui/controllers/forecast_controller.py
+++ b/ai-stock-platform/ui/controllers/forecast_controller.py
@@ -7,6 +7,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, Optional
+from core.config import settings
 
 import requests
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -100,7 +101,7 @@ async def forecast_home(request: Request):
             {
                 "request": request,
                 "user": None,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "forecast_data": forecast_data,
                 "market_overview": market_overview,
                 "page_title": "AI Forecast Dashboard",
@@ -115,7 +116,7 @@ async def forecast_home(request: Request):
             {
                 "request": request,
                 "user": None,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "error": f"Error loading forecast dashboard: {str(e)}",
                 "page_title": "Forecast Error"
             },
@@ -178,7 +179,7 @@ async def stock_forecast(
             {
                 "request": request,
                 "user": None,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "stock_data": stock_forecast_data,
                 "available_timeframes": ["7d", "30d", "90d", "1y"],
                 "page_title": f"{symbol} Forecast",
@@ -193,7 +194,7 @@ async def stock_forecast(
             {
                 "request": request,
                 "user": None,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "error": f"Error loading forecast for {symbol}: {str(e)}",
                 "page_title": "Stock Forecast Error"
             },
@@ -233,7 +234,7 @@ async def get_predictions_api(
             "predictions": predictions,
             "timeframe": timeframe,
             "total_count": len(predictions),
-            "demo_mode": True
+            "demo_mode": settings.DEMO_MODE
         }
         
     except Exception as e:
@@ -265,7 +266,7 @@ async def get_market_sentiment_api(request: Request):
                 "consumer": "neutral"
             },
             "timestamp": "2025-07-07T21:39:48Z",
-            "demo_mode": True
+            "demo_mode": settings.DEMO_MODE
         }
         
         return {
@@ -286,5 +287,5 @@ async def forecast_health_check():
         "status": "healthy",
         "service": "forecast",
         "timestamp": "2025-07-07T21:39:48Z",
-        "demo_mode": True
+        "demo_mode": settings.DEMO_MODE
     }

--- a/ai-stock-platform/ui/controllers/stock_controller.py
+++ b/ai-stock-platform/ui/controllers/stock_controller.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import aiohttp
 from fastapi import APIRouter, Form, HTTPException, Query, Request
 from ui.config.constants import AVAILABLE_MODELS, MODEL_ENSEMBLE
+from core.config import settings
 
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
@@ -45,7 +46,7 @@ async def stocks_list(
                 "request": request,
                 "stocks": stocks,
                 "pagination": trending.get("pagination"),
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "page_title": "Stocks - QuantumVestAI",
             },
         )
@@ -143,7 +144,7 @@ async def stock_search(
                 "results": search_results,
                 "error": error_message,
                 "user": None,
-                "demo_mode": True
+                "demo_mode": settings.DEMO_MODE
             }
         )
     except Exception as e:
@@ -158,7 +159,7 @@ async def stock_search(
                 "error": f"An unexpected error occurred: {str(e)}",
                 "results": [],
                 "user": None,
-                "demo_mode": True
+                "demo_mode": settings.DEMO_MODE
             }
         )
 
@@ -246,7 +247,7 @@ async def stock_detail(
                 "request": request,
                 "stock": stock_data,
                 "user": None,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "available_models": AVAILABLE_MODELS
             }
         )
@@ -256,7 +257,7 @@ async def stock_detail(
         logger.error(f"Stock detail error for {ticker}: {str(e)}")
         return get_templates(request).TemplateResponse(
             "error.html",
-            {"request": request, "error": str(e), "user": None, "demo_mode": True},
+            {"request": request, "error": str(e), "user": None, "demo_mode": settings.DEMO_MODE},
             status_code=500
         )
 
@@ -270,7 +271,7 @@ async def stock_flow_page(request: Request):
             {
                 "request": request,
                 "user": None,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
             },
         )
     except Exception as e:  # pragma: no cover - template errors

--- a/ai-stock-platform/ui/dependencies/common.py
+++ b/ai-stock-platform/ui/dependencies/common.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from core.config.constants import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from fastapi import Query, Request
+from core.config import settings
 
 # Prefer the standalone ``services`` package but fall back to the
 # old ``ui.services`` path when running tests from the monorepo.
@@ -26,7 +27,7 @@ async def get_template_context(request: Request) -> Dict[str, Any]:
         "request": request,
         "user": None,
         "now": datetime.now(),
-        "demo_mode": True,
+        "demo_mode": settings.DEMO_MODE,
         "is_admin": False,
         "is_premium": False
     }

--- a/ai-stock-platform/ui/routes/api_proxy.py
+++ b/ai-stock-platform/ui/routes/api_proxy.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
+from core.config import settings
 
 # Setup router
 router = APIRouter(prefix="/api/v1", tags=["api"])
@@ -108,7 +109,7 @@ async def api_proxy_health():
         "status": "healthy",
         "service": "api_proxy",
         "timestamp": datetime.utcnow().isoformat(),
-        "demo_mode": True
+        "demo_mode": settings.DEMO_MODE
     }
 
 # Generic API proxy for other endpoints
@@ -123,7 +124,7 @@ async def generic_api_proxy(request: Request, path: str):
         return JSONResponse({
             "status": "success",
             "message": f"Demo response for {method} /{path}",
-            "demo_mode": True,
+            "demo_mode": settings.DEMO_MODE,
             "timestamp": datetime.utcnow().isoformat()
         })
         

--- a/ai-stock-platform/ui/routes/forecast.py
+++ b/ai-stock-platform/ui/routes/forecast.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
+from core.config import settings
 
 # Setup router
 router = APIRouter(prefix="/forecast", tags=["forecast"])
@@ -44,7 +45,7 @@ async def forecast_home(request: Request):
             "forecast.html",
             {
                 "request": request,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "predictions": top_predictions,
                 "market_sentiment": MARKET_SENTIMENT,
                 "featured_stocks": [],
@@ -58,7 +59,7 @@ async def forecast_home(request: Request):
             "forecast.html",
             {
                 "request": request,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "predictions": [],
                 "market_sentiment": {},
                 "featured_stocks": [],
@@ -101,7 +102,7 @@ async def stock_forecast(
                 "request": request,
                 "symbol": symbol,
                 "timeframe": timeframe,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "stock_data": demo_data,
                 "prediction": prediction,
                 "historical_data": historical_data,
@@ -161,7 +162,7 @@ async def model_comparison(request: Request):
             "model_comparison.html",
             {
                 "request": request,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "models": model_performance,
                 "page_title": "Model Comparison - QuantumVestAI"
             }
@@ -234,7 +235,7 @@ async def forecast_health_check():
         "status": "healthy",
         "service": "forecast",
         "timestamp": datetime.utcnow().isoformat(),
-        "demo_mode": True,
+        "demo_mode": settings.DEMO_MODE,
         "models_available": [],
         "predictions_count": 0
     }

--- a/ai-stock-platform/ui/routes/market.py
+++ b/ai-stock-platform/ui/routes/market.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
+from core.config import settings
 
 # Setup router and templates
 router = APIRouter(prefix="/market", tags=["market"])
@@ -43,7 +44,7 @@ async def market_overview(request: Request):
             "market/overview.html",
             {
                 "request": request,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "data": data,
                 "market_news": market_news,
                 "page_title": "Market Overview - QuantumVestAI"
@@ -56,7 +57,7 @@ async def market_overview(request: Request):
             "market/overview.html",
             {
                 "request": request,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "data": {
                     "timestamp": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC"),
                     "overview": None,
@@ -134,7 +135,7 @@ async def ticker_details(
                 "request": request,
                 "ticker": ticker,
                 "period": period,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "stock_data": stock_data,
                 "chart_data": chart_data,
                 "technical_indicators": technical_indicators,
@@ -216,7 +217,7 @@ async def market_sentiment(
             {
                 "request": request,
                 "period": period,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "sentiment_data": sentiment_data,
                 "page_title": "Market Sentiment - QuantumVestAI"
             }

--- a/ai-stock-platform/ui/routes/predictability.py
+++ b/ai-stock-platform/ui/routes/predictability.py
@@ -131,7 +131,7 @@ async def predictability_ranking_page(
                 "request": request,
                 "sector": sector,
                 "limit": limit,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "ranked_stocks": ranked_stocks,
                 "sector_data": SECTOR_PREDICTABILITY,
                 "available_sectors": list(SECTOR_PREDICTABILITY.keys()),
@@ -193,7 +193,7 @@ async def predictability_comparison_page(
                 "request": request,
                 "tickers": ticker_list,
                 "timeframe": timeframe,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "comparison_data": comparison_data,
                 "page_title": "Predictability Comparison - QuantumVestAI"
             }
@@ -207,7 +207,7 @@ async def predictability_comparison_page(
                 "request": request,
                 "tickers": tickers.split(","),
                 "timeframe": timeframe,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "comparison_data": [],
                 "error": f"Error loading comparison: {str(e)}",
                 "page_title": "Comparison Error"
@@ -270,7 +270,7 @@ async def predictability_health_check():
         "status": "healthy",
         "service": "predictability",
         "timestamp": datetime.utcnow().isoformat(),
-        "demo_mode": True,
+        "demo_mode": settings.DEMO_MODE,
         "stocks_analyzed": 0,
         "sectors_available": 0
     }

--- a/ai-stock-platform/ui/routes/settings.py
+++ b/ai-stock-platform/ui/routes/settings.py
@@ -11,6 +11,7 @@ from typing import Optional
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
+from core.config import settings
 
 # Setup router
 router = APIRouter(prefix="/settings", tags=["settings"])
@@ -43,7 +44,7 @@ async def settings_page(request: Request):
             "settings.html",
             {
                 "request": request,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "settings": DEMO_USER_SETTINGS,
                 "page_title": "Settings - QuantumVestAI"
             }

--- a/ai-stock-platform/ui/routes/utils.py
+++ b/ai-stock-platform/ui/routes/utils.py
@@ -11,6 +11,7 @@ from typing import Optional
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
+from core.config import settings
 
 # Setup router
 router = APIRouter(prefix="/utils", tags=["utils"])
@@ -32,7 +33,7 @@ async def health_check():
         "status": "healthy",
         "service": "utils",
         "timestamp": datetime.utcnow().isoformat(),
-        "demo_mode": True,
+        "demo_mode": settings.DEMO_MODE,
         "version": "2.0.0",
         "author": "hemanth9398"
     }
@@ -49,7 +50,7 @@ async def get_version_info():
             "build": {
                 "environment": "demo",
                 "features": ["auth", "dashboard", "forecast", "market", "watchlist", "predictability", "settings"],
-                "demo_mode": True
+                "demo_mode": settings.DEMO_MODE
             },
             "timestamp": datetime.utcnow().isoformat()
         })

--- a/ai-stock-platform/ui/routes/watchlist.py
+++ b/ai-stock-platform/ui/routes/watchlist.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
+from core.config import settings
 
 # Setup router
 router = APIRouter(prefix="/watchlist", tags=["watchlist"])
@@ -50,7 +51,7 @@ async def watchlist_page(request: Request, view: str = "grid"):
             "watchlist.html",
             {
                 "request": request,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "watchlist": DEMO_WATCHLIST,
                 "portfolio": DEMO_PORTFOLIO,
                 "summary": watchlist_summary,
@@ -65,7 +66,7 @@ async def watchlist_page(request: Request, view: str = "grid"):
             "watchlist.html",
             {
                 "request": request,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "watchlist": [],
                 "portfolio": {},
                 "summary": {},
@@ -296,7 +297,7 @@ async def portfolio_page(request: Request):
             "portfolio.html",
             {
                 "request": request,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "portfolio": DEMO_PORTFOLIO,
                 "metrics": portfolio_metrics,
                 "page_title": "Portfolio - QuantumVestAI"
@@ -343,7 +344,7 @@ async def alerts_page(request: Request):
             "alerts.html",
             {
                 "request": request,
-                "demo_mode": True,
+                "demo_mode": settings.DEMO_MODE,
                 "alerts": active_alerts,
                 "page_title": "Price Alerts - QuantumVestAI"
             }

--- a/ai-stock-platform/ui/utils/template_context.py
+++ b/ai-stock-platform/ui/utils/template_context.py
@@ -9,6 +9,7 @@ This ensures consistent availability of essential variables like `now`, `user`, 
 
 import logging
 import os
+from core.config import settings
 from datetime import datetime
 from typing import Any, Callable, Dict, Optional
 
@@ -54,8 +55,8 @@ class TemplateContextProcessor:
             
             # Feature flags
             "debug_mode": os.environ.get("DEBUG", "false").lower() == "true",
-            # Demo mode is disabled by default. Enable by setting DEMO_MODE=true
-            "demo_mode": os.environ.get("DEMO_MODE", "false").lower() == "true",
+            # Demo mode flag from shared settings
+            "demo_mode": settings.DEMO_MODE,
             
             # Time helpers
             "timestamp": datetime.utcnow().isoformat(),


### PR DESCRIPTION
## Summary
- import shared `settings` in several UI modules
- use `settings.DEMO_MODE` when rendering templates instead of hardcoded values
- update template context processor to rely on shared configuration

## Testing
- `pytest -q` *(fails: 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68854b8c3e40832a933b3212938152ac