### PR TITLE
Fix missing predictability score

### DIFF
--- a/ai-stock-platform/ui/routes/predictability.py
+++ b/ai-stock-platform/ui/routes/predictability.py
@@ -75,6 +75,7 @@ async def predictability_page(
                 "historical_scores": historical_scores,
                 "top_stocks": top_stocks,
                 "sector_data": SECTOR_PREDICTABILITY,
+                "predictability_score": base_score,
                 "page_title": f"{ticker} Predictability - QuantumVestAI"
             }
         )

--- a/ai-stock-platform/ui/templates/predictability.html
+++ b/ai-stock-platform/ui/templates/predictability.html
@@ -101,7 +101,7 @@
                         <div id="predictability-gauge"></div>
                         <div class="gauge-label">
                             <span class="gauge-title">Overall Predictability</span>
-                            <span class="gauge-score">{{ predictability_score }}%</span>
+                            <span class="gauge-score">{{ predictability_score|default(0) }}%</span>
                         </div>
                     </div>
                     <div class="score-summary">
@@ -326,7 +326,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     // Initialize predictability charts and gauges
     if (typeof initializePredictabilityCharts === 'function') {
-        initializePredictabilityCharts('{{ ticker }}', {{ predictability_score }});
+        initializePredictabilityCharts('{{ ticker }}', {{ predictability_score|default(0) }});
     }
 });
 </script>


### PR DESCRIPTION
## Summary
- ensure predictability score is passed to template
- use default value in template to avoid JS errors

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887de6e90ac832aafc0637626d2f315