### PR TITLE
Add market overview endpoint

### DIFF
--- a/ai-stock-platform/api/main.py
+++ b/ai-stock-platform/api/main.py
@@ -33,6 +33,7 @@ from routers.websocket import manager as websocket_manager
 from routers.websocket import router as websocket_router
 from routers.social import router as social_router
 from routers.docs import router as docs_router
+from routers.analytics import public_router as analytics_public_router
 import sentry_sdk
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 from fastapi import Response as FastAPIResponse
@@ -93,6 +94,7 @@ app.include_router(websocket_router)
 app.include_router(auth_router, prefix="/api/v1/auth")
 app.include_router(social_router)
 app.include_router(docs_router)
+app.include_router(analytics_public_router, prefix="/api/v1")
 
 # Request logging middleware
 @app.middleware("http")

--- a/ai-stock-platform/api/routers/analytics.py
+++ b/ai-stock-platform/api/routers/analytics.py
@@ -6,7 +6,7 @@ Author: daparthi001
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from core.exceptions import PermissionDeniedError, ResourceNotFoundError
+from core.exceptions import ResourceNotFoundError, PermissionError as PermissionDeniedError
 from core.security import get_current_user
 from db.models.user import User
 from db.session import get_db
@@ -43,6 +43,8 @@ public_router = APIRouter(
     prefix="/analytics",
     tags=["analytics"]
 )
+
+from services.market_overview_service import MarketOverviewService
 
 @router.get(
     "/portfolio/{portfolio_id}",
@@ -280,3 +282,25 @@ async def track_pageview(
             "timestamp": pageview_data.timestamp
         }
     }
+
+
+@public_router.get(
+    "/market-overview",
+    summary="Market overview",
+    description="Get market indices and sector performance"
+)
+async def get_market_overview() -> Dict[str, Any]:
+    """Return aggregated market overview data."""
+    data = MarketOverviewService.get_market_overview()
+    return {"data": data, "timestamp": datetime.utcnow().isoformat()}
+
+
+@public_router.get(
+    "/top-movers",
+    summary="Top market movers",
+    description="Get top gaining and losing stocks"
+)
+async def get_top_movers() -> Dict[str, Any]:
+    """Return top gainers and losers."""
+    movers = MarketOverviewService.get_top_movers()
+    return {"data": movers, "timestamp": datetime.utcnow().isoformat()}

--- a/ai-stock-platform/api/services/__init__.py
+++ b/ai-stock-platform/api/services/__init__.py
@@ -46,6 +46,15 @@ except ImportError as e:
     YahooRapidAPIService = None
     YAHOO_RAPIDAPI_SERVICE_AVAILABLE = False
 
+# Market overview service
+try:
+    from services.market_overview_service import MarketOverviewService
+    MARKET_OVERVIEW_SERVICE_AVAILABLE = True
+except ImportError as e:
+    print(f"Warning: MarketOverviewService not available - {e}")
+    MarketOverviewService = None  # type: ignore
+    MARKET_OVERVIEW_SERVICE_AVAILABLE = False
+
 # Only include available services in __all__
 __all__ = []
 if STOCK_SERVICE_AVAILABLE:
@@ -58,3 +67,5 @@ if FORECAST_SERVICE_AVAILABLE:
     __all__.append('ForecastService')
 if YAHOO_RAPIDAPI_SERVICE_AVAILABLE:
     __all__.append('YahooRapidAPIService')
+if MARKET_OVERVIEW_SERVICE_AVAILABLE:
+    __all__.append('MarketOverviewService')

--- a/ai-stock-platform/api/services/market_overview_service.py
+++ b/ai-stock-platform/api/services/market_overview_service.py
@@ -1,0 +1,133 @@
+import logging
+from datetime import datetime
+from typing import Any, Dict, List
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+try:
+    import yfinance as yf
+except Exception:  # pragma: no cover - optional dependency
+    yf = None
+
+# Basic constants mirroring UI service
+MARKET_INDICES = {
+    "S&P 500": "^GSPC",
+    "Dow Jones": "^DJI",
+    "NASDAQ": "^IXIC",
+    "Russell 2000": "^RUT",
+    "VIX": "^VIX",
+}
+
+SECTOR_ETFS = {
+    "Technology": "VGT",
+    "Healthcare": "VHT",
+    "Financials": "VFH",
+    "Consumer Discretionary": "VCR",
+    "Consumer Staples": "VDC",
+    "Energy": "VDE",
+    "Industrials": "VIS",
+    "Utilities": "VPU",
+    "Materials": "VAW",
+    "Real Estate": "VNQ",
+    "Communication Services": "VOX",
+}
+
+DEFAULT_TICKERS = ["AAPL", "MSFT", "GOOGL", "AMZN", "TSLA"]
+
+logger = logging.getLogger(__name__)
+
+class MarketOverviewService:
+    """Simple market overview service using yfinance when available."""
+
+    @staticmethod
+    def _fetch_info(symbol: str) -> Dict[str, Any]:
+        """Fetch basic quote info for a symbol."""
+        if yf is None:
+            # Return mock values if yfinance is unavailable
+            return {
+                "symbol": symbol,
+                "price": 0.0,
+                "change": 0.0,
+                "change_percent": 0.0,
+                "volume": 0,
+                "name": symbol,
+            }
+        try:
+            ticker = yf.Ticker(symbol)
+            info = ticker.info
+            return {
+                "symbol": symbol,
+                "price": info.get("regularMarketPrice", 0.0),
+                "change": info.get("regularMarketChange", 0.0),
+                "change_percent": info.get("regularMarketChangePercent", 0.0),
+                "volume": info.get("regularMarketVolume", 0),
+                "name": info.get("shortName", symbol),
+            }
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.warning("Failed to fetch info for %s: %s", symbol, exc)
+            return {
+                "symbol": symbol,
+                "price": 0.0,
+                "change": 0.0,
+                "change_percent": 0.0,
+                "volume": 0,
+                "name": symbol,
+            }
+
+    @classmethod
+    def get_market_overview(cls) -> Dict[str, Any]:
+        """Return market overview including indices and sector performance."""
+        overview = {
+            "date": datetime.utcnow().strftime("%Y-%m-%d"),
+            "indices": [],
+            "sectors": [],
+            "market_sentiment": "neutral",
+            "volatility_index": 0.0,
+        }
+
+        # Fetch indices
+        indices = []
+        for name, sym in MARKET_INDICES.items():
+            data = cls._fetch_info(sym)
+            indices.append({
+                "name": name,
+                "value": data.get("price", 0.0),
+                "change_percent": data.get("change_percent", 0.0),
+            })
+            if sym == "^VIX":
+                overview["volatility_index"] = data.get("price", 0.0)
+        overview["indices"] = indices
+
+        # Derive simple sentiment from average change
+        if indices:
+            avg_change = sum(i.get("change_percent", 0.0) for i in indices) / len(indices)
+            if avg_change > 0.2:
+                overview["market_sentiment"] = "bullish"
+            elif avg_change < -0.2:
+                overview["market_sentiment"] = "bearish"
+            else:
+                overview["market_sentiment"] = "neutral"
+
+        # Fetch sectors
+        sectors = []
+        for sector, sym in SECTOR_ETFS.items():
+            data = cls._fetch_info(sym)
+            sectors.append({
+                "name": sector,
+                "change_percent": data.get("change_percent", 0.0),
+            })
+        overview["sectors"] = sectors
+        return overview
+
+    @classmethod
+    def get_top_movers(cls) -> Dict[str, List[Dict[str, Any]]]:
+        """Return simple top gainers and losers from a sample list."""
+        tickers = DEFAULT_TICKERS + ["GOOGL", "NFLX", "META", "NVDA"]
+        results: List[Dict[str, Any]] = []
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            futures = {executor.submit(cls._fetch_info, t): t for t in tickers}
+            for fut in as_completed(futures):
+                results.append(fut.result())
+
+        gainers = sorted(results, key=lambda x: x.get("change_percent", 0.0), reverse=True)[:5]
+        losers = sorted(results, key=lambda x: x.get("change_percent", 0.0))[:5]
+        return {"gainers": gainers, "losers": losers}

--- a/tests/test_market_overview_endpoint.py
+++ b/tests/test_market_overview_endpoint.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+ROOT = os.path.join(os.path.dirname(__file__), "..", "ai-stock-platform")
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "api"))
+
+from api.main import app
+
+
+def test_market_overview_endpoint():
+    client = TestClient(app)
+    resp = client.get("/api/v1/analytics/market-overview")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "data" in data
+    assert "indices" in data["data"]
+
+
+def test_top_movers_endpoint():
+    client = TestClient(app)
+    resp = client.get("/api/v1/analytics/top-movers")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert "data" in payload
+    assert "gainers" in payload["data"]
+    assert "losers" in payload["data"]

--- a/utils/market_data.py
+++ b/utils/market_data.py
@@ -1,0 +1,12 @@
+"""Placeholder market data utilities used for tests."""
+
+from typing import Any, Dict
+
+def get_market_data(symbol: str, interval: str = "1min", **kwargs) -> Dict[str, Any]:
+    """Return mock market data for testing."""
+    return {"symbol": symbol, "interval": interval, "data": []}
+
+class MarketDataClient:
+    """Simple mock market data client."""
+    def get_data(self, symbol: str, interval: str = "1min", **kwargs) -> Dict[str, Any]:
+        return get_market_data(symbol, interval, **kwargs)


### PR DESCRIPTION
## Summary
- implement `MarketOverviewService` for simple market data
- expose new `/api/v1/analytics/market-overview` and `/api/v1/analytics/top-movers` endpoints
- include router in API main application
- add placeholder utils.market_data to satisfy imports
- create tests for the new endpoints

## Testing
- `pytest tests/test_market_overview_endpoint.py -q` *(fails: No module named 'utils.market_data')*


------
https://chatgpt.com/codex/tasks/task_e_6886dbe7f800832a9976fc64cc534d96