### PR TITLE
Add notifications dropdown behavior

### DIFF
--- a/ai-stock-platform/ui/static/css/quantum-enhancements.css
+++ b/ai-stock-platform/ui/static/css/quantum-enhancements.css
@@ -109,8 +109,23 @@ p {
 }
 
 .notifications-dropdown {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 100%;
   width: 320px;
   padding: var(--space-md);
+  background: var(--glass-dark);
+  backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--quantum-shadow-strong);
+  margin-top: var(--space-xs);
+  z-index: var(--z-dropdown);
+}
+
+.notifications-dropdown.show {
+  display: block;
 }
 
 .notifications-list {

--- a/ai-stock-platform/ui/static/js/notifications.js
+++ b/ai-stock-platform/ui/static/js/notifications.js
@@ -1,0 +1,39 @@
+// Simple notifications dropdown handler
+// Handles toggling and mark-all-read functionality
+
+document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('notificationsToggle');
+    const dropdown = document.getElementById('notificationsDropdown');
+    const markAllBtn = document.querySelector('.mark-all-read-btn');
+    const badge = document.querySelector('.notification-badge');
+
+    if (toggle && dropdown) {
+        toggle.addEventListener('click', (e) => {
+            e.stopPropagation();
+            dropdown.classList.toggle('show');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!dropdown.contains(e.target) && !toggle.contains(e.target)) {
+                dropdown.classList.remove('show');
+            }
+        });
+    }
+
+    if (markAllBtn && dropdown) {
+        markAllBtn.addEventListener('click', () => {
+            dropdown.querySelectorAll('.notification-card.unread')
+                .forEach(card => card.classList.remove('unread'));
+            if (badge) {
+                badge.textContent = '0';
+                badge.style.display = 'none';
+            }
+        });
+    }
+
+    dropdown?.querySelectorAll('.notification-dismiss').forEach(btn => {
+        btn.addEventListener('click', () => {
+            btn.closest('.notification-card')?.remove();
+        });
+    });
+});

--- a/ai-stock-platform/ui/templates/base.html
+++ b/ai-stock-platform/ui/templates/base.html
@@ -416,6 +416,7 @@
     <script src="{{ get_asset_url('js/enhanced-ui.js') }}" defer></script>
     <script src="{{ get_asset_url('js/navigation.js') }}" defer></script>
     <script src="{{ get_asset_url('js/auth.js') }}" defer></script>
+    <script src="{{ get_asset_url('js/notifications.js') }}" defer></script>
 
     
     <!-- Progressive Web App Support -->


### PR DESCRIPTION
## Summary
- style notifications dropdown and hide by default
- add JavaScript to handle notification dropdown interactions
- include notifications script in base layout

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6886dc0099f4832a8b773eb035b6ee40