### PR TITLE
Fix relative import in twitter sentiment module

### DIFF
--- a/ai-stock-platform/api/social/twitter_sentiment.py
+++ b/ai-stock-platform/api/social/twitter_sentiment.py
@@ -19,7 +19,17 @@ from core.exceptions import (
 )
 
 # Read credentials directly from the environment each time using twitter_config
-from ..twitter_config import twitter_config
+# Import the configuration with fallbacks so the module works whether the
+# ``api`` package is the execution context or ``social`` is imported as a
+# top-level module.  This avoids ``ImportError: attempted relative import beyond
+# top-level package`` when running the API from different entry points.
+try:
+    from api.twitter_config import twitter_config  # type: ignore
+except Exception:  # pragma: no cover - fallback for local package execution
+    try:
+        from twitter_config import twitter_config  # type: ignore
+    except Exception:  # pragma: no cover - final fallback
+        from ..twitter_config import twitter_config
 from textblob import TextBlob
 
 # Import the sentiment record from the API models package explicitly to avoid


### PR DESCRIPTION
## Summary
- avoid 'attempted relative import beyond top-level package' error
- load `twitter_config` with a series of fallbacks so the module can be imported from different entry points

## Testing
- `pytest -q` *(fails: ImportError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_688591fe51b8832a935de536b8bbc50f