### PR TITLE
Fix cookie persistence after SPA login

### DIFF
--- a/ai-stock-platform/ui/src/services/auth.service.ts
+++ b/ai-stock-platform/ui/src/services/auth.service.ts
@@ -95,7 +95,11 @@ class AuthService {
 
         // Store token in local storage
         localStorage.setItem('qvai_token', token);
-        
+
+        // Persist token in cookies so server-rendered pages stay authenticated
+        document.cookie = `qvai_token=${token}; path=/; samesite=lax`;
+        document.cookie = `access_token=Bearer ${token}; path=/; samesite=lax`;
+
         // Update token subject
         this.tokenSubject.next(token);
 
@@ -167,7 +171,12 @@ class AuthService {
   logout(): void {
     // Clear token from storage
     localStorage.removeItem('qvai_token');
-    
+
+    // Remove authentication cookies
+    document.cookie = 'qvai_token=; Max-Age=0; path=/';
+    document.cookie = 'access_token=; Max-Age=0; path=/';
+    document.cookie = 'user_info=; Max-Age=0; path=/';
+
     // Clear current user and token from subjects
     this.currentUserSubject.next(null);
     this.tokenSubject.next(null);


### PR DESCRIPTION
## Summary
- ensure SPA login stores JWT in cookies
- clear auth cookies on logout

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q` *(fails: 12 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68878c4fbfd0832a989923f00a57fa8d