### PR TITLE
Add cooldown for trending stock warnings

### DIFF
--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -41,6 +41,7 @@ except ModuleNotFoundError:
 # Try to import aiohttp, fallback to None if not available
 try:
     import aiohttp
+
     AIOHTTP_AVAILABLE = True
 except ImportError:
     aiohttp = None
@@ -48,15 +49,18 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+
 class TrendingStocksService:
     """Service for managing trending stocks data with real-time updates and caching."""
-    
+
     def __init__(self):
         # Determine whether to fetch real data or use mocked values
         self.use_mock = not getattr(settings, "ENABLE_REAL_DATA", False)
 
         # Use configured API key, falling back to the settings value if provided
-        self.api_key = os.getenv("ALPHA_VANTAGE_API_KEY", settings.ALPHA_VANTAGE_API_KEY)
+        self.api_key = os.getenv(
+            "ALPHA_VANTAGE_API_KEY", settings.ALPHA_VANTAGE_API_KEY
+        )
         if not self.api_key and not self.use_mock:
             raise RuntimeError(
                 "ALPHA_VANTAGE_API_KEY must be set for real-time data access"
@@ -70,11 +74,13 @@ class TrendingStocksService:
         self.request_interval = float(os.getenv("ALPHA_VANTAGE_REQUEST_INTERVAL", "12"))
         self._cache: Dict[str, Any] = {}
         self._cache_timestamp: Optional[datetime] = None
-        
+        self.warning_cooldown = int(os.getenv("TRENDING_WARNING_COOLDOWN", "60"))
+        self._last_failure_warning: Optional[datetime] = None
+
         # Log dependency status
         if not AIOHTTP_AVAILABLE:
             raise RuntimeError("aiohttp is required for real-time data access")
-        
+
         # Placeholder list used until live data is fetched
         self.trending_symbols: List[str] = [
             "AAPL",
@@ -106,15 +112,17 @@ class TrendingStocksService:
         except Exception as exc:
             logger.warning(f"Failed to fetch Yahoo trending symbols: {exc}")
         return []
-    
-    async def get_trending_stocks(self, page: int = 1, limit: int = 10) -> Dict[str, Any]:
+
+    async def get_trending_stocks(
+        self, page: int = 1, limit: int = 10
+    ) -> Dict[str, Any]:
         """
         Get trending stocks with pagination.
-        
+
         Args:
             page: Page number for pagination
             limit: Number of items per page
-            
+
         Returns:
             Dict containing stocks data and pagination info
         """
@@ -144,16 +152,16 @@ class TrendingStocksService:
                     ]
 
             stocks_data = await self._fetch_trending_stocks()
-            
+
             # Update cache
             self._update_cache(stocks_data)
-            
+
             return self._get_paginated_data(stocks_data, page, limit)
-            
+
         except Exception as e:
             logger.error(f"Error fetching trending stocks: {e}")
             raise
-    
+
     async def _fetch_trending_stocks(self) -> List[Dict[str, Any]]:
         """Fetch trending stocks data from external API."""
         if self.use_mock or not AIOHTTP_AVAILABLE:
@@ -184,12 +192,24 @@ class TrendingStocksService:
                         logger.warning(f"Failed to fetch data for {symbol}")
                     # Avoid hitting the free tier limit of 5 requests per minute
                     # by sleeping between calls. Skip the delay after the last request.
-                    if idx < len(self.trending_symbols) - 1 and self.request_interval > 0:
+                    if (
+                        idx < len(self.trending_symbols) - 1
+                        and self.request_interval > 0
+                    ):
                         await asyncio.sleep(self.request_interval)
 
             # If all real-data fetches failed, fall back to mock data
             if not stocks_data:
-                logger.warning("All real data fetches failed; falling back to mock data")
+                now = datetime.now()
+                if (
+                    self._last_failure_warning is None
+                    or (now - self._last_failure_warning).total_seconds()
+                    > self.warning_cooldown
+                ):
+                    logger.warning(
+                        "All real data fetches failed; falling back to mock data"
+                    )
+                    self._last_failure_warning = now
                 for symbol in self.trending_symbols:
                     random.seed(symbol)
                     stocks_data.append(
@@ -208,53 +228,59 @@ class TrendingStocksService:
         stocks_data.sort(key=lambda x: x.get("change_percent", 0), reverse=True)
 
         return stocks_data
-    
-    async def _fetch_stock_quote(self, session, symbol: str) -> Optional[Dict[str, Any]]:
+
+    async def _fetch_stock_quote(
+        self, session, symbol: str
+    ) -> Optional[Dict[str, Any]]:
         """Fetch a single stock quote from Alpha Vantage."""
         if not AIOHTTP_AVAILABLE:
             # This should not be called if aiohttp is not available, but provide a safeguard
-            logger.warning(f"Cannot fetch stock quote for {symbol} - aiohttp not available")
+            logger.warning(
+                f"Cannot fetch stock quote for {symbol} - aiohttp not available"
+            )
             return None
-            
-        params = {
-            "function": "GLOBAL_QUOTE",
-            "symbol": symbol,
-            "apikey": self.api_key
-        }
-        
+
+        params = {"function": "GLOBAL_QUOTE", "symbol": symbol, "apikey": self.api_key}
+
         try:
-            async with session.get(self.base_url, params=params, timeout=10) as response:
+            async with session.get(
+                self.base_url, params=params, timeout=10
+            ) as response:
                 if response.status == 200:
                     data = await response.json()
                     return self._parse_alpha_vantage_response(symbol, data)
                 else:
-                    logger.warning(f"API request failed for {symbol}: status {response.status}")
+                    logger.warning(
+                        f"API request failed for {symbol}: status {response.status}"
+                    )
                     return None
-                    
+
         except asyncio.TimeoutError:
             logger.warning(f"Timeout fetching data for {symbol}")
             return None
         except Exception as e:
             logger.error(f"Error fetching data for {symbol}: {e}")
             return None
-    
-    def _parse_alpha_vantage_response(self, symbol: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+    def _parse_alpha_vantage_response(
+        self, symbol: str, data: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """Parse Alpha Vantage API response into our format."""
         try:
             quote = data.get("Global Quote", {})
             if not quote:
                 return None
-            
+
             # Alpha Vantage field mappings
             price = float(quote.get("05. price", 0))
             change = float(quote.get("09. change", 0))
-            change_percent = float(quote.get("10. change percent", "0%").rstrip('%'))
+            change_percent = float(quote.get("10. change percent", "0%").rstrip("%"))
             volume = int(quote.get("06. volume", 0))
-            
+
             # Get company name mapping (simplified)
             company_names = {
                 "AAPL": "Apple Inc.",
-                "MSFT": "Microsoft Corporation", 
+                "MSFT": "Microsoft Corporation",
                 "AMZN": "Amazon.com Inc.",
                 "GOOGL": "Alphabet Inc.",
                 "NVDA": "NVIDIA Corporation",
@@ -262,9 +288,9 @@ class TrendingStocksService:
                 "META": "Meta Platforms Inc.",
                 "NFLX": "Netflix Inc.",
                 "CRM": "Salesforce Inc.",
-                "ADBE": "Adobe Inc."
+                "ADBE": "Adobe Inc.",
             }
-            
+
             return {
                 "symbol": symbol,
                 "name": company_names.get(symbol, f"{symbol} Corp."),
@@ -272,37 +298,35 @@ class TrendingStocksService:
                 "change": round(change, 2),
                 "change_percent": round(change_percent, 2),
                 "volume": volume,
-                "last_updated": datetime.now().isoformat()
+                "last_updated": datetime.now().isoformat(),
             }
-            
+
         except (ValueError, KeyError) as e:
             logger.error(f"Error parsing data for {symbol}: {e}")
             return None
-    
-    
+
     def _is_cache_valid(self) -> bool:
         """Check if cache is valid based on TTL."""
         if not self._cache_timestamp or not self._cache:
             return False
-        
+
         age = datetime.now() - self._cache_timestamp
         return age.total_seconds() < self.cache_ttl
-    
+
     def _update_cache(self, stocks_data: List[Dict[str, Any]]) -> None:
         """Update cache with fresh data."""
-        self._cache = {
-            "stocks": stocks_data,
-            "timestamp": datetime.now().isoformat()
-        }
+        self._cache = {"stocks": stocks_data, "timestamp": datetime.now().isoformat()}
         self._cache_timestamp = datetime.now()
         logger.info(f"Cache updated with {len(stocks_data)} stocks")
-    
-    def _get_paginated_data(self, stocks_data: List[Dict[str, Any]], page: int, limit: int) -> Dict[str, Any]:
+
+    def _get_paginated_data(
+        self, stocks_data: List[Dict[str, Any]], page: int, limit: int
+    ) -> Dict[str, Any]:
         """Apply pagination to stocks data."""
         start_idx = (page - 1) * limit
         end_idx = start_idx + limit
         paginated_stocks = stocks_data[start_idx:end_idx]
-        
+
         return {
             "stocks": paginated_stocks,
             "pagination": {
@@ -310,34 +334,35 @@ class TrendingStocksService:
                 "limit": limit,
                 "total": len(stocks_data),
                 "has_next": end_idx < len(stocks_data),
-                "has_prev": page > 1
+                "has_prev": page > 1,
             },
             "metadata": {
-                "last_updated": self._cache.get("timestamp") if self._cache else datetime.now().isoformat(),
+                "last_updated": self._cache.get("timestamp")
+                if self._cache
+                else datetime.now().isoformat(),
                 "cache_ttl_seconds": self.cache_ttl,
-                "data_source": "real" if not self.use_mock else "mock"
-            }
+                "data_source": "real" if not self.use_mock else "mock",
+            },
         }
-    
-    
+
     def invalidate_cache(self) -> None:
         """Manually invalidate the cache to force fresh data fetch."""
         self._cache = {}
         self._cache_timestamp = None
         logger.info("Trending stocks cache invalidated")
-    
+
     def get_cache_status(self) -> Dict[str, Any]:
         """Get current cache status for monitoring."""
         if not self._cache_timestamp:
             return {"status": "empty", "age_seconds": None}
-        
+
         age = datetime.now() - self._cache_timestamp
         age_seconds = int(age.total_seconds())
-        
+
         return {
             "status": "valid" if age_seconds < self.cache_ttl else "expired",
             "age_seconds": age_seconds,
             "ttl_seconds": self.cache_ttl,
             "items_count": len(self._cache.get("stocks", [])),
-            "last_updated": self._cache_timestamp.isoformat()        }
-
+            "last_updated": self._cache_timestamp.isoformat(),
+        }

--- a/ai-stock-platform/api/tests/test_trending_warning_cooldown.py
+++ b/ai-stock-platform/api/tests/test_trending_warning_cooldown.py
@@ -1,0 +1,42 @@
+import asyncio
+import os
+import importlib.util
+import pytest
+from datetime import datetime
+
+spec = importlib.util.spec_from_file_location(
+    "trending_stocks_service",
+    os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        "services",
+        "trending_stocks_service.py",
+    ),
+)
+trending_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(trending_module)
+TrendingStocksService = trending_module.TrendingStocksService
+
+
+@pytest.mark.asyncio
+async def test_failure_warning_cooldown(caplog):
+    os.environ["ENABLE_REAL_DATA"] = "true"
+    os.environ["ALPHA_VANTAGE_API_KEY"] = "testkey"
+    service = TrendingStocksService()
+    service.use_mock = False
+
+    async def fake_fetch(session, symbol):
+        return None
+
+    service._fetch_stock_quote = fake_fetch  # type: ignore
+    caplog.set_level("WARNING")
+
+    await service.get_trending_stocks()
+    first_warning = service._last_failure_warning
+    assert first_warning is not None
+    assert "falling back to mock data" in caplog.text
+
+    caplog.clear()
+    await service.get_trending_stocks()
+    # Should not log again within cooldown
+    assert "falling back to mock data" not in caplog.text
+    assert service._last_failure_warning == first_warning

--- a/utils/market_data.py
+++ b/utils/market_data.py
@@ -1,12 +1,19 @@
 """Placeholder market data utilities used for tests."""
 
+import os
 from typing import Any, Dict
+
+# Re-export the API key used by legacy modules
+ALPHA_VANTAGE_API_KEY = os.getenv("ALPHA_VANTAGE_API_KEY", "demo")
+
 
 def get_market_data(symbol: str, interval: str = "1min", **kwargs) -> Dict[str, Any]:
     """Return mock market data for testing."""
     return {"symbol": symbol, "interval": interval, "data": []}
 
+
 class MarketDataClient:
     """Simple mock market data client."""
+
     def get_data(self, symbol: str, interval: str = "1min", **kwargs) -> Dict[str, Any]:
         return get_market_data(symbol, interval, **kwargs)


### PR DESCRIPTION
## Summary
- avoid repeated warning logs about real data fetch failures
- expose API key constant in `utils.market_data`
- test warning cooldown logic for the trending stocks service

## Testing
- `pytest -q` *(fails: ImportError cannot import name 'logger')*

------
https://chatgpt.com/codex/tasks/task_e_6886f1ae2d7c832a89026b5aa6c466c4