### PR TITLE
Fix pytest collection of SQLAlchemy models

### DIFF
--- a/ai-stock-platform/ui/routes/admin.py
+++ b/ai-stock-platform/ui/routes/admin.py
@@ -7,7 +7,8 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from config.settings import settings
+# Import settings from the shared core config to avoid missing-module errors
+from core.config.settings import settings
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates

--- a/ai-stock-platform/ui/routes/profile.py
+++ b/ai-stock-platform/ui/routes/profile.py
@@ -10,7 +10,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from config.settings import settings
+# Import settings from the shared core config
+from core.config.settings import settings
 from fastapi import (APIRouter, Depends, File, Form, HTTPException, Request,
                      UploadFile)
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse

--- a/ai-stock-platform/ui/routes/settings_old.py
+++ b/ai-stock-platform/ui/routes/settings_old.py
@@ -7,7 +7,8 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from config.settings import settings
+# Import settings from the shared core configuration
+from core.config.settings import settings
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates

--- a/ai-stock-platform/ui/test_startup.py
+++ b/ai-stock-platform/ui/test_startup.py
@@ -42,10 +42,11 @@ try:
     for module in modules_to_test:
         try:
             # Test if we can at least parse the module
-            with open(f"{module.replace('.', '/')}.py", 'r') as f:
+            module_path = current_dir / f"{module.replace('.', '/')}.py"
+            with open(module_path, 'r') as f:
                 content = f.read()
                 # Simple validation - check if it compiles
-                compile(content, f"{module}.py", 'exec')
+                compile(content, str(module_path), 'exec')
             imported_modules.append(module)
             print(f"✓ {module}")
         except Exception as e:
@@ -72,19 +73,21 @@ try:
     missing_dirs = []
     
     for dir_name in required_dirs:
-        if os.path.exists(dir_name):
+        dir_path = current_dir / dir_name
+        if dir_path.exists():
             print(f"✓ {dir_name}/ directory exists")
         else:
             missing_dirs.append(dir_name)
             print(f"✗ {dir_name}/ directory missing")
     
     # Check main.py
-    if os.path.exists('main.py'):
+    main_path = current_dir / 'main.py'
+    if main_path.exists():
         print("✓ main.py exists")
         try:
-            with open('main.py', 'r') as f:
+            with open(main_path, 'r') as f:
                 content = f.read()
-                compile(content, 'main.py', 'exec')
+                compile(content, str(main_path), 'exec')
             print("✓ main.py compiles successfully")
         except Exception as e:
             print(f"✗ main.py compilation error: {str(e)}")

--- a/tests/test_prediction_data_agent.py
+++ b/tests/test_prediction_data_agent.py
@@ -10,9 +10,11 @@ from sqlalchemy.orm import declarative_base
 from sqlalchemy import Column, Integer, Float, String, DateTime
 
 TestBase = declarative_base()
+# Mark the base class so PyTest does not treat it as a test
+TestBase.__test__ = False
 
 
-class TestStock(TestBase):
+class Stock(TestBase):
     __tablename__ = "stocks"
     id = Column(Integer, primary_key=True)
     ticker = Column(String)
@@ -22,7 +24,7 @@ class TestStock(TestBase):
     last_updated = Column(DateTime)
 
 
-class TestStockPrice(TestBase):
+class StockPrice(TestBase):
     __tablename__ = "stock_prices"
     id = Column(Integer, primary_key=True)
     stock_id = Column(Integer)
@@ -59,11 +61,11 @@ def test_prediction_data_agent(monkeypatch):
     agent = PredictionDataAgent(
         session,
         ["TEST"],
-        stock_model=TestStock,
-        price_model=TestStockPrice,
+        stock_model=Stock,
+        price_model=StockPrice,
     )
     agent.update_symbols(days=1)
 
-    assert session.query(TestStock).count() == 1
-    assert session.query(TestStockPrice).count() == 1
+    assert session.query(Stock).count() == 1
+    assert session.query(StockPrice).count() == 1
 


### PR DESCRIPTION
## Summary
- rename local SQLAlchemy models in `test_prediction_data_agent.py`
- adjust references to new names
- fix imports in UI routes to use core settings
- update UI startup test to validate paths relative to its directory

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68855f974d54832ab56df731c7e49140