### PR TITLE
Ensure UI and API share default SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ kubectl apply -f ci-cd/k8s/all-secrets.yaml
 
 This single file avoids managing multiple secret manifests across environments.
 
-**Important:** The UI and API must use the same `SECRET_KEY` value. If these values differ, the UI cannot verify JWT tokens issued by the API and users may be redirected back to the login page repeatedly.
+**Important:** The UI and API must use the same `SECRET_KEY` value. If these values differ, the UI cannot verify JWT tokens issued by the API and users may be redirected back to the login page repeatedly. The default for both services is now `"your-secret-key"` to prevent mismatched values during local development.
 
 ### Generating Test JWT Tokens
 For manual testing you can generate a signed JWT from the command line:

--- a/ai-stock-platform/ui/auth/dependencies.py
+++ b/ai-stock-platform/ui/auth/dependencies.py
@@ -22,7 +22,8 @@ logger = logging.getLogger(__name__)
 
 # JWT Configuration
 # Prefer JWT_SECRET but fall back to SECRET_KEY for backward compatibility
-JWT_SECRET = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "default-dev-key")
+# Use the API default when neither is provided to avoid mismatched tokens
+JWT_SECRET = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "your-secret-key")
 JWT_ALGORITHM = "HS256"
 TOKEN_EXPIRE_MINUTES = int(os.getenv("TOKEN_EXPIRE_MINUTES", "60"))
 

--- a/ai-stock-platform/ui/config/auth.dependencies.py
+++ b/ai-stock-platform/ui/config/auth.dependencies.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 
 # JWT Configuration
 # Prefer JWT_SECRET but fall back to SECRET_KEY for backward compatibility
-JWT_SECRET = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "default-dev-key")
+# Use the API default when neither is provided to avoid mismatched tokens
+JWT_SECRET = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "your-secret-key")
 JWT_ALGORITHM = "HS256"
 TOKEN_EXPIRE_MINUTES = int(os.getenv("TOKEN_EXPIRE_MINUTES", "60"))
 

--- a/ai-stock-platform/ui/core/config/settings.py
+++ b/ai-stock-platform/ui/core/config/settings.py
@@ -31,7 +31,8 @@ class Settings:
     STATIC_DIR = BASE_DIR / "static"
     
     # Secret key for session encryption
-    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-key-change-in-production")
+    # Use the same default value as the API to avoid mismatched JWT secrets
+    SECRET_KEY = os.environ.get("SECRET_KEY", "your-secret-key")
     
     # CORS settings
     CORS_ORIGINS = os.environ.get("CORS_ORIGINS", "http://ui-service:3000,http://quantumvestai-dev-api.dev.svc.cluster.local:8000").split(",")
@@ -40,7 +41,8 @@ class Settings:
     API_BASE_URL = os.environ.get("API_BASE_URL", "http://quantumvestai-dev-api.dev.svc.cluster.local:8000")
     
     # JWT settings
-    JWT_SECRET = os.environ.get("JWT_SECRET", "jwt-secret-change-in-production")
+    # JWT secret should default to the same key as the API for local development
+    JWT_SECRET = os.environ.get("JWT_SECRET", SECRET_KEY)
     JWT_ALGORITHM = "HS256"
     JWT_ACCESS_TOKEN_EXPIRE_MINUTES = 60
     

--- a/ai-stock-platform/ui/middleware/auth_middleware.py
+++ b/ai-stock-platform/ui/middleware/auth_middleware.py
@@ -25,7 +25,8 @@ try:
     from core.config.settings import settings
 except Exception:  # pragma: no cover - fallback if settings import fails
     class Settings:
-        SECRET_KEY = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "supersecretkey123456789abcdef")
+        # Match API default to prevent token verification issues during import failures
+        SECRET_KEY = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "your-secret-key")
         JWT_ALGORITHM = "HS256"
         ACCESS_TOKEN_EXPIRE_MINUTES = 30
 

--- a/ai-stock-platform/ui/templates/auth/dependencies.py
+++ b/ai-stock-platform/ui/templates/auth/dependencies.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 
 # JWT Configuration
 # Prefer JWT_SECRET but fall back to SECRET_KEY for backward compatibility
-JWT_SECRET = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "default-dev-key")
+# Use the API default when neither is provided to avoid mismatched tokens
+JWT_SECRET = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "your-secret-key")
 JWT_ALGORITHM = "HS256"
 TOKEN_EXPIRE_MINUTES = int(os.getenv("TOKEN_EXPIRE_MINUTES", "60"))
 


### PR DESCRIPTION
## Summary
- set the UI default `SECRET_KEY` to match the API
- default `JWT_SECRET` to the same key when unset
- update auth helpers and middleware accordingly
- document unified default in README

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 11 errors)*


------
https://chatgpt.com/codex/tasks/task_e_6886f1581fbc832aab8147bfbad6c657