### PR TITLE
Fix profile template missing user bug

### DIFF
--- a/ai-stock-platform/ui/templates/admin/users.html
+++ b/ai-stock-platform/ui/templates/admin/users.html
@@ -158,7 +158,7 @@
                                     <img src="{{ user.avatar_url }}" alt="{{ user.username }}">
                                     {% else %}
                                     <div class="avatar-placeholder">
-                                        <span>{{ user.username[0]|upper }}</span>
+                                        <span>{{ user.username[0]|upper if user and user.username else '' }}</span>
                                     </div>
                                     {% endif %}
                                 </div>

--- a/ai-stock-platform/ui/templates/profile.html
+++ b/ai-stock-platform/ui/templates/profile.html
@@ -45,7 +45,7 @@
                         <img src="{{ user.avatar_url }}" alt="{{ user.username }}">
                         {% else %}
                         <div class="avatar-placeholder">
-                            <span>{{ user.username[0]|upper }}</span>
+                            <span>{{ user.username[0]|upper if user and user.username else '' }}</span>
                         </div>
                         {% endif %}
                         <div class="avatar-overlay">


### PR DESCRIPTION
## Summary
- prevent crash when user is undefined in profile page
- handle missing user in admin user list

## Testing
- `pytest -q` *(fails: 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6885a668ad88832a8b50ed45f864435f