### PR TITLE
Improve error handling for Alpha Vantage failures

### DIFF
--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 import os
 import random
+import json
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
@@ -224,11 +225,20 @@ class TrendingStocksService:
         
         try:
             async with session.get(self.base_url, params=params, timeout=10) as response:
+                text = await response.text()
                 if response.status == 200:
-                    data = await response.json()
+                    try:
+                        data = json.loads(text)
+                    except Exception as exc:
+                        logger.error(
+                            f"Error decoding response for {symbol}: {exc}; body: {text[:100]}"
+                        )
+                        return None
                     return self._parse_alpha_vantage_response(symbol, data)
                 else:
-                    logger.warning(f"API request failed for {symbol}: status {response.status}")
+                    logger.warning(
+                        f"API request failed for {symbol}: status {response.status}; body: {text[:100]}"
+                    )
                     return None
                     
         except asyncio.TimeoutError:
@@ -241,8 +251,16 @@ class TrendingStocksService:
     def _parse_alpha_vantage_response(self, symbol: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Parse Alpha Vantage API response into our format."""
         try:
+            if "Note" in data:
+                logger.warning(f"Alpha Vantage note for {symbol}: {data['Note']}")
+                return None
+            if "Error Message" in data:
+                logger.error(f"Alpha Vantage error for {symbol}: {data['Error Message']}")
+                return None
+
             quote = data.get("Global Quote", {})
             if not quote:
+                logger.warning(f"No quote data returned for {symbol}: {data}")
                 return None
             
             # Alpha Vantage field mappings

--- a/ai-stock-platform/api/tests/test_trending_stocks.py
+++ b/ai-stock-platform/api/tests/test_trending_stocks.py
@@ -177,6 +177,19 @@ async def test_data_consistency():
             assert -20 <= stock["change_percent"] <= 20  # Reasonable range
 
 
+def test_parse_alpha_vantage_errors():
+    """Ensure API error responses are handled gracefully."""
+    service = TrendingStocksService()
+
+    # Note message should return None
+    data_note = {"Note": "API limit"}
+    assert service._parse_alpha_vantage_response("AAPL", data_note) is None
+
+    # Error message should also return None
+    data_error = {"Error Message": "Invalid API call"}
+    assert service._parse_alpha_vantage_response("AAPL", data_error) is None
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- handle error responses from Alpha Vantage
- expose details when the API returns malformed data
- test the error parsing logic

## Testing
- `pytest -q` *(fails: 11 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6886f19b0ca8832aaca379baaf95a8b8