### PR TITLE
fix: set pythonpath for retrain job

### DIFF
--- a/ci-cd/k8s/model-retrain-job.yaml
+++ b/ci-cd/k8s/model-retrain-job.yaml
@@ -36,6 +36,8 @@ spec:
                 cpu: "2000m"
                 memory: "8Gi"
             env:
+              - name: PYTHONPATH
+                value: "/app/core:/app/ai-stock-platform:/app/ai-stock-platform/api:/app/api:/app/ui:/app"
               # Database credentials from Terraform-created secret
               - name: DB_HOST
                 valueFrom:


### PR DESCRIPTION
## Summary
- specify PYTHONPATH for model retrain CronJob so api module resolves

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ImportError cannot import name 'logger')*

------
https://chatgpt.com/codex/tasks/task_e_688eec601b8c832a94543f1c4c1acf29