### PR TITLE
Fix Twitter API key retrieval

### DIFF
--- a/ai-stock-platform/api/social/twitter_sentiment.py
+++ b/ai-stock-platform/api/social/twitter_sentiment.py
@@ -6,15 +6,25 @@ Enhanced: 2025-01-09 (AI Assistant)
 """
 import asyncio
 import logging
+import os
 import re
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
 import tweepy
-from core.config import settings
-from core.exceptions import (ConfigurationError, ExternalAPIError,
-                             RateLimitError)
+from core.exceptions import (
+    ConfigurationError,
+    ExternalAPIError,
+    RateLimitError,
+)
+
+# Read credentials directly from the environment to avoid stale values
+TWITTER_BEARER_TOKEN = os.getenv("TWITTER_BEARER_TOKEN")
+TWITTER_API_KEY = os.getenv("TWITTER_API_KEY") or os.getenv("TWITTER_CONSUMER_KEY")
+TWITTER_API_SECRET = os.getenv("TWITTER_API_SECRET") or os.getenv("TWITTER_CONSUMER_SECRET")
+TWITTER_ACCESS_TOKEN = os.getenv("TWITTER_ACCESS_TOKEN")
+TWITTER_ACCESS_TOKEN_SECRET = os.getenv("TWITTER_ACCESS_TOKEN_SECRET") or os.getenv("TWITTER_ACCESS_SECRET")
 from textblob import TextBlob
 
 # Import the sentiment record from the API models package explicitly to avoid
@@ -31,21 +41,21 @@ class TwitterSentimentAnalyzer:
         try:
             # Check if credentials are available
             if not any([
-                settings.TWITTER_BEARER_TOKEN,
-                settings.TWITTER_API_KEY,
-                settings.TWITTER_API_SECRET,
-                settings.TWITTER_ACCESS_TOKEN,
-                settings.TWITTER_ACCESS_TOKEN_SECRET
+                TWITTER_BEARER_TOKEN,
+                TWITTER_API_KEY,
+                TWITTER_API_SECRET,
+                TWITTER_ACCESS_TOKEN,
+                TWITTER_ACCESS_TOKEN_SECRET,
             ]):
                 raise ConfigurationError("Twitter API credentials not configured")
-            
+
             # Twitter API credentials
             self.client = tweepy.Client(
-                bearer_token=settings.TWITTER_BEARER_TOKEN,
-                consumer_key=settings.TWITTER_API_KEY,
-                consumer_secret=settings.TWITTER_API_SECRET,
-                access_token=settings.TWITTER_ACCESS_TOKEN,
-                access_token_secret=settings.TWITTER_ACCESS_TOKEN_SECRET,
+                bearer_token=TWITTER_BEARER_TOKEN,
+                consumer_key=TWITTER_API_KEY,
+                consumer_secret=TWITTER_API_SECRET,
+                access_token=TWITTER_ACCESS_TOKEN,
+                access_token_secret=TWITTER_ACCESS_TOKEN_SECRET,
                 wait_on_rate_limit=True  # Automatically wait when rate limited
             )
             

--- a/ai-stock-platform/api/twitter_config.py
+++ b/ai-stock-platform/api/twitter_config.py
@@ -7,23 +7,35 @@ from typing import Optional
 
 
 class TwitterConfig:
-    """Simple Twitter configuration class"""
-    
-    def __init__(self):
-        self.TWITTER_BEARER_TOKEN = os.getenv('TWITTER_BEARER_TOKEN')
+    """Simple Twitter configuration class that reads values from the environment"""
 
-        # Support both new-style and legacy environment variable names so that
-        # deployments using either set will work correctly. The *.env.template*
-        # file uses the legacy `TWITTER_CONSUMER_*` names while the code expects
-        # `TWITTER_API_*`.  Here we check the API variables first and fall back
-        # to the consumer versions if they are present.
-        self.TWITTER_API_KEY = os.getenv('TWITTER_API_KEY') or os.getenv('TWITTER_CONSUMER_KEY')
-        self.TWITTER_API_SECRET = os.getenv('TWITTER_API_SECRET') or os.getenv('TWITTER_CONSUMER_SECRET')
-        self.TWITTER_ACCESS_TOKEN = os.getenv('TWITTER_ACCESS_TOKEN')
-        self.TWITTER_ACCESS_TOKEN_SECRET = (
-            os.getenv('TWITTER_ACCESS_TOKEN_SECRET')
-            or os.getenv('TWITTER_ACCESS_SECRET')
-        )
+    def __init__(self) -> None:
+        """No-op constructor for compatibility."""
+        # The previous implementation stored the values at import time.  This
+        # caused issues when environment variables were updated after the module
+        # was loaded.  The new implementation exposes properties that read from
+        # ``os.environ`` on each access so the latest values are always used.
+        pass
+
+    @property
+    def TWITTER_BEARER_TOKEN(self) -> Optional[str]:
+        return os.getenv('TWITTER_BEARER_TOKEN')
+
+    @property
+    def TWITTER_API_KEY(self) -> Optional[str]:
+        return os.getenv('TWITTER_API_KEY') or os.getenv('TWITTER_CONSUMER_KEY')
+
+    @property
+    def TWITTER_API_SECRET(self) -> Optional[str]:
+        return os.getenv('TWITTER_API_SECRET') or os.getenv('TWITTER_CONSUMER_SECRET')
+
+    @property
+    def TWITTER_ACCESS_TOKEN(self) -> Optional[str]:
+        return os.getenv('TWITTER_ACCESS_TOKEN')
+
+    @property
+    def TWITTER_ACCESS_TOKEN_SECRET(self) -> Optional[str]:
+        return os.getenv('TWITTER_ACCESS_TOKEN_SECRET') or os.getenv('TWITTER_ACCESS_SECRET')
     
     def has_credentials(self) -> bool:
         """Check if any Twitter credentials are configured"""
@@ -32,7 +44,7 @@ class TwitterConfig:
             self.TWITTER_API_KEY,
             self.TWITTER_API_SECRET,
             self.TWITTER_ACCESS_TOKEN,
-            self.TWITTER_ACCESS_TOKEN_SECRET
+            self.TWITTER_ACCESS_TOKEN_SECRET,
         ])
 
 # Create global instance


### PR DESCRIPTION
## Summary
- dynamically load Twitter credentials via `os.environ`
- use environment variables directly in Twitter sentiment module

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 10 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885870006fc832a8bde184d297b9b70