### PR TITLE
Fix login session persistence

### DIFF
--- a/ai-stock-platform/ui/routes/auth.py
+++ b/ai-stock-platform/ui/routes/auth.py
@@ -114,6 +114,14 @@ async def login_post(
             samesite="lax",
             secure=request.url.scheme == "https"
         )
+        # Additional non-HTTP-only cookie so the SPA can sync the token
+        response.set_cookie(
+            key="qvai_token",
+            value=token,
+            max_age=max_age,
+            samesite="lax",
+            secure=request.url.scheme == "https"
+        )
 
         if user_info:
             response.set_cookie(
@@ -275,6 +283,7 @@ async def logout(request: Request):
         response = RedirectResponse(url="/auth/login?msg=Successfully logged out", status_code=status.HTTP_302_FOUND)
         response.delete_cookie("access_token")
         response.delete_cookie("user_info")
+        response.delete_cookie("qvai_token")
         
         return response
         

--- a/ai-stock-platform/ui/templates/base.html
+++ b/ai-stock-platform/ui/templates/base.html
@@ -36,6 +36,15 @@
         if (savedLang) {
             document.documentElement.setAttribute('lang', savedLang);
         }
+        // Sync auth token from cookie to localStorage for SPA compatibility
+        (function () {
+            const tokenKey = 'qvai_token';
+            const match = document.cookie.match(new RegExp('(?:^|; )' + tokenKey.replace(/([.$?*|{}()\[\]\\\/\+^])/g, '\\$1') + '=([^;]*)'));
+            const cookieToken = match ? decodeURIComponent(match[1]) : null;
+            if (cookieToken && !localStorage.getItem(tokenKey)) {
+                localStorage.setItem(tokenKey, cookieToken);
+            }
+        })();
     </script>
 
     <!-- Preconnect to external resources -->

--- a/ai-stock-platform/ui/tests/test_routes/test_auth_routes.py
+++ b/ai-stock-platform/ui/tests/test_routes/test_auth_routes.py
@@ -89,7 +89,7 @@ def test_logout_route(client):
     
     # Check token cookie is cleared
     cookies = response.headers.get('set-cookie', '')
-    assert 'token=;' in cookies
+    assert 'qvai_token=;' in cookies
     assert 'Max-Age=0' in cookies
 
 def test_register_page_get(client):


### PR DESCRIPTION
## Summary
- store auth token in a JS-readable cookie during login
- sync token from cookie to localStorage in base template
- clear the SPA token on logout
- update tests

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 12 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688704eea1a4832abdb3b5897ee39104