### PR TITLE
Fix Pydantic protected namespace warnings

### DIFF
--- a/ai-stock-platform/api/schemas/admin.py
+++ b/ai-stock-platform/api/schemas/admin.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
+from .base import SafeBaseModel
 
 
 class SystemMetrics(BaseModel):
@@ -55,7 +56,7 @@ class APIKeyResponse(BaseModel):
     last_used: Optional[datetime]
     permissions: List[str]
 
-class UsageMetrics(BaseModel):
+class UsageMetrics(SafeBaseModel):
     """Usage metrics schema."""
     total_requests: int
     unique_users: int
@@ -65,7 +66,7 @@ class UsageMetrics(BaseModel):
     model_accuracy: float
     average_response_time: float
 
-class UsageStatsResponse(BaseModel):
+class UsageStatsResponse(SafeBaseModel):
     """Usage statistics response schema."""
     period_start: datetime
     period_end: datetime
@@ -74,7 +75,7 @@ class UsageStatsResponse(BaseModel):
     popular_endpoints: List[Dict[str, Any]]
     error_rates: Dict[str, float]
 
-class ModelMetrics(BaseModel):
+class ModelMetrics(SafeBaseModel):
     """Model metrics schema."""
     accuracy: float
     precision: float
@@ -83,7 +84,7 @@ class ModelMetrics(BaseModel):
     latency: float
     throughput: int
 
-class ModelPerformanceResponse(BaseModel):
+class ModelPerformanceResponse(SafeBaseModel):
     """Model performance response schema."""
     model_name: str
     model_version: str

--- a/ai-stock-platform/api/schemas/analytics.py
+++ b/ai-stock-platform/api/schemas/analytics.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
+from .base import SafeBaseModel
 
 
 class PortfolioMetrics(BaseModel):
@@ -104,7 +105,7 @@ class Prediction(BaseModel):
     probability: float
     factors: Dict[str, float]
 
-class PredictiveAnalyticsResponse(BaseModel):
+class PredictiveAnalyticsResponse(SafeBaseModel):
     """Predictive analytics response schema."""
     timestamp: datetime
     horizon: str

--- a/ai-stock-platform/api/schemas/base.py
+++ b/ai-stock-platform/api/schemas/base.py
@@ -6,7 +6,7 @@ Author: daparthi001
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, ConfigDict, validator
 
 
 class TimestampModel(BaseModel):
@@ -24,3 +24,8 @@ class ApiResponse(BaseModel):
     success: bool
     message: Optional[str] = None
     error: Optional[str] = None
+
+class SafeBaseModel(BaseModel):
+    """BaseModel with protected namespace warnings disabled."""
+
+    model_config = ConfigDict(protected_namespaces=())

--- a/ai-stock-platform/api/schemas/ml.py
+++ b/ai-stock-platform/api/schemas/ml.py
@@ -7,9 +7,10 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
+from .base import SafeBaseModel
 
 
-class ModelMetrics(BaseModel):
+class ModelMetrics(SafeBaseModel):
     """Model metrics schema."""
     accuracy: float
     precision: float
@@ -21,7 +22,7 @@ class ModelMetrics(BaseModel):
     latency: float
     memory_usage: float
 
-class ModelResponse(BaseModel):
+class ModelResponse(SafeBaseModel):
     """Model response schema."""
     id: int
     name: str
@@ -50,7 +51,7 @@ class TrainingConfig(BaseModel):
     early_stopping: bool
     custom_parameters: Optional[Dict[str, Any]]
 
-class ModelTrainingResponse(BaseModel):
+class ModelTrainingResponse(SafeBaseModel):
     """Model training response schema."""
     job_id: str
     model_id: int
@@ -69,7 +70,7 @@ class EvaluationMetric(BaseModel):
     threshold: Optional[float]
     comparison: Optional[str]
 
-class ModelEvaluationResponse(BaseModel):
+class ModelEvaluationResponse(SafeBaseModel):
     """Model evaluation response schema."""
     model_id: int
     timestamp: datetime
@@ -87,7 +88,7 @@ class PredictionResult(BaseModel):
     features_used: Dict[str, Any]
     explanation: Optional[Dict[str, Any]]
 
-class ModelPredictionResponse(BaseModel):
+class ModelPredictionResponse(SafeBaseModel):
     """Model prediction response schema."""
     model_id: int
     timestamp: datetime
@@ -110,7 +111,7 @@ class FeatureImportanceResponse(BaseModel):
     features: List[FeatureImportance]
     visualization_data: Dict[str, Any]
 
-class ModelComparison(BaseModel):
+class ModelComparison(SafeBaseModel):
     """Model comparison schema."""
     model_id: int
     name: str
@@ -118,7 +119,7 @@ class ModelComparison(BaseModel):
     advantages: List[str]
     disadvantages: List[str]
 
-class ModelComparisonResponse(BaseModel):
+class ModelComparisonResponse(SafeBaseModel):
     """Model comparison response schema."""
     timestamp: datetime
     models: List[ModelComparison]
@@ -126,7 +127,7 @@ class ModelComparisonResponse(BaseModel):
     comparison_matrix: Dict[str, List[float]]
     statistical_tests: Dict[str, Any]
 
-class Hyperparameter(BaseModel):
+class Hyperparameter(SafeBaseModel):
     """Hyperparameter schema."""
     name: str
     value: Any
@@ -134,7 +135,7 @@ class Hyperparameter(BaseModel):
     range: Optional[List[Any]]
     importance: Optional[float]
 
-class HyperparameterResponse(BaseModel):
+class HyperparameterResponse(SafeBaseModel):
     """Hyperparameter response schema."""
     model_id: int
     timestamp: datetime
@@ -142,7 +143,7 @@ class HyperparameterResponse(BaseModel):
     tuning_history: Optional[Dict[str, Any]]
     optimal_values: Dict[str, Any]
 
-class DatasetMetadata(BaseModel):
+class DatasetMetadata(SafeBaseModel):
     """Dataset metadata schema."""
     rows: int
     columns: int
@@ -151,7 +152,7 @@ class DatasetMetadata(BaseModel):
     time_range: Dict[str, datetime]
     missing_values: Dict[str, int]
 
-class DatasetResponse(BaseModel):
+class DatasetResponse(SafeBaseModel):
     """Dataset response schema."""
     id: int
     name: str


### PR DESCRIPTION
## Summary
- add `SafeBaseModel` that disables Pydantic protected namespaces
- use `SafeBaseModel` in analytics, admin and ml schemas

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 11 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6886e9218e44832aaf987f4ec7133fc7