### PR TITLE
Add notifications page route

### DIFF
--- a/ai-stock-platform/main.py
+++ b/ai-stock-platform/main.py
@@ -994,6 +994,15 @@ async def dashboard(request: Request):
             status_code=200
         )
 
+# Notifications page
+@app.get("/notifications", response_class=HTMLResponse)
+async def notifications(request: Request):
+    """Display user notifications."""
+    return app.state.templates.TemplateResponse(
+        "notifications.html",
+        {"request": request}
+    )
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(

--- a/ai-stock-platform/ui/templates/notifications.html
+++ b/ai-stock-platform/ui/templates/notifications.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}Notifications - QuantumVestAI{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="/">Home</a></li>
+<li class="breadcrumb-item active">Notifications</li>
+{% endblock %}
+
+{% block content %}
+<div class="page-header mb-4">
+    <div class="header-content">
+        <h1 class="page-title">Notifications</h1>
+        <p class="text-muted">View your latest alerts and messages</p>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-body">
+        <p class="mb-0">No notifications to display.</p>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a route for `/notifications` in the UI app
- create a simple notifications template

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q` *(fails: 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68857e8dcad8832abba63e6cbdb0dfe7