### PR TITLE
fix: correct model retrain job command

### DIFF
--- a/ci-cd/k8s/model-retrain-job.yaml
+++ b/ci-cd/k8s/model-retrain-job.yaml
@@ -26,7 +26,7 @@ spec:
           - name: model-trainer
             image: 921930869047.dkr.ecr.us-east-1.amazonaws.com/quantumvestai:api-dev-latest
             imagePullPolicy: Always
-            command: ["python", "-m", "app.ml.train_models"]
+            command: ["python", "-m", "api.ml.train_models"]
             args: ["--full-retrain", "--all-models"]
             resources:
               requests:


### PR DESCRIPTION
## Summary
- point model retrain CronJob to the correct `api.ml.train_models` module

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ImportError: cannot import name 'logger' from '<unknown module name>' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688ed9e343f0832ab5d9e087561cf37e