### PR TITLE
Fix Pydantic protected namespace warning

### DIFF
--- a/ai-stock-platform/api/schemas/analytics.py
+++ b/ai-stock-platform/api/schemas/analytics.py
@@ -113,6 +113,9 @@ class PredictiveAnalyticsResponse(BaseModel):
     model_metrics: Dict[str, float]
     feature_importance: Dict[str, float]
 
+    # Disable protected namespace warnings for fields beginning with "model_"
+    model_config = {"protected_namespaces": ()}
+
 class SentimentScore(BaseModel):
     """Sentiment score schema."""
     source: str


### PR DESCRIPTION
## Summary
- disable protected namespace warnings on PredictiveAnalyticsResponse

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6886e75f18c8832aa58fe9c9a57c846d