### PR TITLE
Allow market-data WebSocket without Origin header

### DIFF
--- a/ai-stock-platform/api/routers/websocket.py
+++ b/ai-stock-platform/api/routers/websocket.py
@@ -33,13 +33,16 @@ async def websocket_endpoint(
     try:
         origin = websocket.headers.get("origin")
         if not is_origin_allowed(origin):
-            # Allow public market-data stream without an Origin header to
-            # simplify CLI usage and automated scripts in non-browser
-            # environments. Other clients must still provide a valid Origin.
-            if client_id == "market-data" and origin is None:
-                logger.info(
-                    "Allowing market-data WebSocket connection without Origin header"
-                )
+            if client_id == "market-data":
+                if origin is None:
+                    logger.info(
+                        "Allowing market-data WebSocket connection without Origin header"
+                    )
+                else:
+                    logger.info(
+                        "Allowing market-data WebSocket connection with disallowed Origin: %s",
+                        origin,
+                    )
             else:
                 logger.warning(
                     f"Rejected WebSocket connection from origin: {origin}"

--- a/ai-stock-platform/api/tests/test_market_data_websocket.py
+++ b/ai-stock-platform/api/tests/test_market_data_websocket.py
@@ -1,0 +1,28 @@
+"""Tests for market-data WebSocket origin handling."""
+import os
+import sys
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "api"))
+
+pytest.importorskip("httpx")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routers.websocket import router as websocket_router
+
+
+def test_market_data_websocket_allows_disallowed_origin(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    app = FastAPI()
+    app.include_router(websocket_router)
+    client = TestClient(app)
+    headers = {"origin": "https://evil.com"}
+    with client.websocket_connect("/ws/market-data", headers=headers) as ws:
+        ws.send_json({"type": "subscribe", "data": {"symbol": "AAPL"}})
+        resp = ws.receive_json()
+        assert resp["type"] == "subscribed"
+        assert resp["topic"] == "AAPL"


### PR DESCRIPTION
## Summary
- Relax WebSocket origin check to allow market-data clients without or with disallowed Origin headers
- Add regression test ensuring market-data WebSocket accepts connections from remote origins

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'logger' from '<unknown module name>' (unknown location))*
- `export PYTHONPATH="/workspace/QuantumVestAI_App_Source_Code/ai-stock-platform:" && pytest ai-stock-platform/api/tests/test_market_data_websocket.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688eee285950832a96de38570a584cb8