### PR TITLE
Add AI sentiment, prediction, summary services and market websocket broadcaster

### DIFF
--- a/ai-stock-platform/api/services/__init__.py
+++ b/ai-stock-platform/api/services/__init__.py
@@ -69,3 +69,35 @@ if YAHOO_RAPIDAPI_SERVICE_AVAILABLE:
     __all__.append('YahooRapidAPIService')
 if MARKET_OVERVIEW_SERVICE_AVAILABLE:
     __all__.append('MarketOverviewService')
+
+# New lightweight services used in tests
+try:
+    from services.sentiment import SentimentService
+    SENTIMENT_SERVICE_AVAILABLE = True
+except ImportError as e:
+    print(f"Warning: SentimentService not available - {e}")
+    SentimentService = None  # type: ignore
+    SENTIMENT_SERVICE_AVAILABLE = False
+
+try:
+    from services.prediction import PredictionService
+    PREDICTION_SERVICE_AVAILABLE = True
+except ImportError as e:
+    print(f"Warning: PredictionService not available - {e}")
+    PredictionService = None  # type: ignore
+    PREDICTION_SERVICE_AVAILABLE = False
+
+try:
+    from services.ai_summary import AISummaryService
+    AI_SUMMARY_SERVICE_AVAILABLE = True
+except ImportError as e:
+    print(f"Warning: AISummaryService not available - {e}")
+    AISummaryService = None  # type: ignore
+    AI_SUMMARY_SERVICE_AVAILABLE = False
+
+if SENTIMENT_SERVICE_AVAILABLE:
+    __all__.append('SentimentService')
+if PREDICTION_SERVICE_AVAILABLE:
+    __all__.append('PredictionService')
+if AI_SUMMARY_SERVICE_AVAILABLE:
+    __all__.append('AISummaryService')

--- a/ai-stock-platform/api/services/ai_summary.py
+++ b/ai-stock-platform/api/services/ai_summary.py
@@ -1,0 +1,38 @@
+"""Generate plain English explanations of market movements.
+
+The real application uses a GPT model to craft natural language summaries.
+To keep the test suite lightweight this module simply formats a short message
+based on the provided sentiment and forecast data.  The interface mirrors what
+would be expected from an actual GPT powered service so higher level modules
+can rely on it without modification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class SummaryInput:
+    symbol: str
+    sentiment: Dict[str, Any]
+    forecast: Dict[str, Any]
+
+
+class AISummaryService:
+    """Create human friendly summaries for stock movements."""
+
+    def generate(self, data: SummaryInput) -> str:
+        """Return a brief summary for the supplied ``data``."""
+
+        sentiment = data.sentiment.get("label", "unknown")
+        price = data.forecast.get("yhat") or data.forecast.get("prediction")
+        if price is None:
+            price_part = "an unknown price"
+        else:
+            price_part = f"around {price:.2f}"
+        return (
+            f"{data.symbol} shows {sentiment} sentiment with a price forecast "
+            f"of {price_part}."
+        )

--- a/ai-stock-platform/api/services/prediction.py
+++ b/ai-stock-platform/api/services/prediction.py
@@ -1,0 +1,63 @@
+"""Price forecasting helpers.
+
+A small wrapper around the `prophet` library is provided when available.  In
+environments where Prophet cannot be installed the service falls back to a
+naive prediction that simply repeats the last observed price.  The goal is to
+provide a stable API for tests without introducing heavy dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import pandas as pd
+
+try:  # pragma: no cover - only executed when Prophet is installed
+    from prophet import Prophet  # type: ignore
+    _PROPHET_AVAILABLE = True
+except Exception:  # pragma: no cover - default path in tests
+    Prophet = None  # type: ignore
+    _PROPHET_AVAILABLE = False
+
+
+@dataclass
+class ForecastPoint:
+    ds: pd.Timestamp
+    yhat: float
+
+
+class PredictionService:
+    """Generate simple price forecasts."""
+
+    def forecast(self, history: pd.DataFrame, days: int = 1) -> List[ForecastPoint]:
+        """Forecast prices based on ``history``.
+
+        Parameters
+        ----------
+        history: pd.DataFrame
+            Historical price data containing ``ds`` (datetime) and ``y`` (price)
+            columns.
+        days: int
+            Number of periods to forecast into the future.
+        """
+
+        if {"ds", "y"} - set(history.columns):
+            raise ValueError("history must contain 'ds' and 'y' columns")
+
+        if _PROPHET_AVAILABLE:  # pragma: no cover - heavy dependency path
+            model = Prophet()
+            model.fit(history[["ds", "y"]])
+            future = model.make_future_dataframe(periods=days)
+            forecast = model.predict(future).tail(days)
+            return [
+                ForecastPoint(row.ds, float(row.yhat))
+                for _, row in forecast.iterrows()
+            ]
+
+        # Fallback: repeat the last observed value
+        last_row = history.iloc[-1]
+        return [
+            ForecastPoint(last_row.ds + pd.Timedelta(days=i + 1), float(last_row.y))
+            for i in range(days)
+        ]

--- a/ai-stock-platform/api/services/sentiment.py
+++ b/ai-stock-platform/api/services/sentiment.py
@@ -1,0 +1,78 @@
+"""News sentiment analysis using a FinBERT model.
+
+The real project uses the FinBERT transformer from HuggingFace.  Downloading
+and executing that model would make the test environment very heavy, so this
+module loads the model only when the required dependencies are available.  When
+`transformers` or its model files are missing the service falls back to a
+very small rule based heuristic so that unit tests can still exercise the API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+try:  # pragma: no cover - exercised conditionally during tests
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+    import torch
+    _TRANSFORMERS_AVAILABLE = True
+except Exception:  # pragma: no cover - used when dependencies are missing
+    AutoModelForSequenceClassification = AutoTokenizer = None  # type: ignore
+    torch = None  # type: ignore
+    _TRANSFORMERS_AVAILABLE = False
+
+LABELS = ["negative", "neutral", "positive"]
+
+
+@dataclass
+class SentimentResult:
+    label: str
+    score: float
+
+
+class SentimentService:
+    """Analyse news text and return a sentiment score."""
+
+    def __init__(self) -> None:
+        if _TRANSFORMERS_AVAILABLE:
+            try:  # pragma: no cover - model loading is expensive
+                self.tokenizer = AutoTokenizer.from_pretrained(
+                    "ProsusAI/finbert",
+                    local_files_only=True,
+                )
+                self.model = AutoModelForSequenceClassification.from_pretrained(
+                    "ProsusAI/finbert",
+                    local_files_only=True,
+                )
+            except Exception:
+                # Model files not available; fall back to heuristic mode.
+                self.tokenizer = None
+                self.model = None
+        else:
+            self.tokenizer = None
+            self.model = None
+
+    # The method is kept synchronous for simplicity
+    def analyse(self, text: str) -> SentimentResult:
+        """Return the sentiment for ``text``.
+
+        When the FinBERT model is available it is used, otherwise a very small
+        heuristic based on keyword matching is employed.  This keeps the tests
+        lightweight while exercising the same API surface.
+        """
+
+        if self.model and self.tokenizer:  # pragma: no cover - heavy path
+            inputs = self.tokenizer(text, return_tensors="pt")
+            with torch.no_grad():
+                logits = self.model(**inputs).logits
+                scores = torch.softmax(logits, dim=1)[0]
+            idx = int(scores.argmax())
+            return SentimentResult(LABELS[idx], float(scores[idx]))
+
+        # Heuristic fallback
+        lowered = text.lower()
+        if any(word in lowered for word in ["gain", "positive", "up"]):
+            return SentimentResult("positive", 0.0)
+        if any(word in lowered for word in ["loss", "negative", "down"]):
+            return SentimentResult("negative", 0.0)
+        return SentimentResult("neutral", 0.0)

--- a/ai-stock-platform/api/websocket/__init__.py
+++ b/ai-stock-platform/api/websocket/__init__.py
@@ -5,12 +5,14 @@ Author: daparthi001
 """
 """Simplified exports for the local WebSocket utilities."""
 
-# Only the connection manager exists in this module hierarchy. The
-# previous implementation attempted to expose several classes that are not
-# actually present in the repository which caused import errors when the
-# package was initialised.
+# Only the connection manager existed initially in this module hierarchy.
+# A small market data broadcaster is also exposed to support tests that need
+# to push mock prices to connected clients.
 
 from .manager import ConnectionManager
+from .market import MarketWebSocketService
 
 __all__ = [
-    "ConnectionManager",]
+    "ConnectionManager",
+    "MarketWebSocketService",
+]

--- a/ai-stock-platform/api/websocket/market.py
+++ b/ai-stock-platform/api/websocket/market.py
@@ -1,0 +1,44 @@
+"""Market data websocket utilities.
+
+This module provides a lightweight service that periodically fetches mock
+market data and broadcasts the results to any connected websocket clients.
+It relies on the existing :class:`ConnectionManager` to handle subscriptions
+and client management.  The service is intentionally simple so it can operate
+in the test environment without external dependencies or real market feeds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from .manager import ConnectionManager
+from utils.market_data import MarketDataClient
+
+
+class MarketWebSocketService:
+    """Background broadcaster for live stock data."""
+
+    def __init__(
+        self,
+        manager: Optional[ConnectionManager] = None,
+        client: Optional[MarketDataClient] = None,
+    ) -> None:
+        self.manager = manager or ConnectionManager()
+        self.client = client or MarketDataClient()
+
+    async def stream(self, symbol: str, interval: float = 1.0) -> None:
+        """Continuously fetch data for ``symbol`` and broadcast to subscribers.
+
+        Parameters
+        ----------
+        symbol: str
+            Stock ticker symbol to broadcast.
+        interval: float, optional
+            Delay between fetches in seconds.  Defaults to ``1``.
+        """
+
+        while True:
+            data = self.client.get_data(symbol)
+            await self.manager.broadcast_stock_update(symbol, data)
+            await asyncio.sleep(interval)


### PR DESCRIPTION
## Summary
- add MarketWebSocketService for broadcasting mock stock data
- implement lightweight FinBERT-like SentimentService
- implement prediction and AI summary helpers for forecasts

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 13 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688f78b11a44832aacf96cffd49f7065