### PR TITLE
Fix predictability score reference

### DIFF
--- a/ai-stock-platform/ui/routes/predictability.py
+++ b/ai-stock-platform/ui/routes/predictability.py
@@ -74,6 +74,7 @@ async def predictability_page(
                 "stock_info": stock_data,
                 "historical_scores": historical_scores,
                 "top_stocks": top_stocks,
+                "predictability_score": base_score,
                 "sector_data": SECTOR_PREDICTABILITY,
                 "page_title": f"{ticker} Predictability - QuantumVestAI"
             }
@@ -93,6 +94,7 @@ async def predictability_page(
             "historical_scores": [],
             "top_stocks": [],
             "sector_data": {},
+            "predictability_score": 0,
                 "error": f"Error loading predictability analysis: {str(e)}",
                 "page_title": "Predictability Error"
             },


### PR DESCRIPTION
## Summary
- ensure `predictability_score` is passed in predictability view context

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q` *(fails: 12 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6887dd18c478832ab73e82154a23f8bd