### PR TITLE
Fix live trending data defaults

### DIFF
--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -82,19 +82,25 @@ class TrendingStocksService:
         if not AIOHTTP_AVAILABLE:
             raise RuntimeError("aiohttp is required for real-time data access")
 
-        # Placeholder list used until live data is fetched
-        self.trending_symbols: List[str] = [
-            "AAPL",
-            "MSFT",
-            "AMZN",
-            "GOOGL",
-            "NVDA",
-            "TSLA",
-            "META",
-            "NFLX",
-            "CRM",
-            "ADBE",
-        ]
+        # Placeholder list used until live data is fetched. When ``ENABLE_REAL_DATA``
+        # is true we start with an empty list so that ``_fetch_yahoo_trending_symbols``
+        # is called on the first request to populate this list.
+        self.trending_symbols: List[str]
+        if self.use_mock:
+            self.trending_symbols = [
+                "AAPL",
+                "MSFT",
+                "AMZN",
+                "GOOGL",
+                "NVDA",
+                "TSLA",
+                "META",
+                "NFLX",
+                "CRM",
+                "ADBE",
+            ]
+        else:
+            self.trending_symbols = []
 
     async def _fetch_yahoo_trending_symbols(self) -> List[str]:
         """Fetch trending tickers from Yahoo Finance."""

--- a/services/trending_stocks_service.py
+++ b/services/trending_stocks_service.py
@@ -13,8 +13,10 @@ try:  # pragma: no cover - handle missing package gracefully
     # entire ``api.services`` package which has heavy side effects (e.g. DB
     # initialization).  Loading the module directly avoids those side effects
     # while providing the same ``TrendingStocksService`` class.
+    # Resolve the service path relative to the repository root rather than the
+    # ``services`` directory containing this wrapper.
     service_path = (
-        Path(__file__).resolve().parent
+        Path(__file__).resolve().parent.parent
         / "ai-stock-platform"
         / "api"
         / "services"


### PR DESCRIPTION
## Summary
- initialize trending stocks list only when using mock data
- load implementation from repo root instead of `services` folder

## Testing
- `pytest -q` *(fails: No module named 'utils.market_data')*

------
https://chatgpt.com/codex/tasks/task_e_6887906b8574832a851e56b6e1827da0