### PR TITLE
Fix utils imports and logging

### DIFF
--- a/ai-stock-platform/api/main.py
+++ b/ai-stock-platform/api/main.py
@@ -36,7 +36,6 @@ from routers.docs import router as docs_router
 import sentry_sdk
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 from fastapi import Response as FastAPIResponse
-from utils.data_loader import load_stock_data
 
 REQUEST_COUNT = Counter(
     'api_requests_total',
@@ -633,6 +632,7 @@ async def pre_market_prediction(request: Request, symbol: str) -> Response:
     """Generate a simple pre-market prediction based on recent closing prices."""
     logger.info("Pre-market prediction endpoint accessed")
     try:
+        from utils.data_loader import load_stock_data
         df = await load_stock_data(symbol, period="5d")
         if df.empty or "close" not in df.columns:
             raise ValueError("No historical data available")

--- a/ai-stock-platform/api/utils/logging.py
+++ b/ai-stock-platform/api/utils/logging.py
@@ -1,18 +1,19 @@
 import json
-import logging
+import importlib
+py_logging = importlib.import_module("logging")
 import traceback
 from datetime import datetime
 from typing import Any, Dict, Optional
 
 
-class JsonFormatter(logging.Formatter):
+class JsonFormatter(py_logging.Formatter):
     """Custom formatter that outputs log entries as JSON."""
     
     def __init__(self, fmt=None, datefmt=None, style='%', validate=True):
         """Initialize JsonFormatter."""
         super().__init__(fmt, datefmt, style, validate)
     
-    def format(self, record: logging.LogRecord) -> str:
+    def format(self, record: py_logging.LogRecord) -> str:
         """Format log record as JSON."""
         log_data = {
             "timestamp": datetime.utcnow().isoformat(),
@@ -60,14 +61,14 @@ def setup_logger(
     name: str,
     level: str = "INFO",
     log_file: Optional[str] = None
-) -> logging.Logger:
+) -> py_logging.Logger:
     """Set up and return a logger with the specified configuration."""
-    logger = logging.getLogger(name)
-    logger.setLevel(getattr(logging, level))
+    logger = py_logging.getLogger(name)
+    logger.setLevel(getattr(py_logging, level))
     
     # Add console handler
-    console_handler = logging.StreamHandler()
-    console_handler.setFormatter(logging.Formatter(
+    console_handler = py_logging.StreamHandler()
+    console_handler.setFormatter(py_logging.Formatter(
         "%(levelname)s | %(asctime)s | %(name)s | %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S"
     ))
@@ -75,7 +76,7 @@ def setup_logger(
     
     # Add file handler if log file specified
     if log_file:
-        file_handler = logging.handlers.RotatingFileHandler(
+        file_handler = py_logging.handlers.RotatingFileHandler(
             log_file,
             maxBytes=10485760,  # 10MB
             backupCount=5

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,7 +1,21 @@
-import sys
-from pathlib import Path
+"""Utility package compatibility wrapper.
 
-_pkg_path = Path(__file__).resolve().parent.parent / 'ai-stock-platform' / 'ui' / 'utils'
-__path__ = [str(_pkg_path)]
-if str(_pkg_path) not in sys.path:
-    sys.path.insert(0, str(_pkg_path))
+This module exposes the utility packages from both the UI and API portions of
+the project under a single namespace.  Earlier revisions only exposed the UI
+utilities which meant imports such as ``utils.data_loader`` failed during test
+collection.  The path handling has been extended to include the API utilities as
+well so that ``import utils.*`` works consistently across the codebase.
+"""
+
+from pathlib import Path
+import sys
+
+root = Path(__file__).resolve().parent.parent / "ai-stock-platform"
+ui_utils = root / "ui" / "utils"
+api_utils = root / "api" / "utils"
+
+__path__ = [str(ui_utils), str(api_utils)]
+
+for pkg_path in (ui_utils, api_utils):
+    if str(pkg_path) not in sys.path:
+        sys.path.insert(0, str(pkg_path))


### PR DESCRIPTION
## Summary
- include API utils in `utils` package path
- avoid circular logging import
- lazily import `load_stock_data` to reduce side effects

## Testing
- `pytest -q` *(fails: 49 failed, 71 passed, 7 skipped, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68858ea898e4832aae2b0419d48d75fd