### PR TITLE
Fix variable usage in Alpha Vantage quote fetch

### DIFF
--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -250,6 +250,7 @@ class TrendingStocksService:
 
                 if response.status == 200:
                     try:
+                        text = await response.text()
                         data = json.loads(text)
                     except Exception as exc:
                         logger.error(


### PR DESCRIPTION
## Summary
- fix undefined variable error while fetching stock quotes

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q` *(fails: ImportError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_6886f8c5380c832a812596c19113edd4