### PR TITLE
Fix Stock Flow page redirect

### DIFF
--- a/ai-stock-platform/ui/middleware/auth_middleware.py
+++ b/ai-stock-platform/ui/middleware/auth_middleware.py
@@ -62,6 +62,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             "/auth/password-reset",
             "/forgot-password",
             "/auth/forgot-password",
+            "/stocks/flow",
             "/static",
             "/docs",
             "/redoc",


### PR DESCRIPTION
## Summary
- update authentication middleware to allow public access to `/stocks/flow`

## Testing
- `pytest -q` *(fails: 11 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6886f6cd3b64832a93ef8a4fcad23c50