### PR TITLE
Fix profile path routing

### DIFF
--- a/ai-stock-platform/ui/main.py
+++ b/ai-stock-platform/ui/main.py
@@ -955,6 +955,7 @@ routers_to_include = [
     ("ui.routes.forecast", "forecast"),
     ("ui.routes.market", "market"),
     ("ui.routes.watchlist", "watchlist"),
+    ("ui.routes.profile", "profile"),
     ("ui.routes.predictability", "predictability"),
     ("ui.routes.settings", "settings"),
     ("ui.routes.ai_api", "ai_api"),

--- a/ai-stock-platform/ui/routes/__init__.py
+++ b/ai-stock-platform/ui/routes/__init__.py
@@ -29,6 +29,11 @@ except ImportError:
     watchlist_router = None
 
 try:
+    from .profile import router as profile_router
+except ImportError:
+    profile_router = None
+
+try:
     from .predictability import router as predictability_router
 except ImportError:
     predictability_router = None
@@ -55,7 +60,8 @@ all_routers = [
         dashboard_router, 
         forecast_router,
         market_router,
-        watchlist_router, 
+        watchlist_router,
+        profile_router,
         predictability_router,
         settings_router,
         api_proxy_router,


### PR DESCRIPTION
## Summary
- include profile router in routes package
- add profile router to the main router registration

## Testing
- `pytest -q` *(fails: 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68855bf2deac832ab7f540828ead4bab