### PR TITLE
Allow mock trending service without aiohttp

### DIFF
--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -78,8 +78,8 @@ class TrendingStocksService:
         self.warning_cooldown = int(os.getenv("TRENDING_WARNING_COOLDOWN", "60"))
         self._last_failure_warning: Optional[datetime] = None
 
-        # Log dependency status
-        if not AIOHTTP_AVAILABLE:
+        # Log dependency status. Only require aiohttp when real data is enabled
+        if not self.use_mock and not AIOHTTP_AVAILABLE:
             raise RuntimeError("aiohttp is required for real-time data access")
 
         # Placeholder list used until live data is fetched. When ``ENABLE_REAL_DATA``

--- a/ai-stock-platform/api/tests/test_trending_stocks.py
+++ b/ai-stock-platform/api/tests/test_trending_stocks.py
@@ -30,9 +30,6 @@ trending_module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(trending_module)
 TrendingStocksService = trending_module.TrendingStocksService
 
-if not getattr(trending_module, "AIOHTTP_AVAILABLE", False):
-    pytest.skip("aiohttp not available", allow_module_level=True)
-
 
 def test_trending_stocks_service_initialization():
     """Test that the service initializes correctly."""
@@ -175,6 +172,17 @@ async def test_data_consistency():
         for stock in stocks:
             assert isinstance(stock["change_percent"], (int, float))
             assert -20 <= stock["change_percent"] <= 20  # Reasonable range
+
+
+@pytest.mark.asyncio
+async def test_service_without_aiohttp(monkeypatch):
+    """Service should fall back to mock data if aiohttp is missing."""
+    monkeypatch.setattr(trending_module, "AIOHTTP_AVAILABLE", False, raising=False)
+    monkeypatch.setattr(trending_module, "aiohttp", None, raising=False)
+    service = TrendingStocksService()
+    result = await service.get_trending_stocks(limit=1)
+    assert result["metadata"]["data_source"] == "mock"
+    assert len(result["stocks"]) == 1
 
 
 def test_parse_alpha_vantage_errors():


### PR DESCRIPTION
## Summary
- Relax aiohttp dependency for TrendingStocksService when real-time data is disabled
- Remove test skip and add coverage to ensure mock fallback when aiohttp is missing

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'logger' and other module import errors)*

------
https://chatgpt.com/codex/tasks/task_e_688eda8a7918832ab260dd9363175268