### PR TITLE
Add nav auto hide on scroll

### DIFF
--- a/ai-stock-platform/ui/static/css/quantum-enhancements.css
+++ b/ai-stock-platform/ui/static/css/quantum-enhancements.css
@@ -205,6 +205,11 @@ body {
   transition: var(--transition-quantum);
 }
 
+/* Hide navigation when scrolling down */
+.quantum-nav.nav-hidden {
+  transform: translateY(-100%);
+}
+
 .quantum-nav.scrolled {
   background: var(--glass-dark);
   box-shadow: var(--quantum-shadow-soft);

--- a/ai-stock-platform/ui/static/js/navigation.js
+++ b/ai-stock-platform/ui/static/js/navigation.js
@@ -22,9 +22,7 @@ class NavigationController {
         this.setupSearchFunctionality();
         this.setupDropdownMenus();
         this.setupTooltips();
-        // Scroll-based nav hiding caused unexpected jumping on some pages.
-        // Temporarily disable scroll effects to keep the main menu fixed.
-        // this.setupScrollEffects();
+        this.setupScrollEffects();
         this.setupKeyboardNavigation();
     }
     
@@ -522,28 +520,34 @@ NavigationController.prototype.setupTooltips = function() {
 NavigationController.prototype.setupScrollEffects = function() {
     const nav = document.querySelector('.quantum-nav');
     if (!nav) return;
-    
     let lastScrollY = window.scrollY;
-    
-    window.addEventListener('scroll', () => {
+    let ticking = false;
+
+    const update = () => {
         const currentScrollY = window.scrollY;
-        
-        // Add scrolled class when scrolling down
+
         if (currentScrollY > 50) {
             nav.classList.add('scrolled');
         } else {
             nav.classList.remove('scrolled');
         }
-        
-        // Hide/show navigation based on scroll direction
-        if (currentScrollY > lastScrollY && currentScrollY > 200) {
-            nav.style.transform = 'translateY(-100%)';
+
+        if (currentScrollY > lastScrollY && currentScrollY > 100) {
+            nav.classList.add('nav-hidden');
         } else {
-            nav.style.transform = 'translateY(0)';
+            nav.classList.remove('nav-hidden');
         }
-        
+
         lastScrollY = currentScrollY;
-    });
+        ticking = false;
+    };
+
+    window.addEventListener('scroll', () => {
+        if (!ticking) {
+            window.requestAnimationFrame(update);
+            ticking = true;
+        }
+    }, { passive: true });
 };
 
 NavigationController.prototype.setupKeyboardNavigation = function() {


### PR DESCRIPTION
## Summary
- enable navigation scroll effects so the top bar hides when scrolling down
- add CSS helper class to translate nav out of view

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68858ba17a70832aa3850ca28a729a4a