### PR TITLE
Add utility for fetching market indices

### DIFF
--- a/utils/fetch_indices.py
+++ b/utils/fetch_indices.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from datetime import datetime
+
+# Ensure we can import the API package
+ROOT = os.path.join(os.path.dirname(__file__), "..", "ai-stock-platform")
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "api"))
+
+from api.services.market_overview_service import MarketOverviewService
+
+
+def main():
+    overview = MarketOverviewService.get_market_overview()
+    date = overview.get("date")
+    print(f"Market overview for {date}")
+    for idx in overview.get("indices", []):
+        name = idx.get("name")
+        value = idx.get("value")
+        change = idx.get("change_percent")
+        icon = "📈" if change >= 0 else "📉"
+        print(f"{name}: {icon} ${value:.2f} ({change:+.2f}%)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `utils/fetch_indices.py` for retrieving market indices via `MarketOverviewService`

## Testing
- `pytest -q` *(fails: 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6886e5dcae44832a80949573c1dfce21