### PR TITLE
Fix JS snippet in predictability template

### DIFF
--- a/ai-stock-platform/ui/templates/predictability.html
+++ b/ai-stock-platform/ui/templates/predictability.html
@@ -322,11 +322,12 @@
 {% block scripts %}
 <script src="{{ get_asset_url('js/chart.js') }}"></script>
 <script src="{{ get_asset_url('js/predictability.js') }}"></script>
-
+<script>
 document.addEventListener('DOMContentLoaded', function() {
     // Initialize predictability charts and gauges
     if (typeof initializePredictabilityCharts === 'function') {
         initializePredictabilityCharts('{{ ticker }}', {{ predictability_score }});
     }
 });
-</script>{% endblock %}
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- close script tag in `predictability.html`

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services.stock_service', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6887db668124832ab7b8b3b04fe60ea7