### PR TITLE
Add responsive app layout with header and sidebar navigation

### DIFF
--- a/ai-stock-platform/ui/src/components/Header.tsx
+++ b/ai-stock-platform/ui/src/components/Header.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import {
+  AppBar,
+  Toolbar,
+  IconButton,
+  InputBase,
+  Badge,
+  Menu,
+  MenuItem,
+  Avatar,
+  Box
+} from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import SearchIcon from '@mui/icons-material/Search';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+
+interface HeaderProps {
+  /** Called when the sidebar menu icon is clicked */
+  onMenuClick?: () => void;
+}
+
+const Header: React.FC<HeaderProps> = ({ onMenuClick }) => {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+
+  const handleProfileClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <AppBar position="fixed" color="primary" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
+      <Toolbar>
+        {onMenuClick && (
+          <IconButton
+            color="inherit"
+            edge="start"
+            onClick={onMenuClick}
+            sx={{ mr: 2 }}
+            aria-label="open drawer"
+          >
+            <MenuIcon />
+          </IconButton>
+        )}
+        <Box
+          sx={{
+            position: 'relative',
+            borderRadius: 1,
+            backgroundColor: 'rgba(255,255,255,0.15)',
+            '&:hover': { backgroundColor: 'rgba(255,255,255,0.25)' },
+            mr: 2,
+            ml: 0,
+            width: '100%',
+            maxWidth: 400
+          }}
+        >
+          <Box
+            sx={{
+              padding: '0 16px',
+              height: '100%',
+              position: 'absolute',
+              pointerEvents: 'none',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center'
+            }}
+          >
+            <SearchIcon />
+          </Box>
+          <InputBase
+            placeholder="Search…"
+            sx={{
+              color: 'inherit',
+              '& .MuiInputBase-input': {
+                padding: '8px 8px 8px 48px',
+                width: '100%'
+              }
+            }}
+            inputProps={{ 'aria-label': 'search' }}
+          />
+        </Box>
+        <Box sx={{ flexGrow: 1 }} />
+        <IconButton color="inherit" aria-label="show notifications">
+          <Badge badgeContent={4} color="secondary">
+            <NotificationsIcon />
+          </Badge>
+        </IconButton>
+        <IconButton color="inherit" onClick={handleProfileClick} sx={{ ml: 2 }} aria-label="account options">
+          <Avatar sx={{ width: 32, height: 32 }}>U</Avatar>
+        </IconButton>
+        <Menu
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={handleClose}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        >
+          <MenuItem onClick={handleClose}>Profile</MenuItem>
+          <MenuItem onClick={handleClose}>Logout</MenuItem>
+        </Menu>
+      </Toolbar>
+    </AppBar>
+  );
+};
+
+export default Header;

--- a/ai-stock-platform/ui/src/components/Layout/AppLayout.tsx
+++ b/ai-stock-platform/ui/src/components/Layout/AppLayout.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { Box } from '@mui/material';
+import Header from '../Header';
+import Sidebar from '../Sidebar';
+
+interface AppLayoutProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Global application layout with header, sidebar and main content area.
+ * The sidebar collapses on mobile and can be toggled via the header menu button.
+ */
+const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+      <Header onMenuClick={handleDrawerToggle} />
+      <Sidebar open={mobileOpen} onClose={handleDrawerToggle} />
+      <Box component="main" sx={{ flexGrow: 1, p: 3, mt: 8 }}>
+        {children}
+      </Box>
+    </Box>
+  );
+};
+
+export default AppLayout;

--- a/ai-stock-platform/ui/src/components/Sidebar.tsx
+++ b/ai-stock-platform/ui/src/components/Sidebar.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import {
+  Drawer,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  IconButton,
+  useMediaQuery,
+  Box
+} from '@mui/material';
+import HomeIcon from '@mui/icons-material/Home';
+import InsightsIcon from '@mui/icons-material/Insights';
+import SettingsIcon from '@mui/icons-material/Settings';
+import PortfolioIcon from '@mui/icons-material/PieChart';
+import MenuIcon from '@mui/icons-material/Menu';
+import { useTheme } from '@mui/material/styles';
+
+interface SidebarProps {
+  /** Controls drawer visibility on mobile */
+  open?: boolean;
+  /** Callback when drawer should close on mobile */
+  onClose?: () => void;
+}
+
+const drawerWidth = 240;
+const collapsedWidth = 64;
+
+const menuItems = [
+  { label: 'Home', icon: <HomeIcon />, path: '/' },
+  { label: 'Portfolio', icon: <PortfolioIcon />, path: '/portfolio' },
+  { label: 'AI Insights', icon: <InsightsIcon />, path: '/ai' },
+  { label: 'Settings', icon: <SettingsIcon />, path: '/settings' }
+];
+
+const Sidebar: React.FC<SidebarProps> = ({ open, onClose }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const [collapsed, setCollapsed] = useState(false);
+
+  const handleToggleCollapse = () => setCollapsed(!collapsed);
+
+  const drawerContent = (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <IconButton
+        onClick={handleToggleCollapse}
+        sx={{ m: 1, alignSelf: collapsed ? 'center' : 'flex-end' }}
+        aria-label="toggle sidebar"
+      >
+        <MenuIcon />
+      </IconButton>
+      <List sx={{ flexGrow: 1 }}>
+        {menuItems.map((item) => (
+          <ListItem
+            button
+            key={item.label}
+            sx={{
+              justifyContent: collapsed ? 'center' : 'flex-start',
+              px: collapsed ? 0 : 2
+            }}
+          >
+            <ListItemIcon
+              sx={{
+                minWidth: 0,
+                mr: collapsed ? 0 : 2,
+                justifyContent: 'center'
+              }}
+            >
+              {item.icon}
+            </ListItemIcon>
+            {!collapsed && <ListItemText primary={item.label} />}
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+
+  return (
+    <Drawer
+      variant={isMobile ? 'temporary' : 'permanent'}
+      open={isMobile ? open : true}
+      onClose={onClose}
+      ModalProps={{ keepMounted: true }}
+      sx={{
+        width: collapsed ? collapsedWidth : drawerWidth,
+        flexShrink: 0,
+        '& .MuiDrawer-paper': {
+          width: collapsed ? collapsedWidth : drawerWidth,
+          boxSizing: 'border-box'
+        }
+      }}
+    >
+      {drawerContent}
+    </Drawer>
+  );
+};
+
+export default Sidebar;


### PR DESCRIPTION
## Summary
- add global AppLayout that combines header and sidebar
- build collapsible sidebar with navigation icons
- implement header with search, notifications, and profile menu

## Testing
- `pytest -q` *(fails: cannot import name 'logger' from '<unknown module name>')*

------
https://chatgpt.com/codex/tasks/task_e_688f7887b998832a8a636a5f89fa45fb