### PR TITLE
feat(ui): add theme toggle and settings page

### DIFF
--- a/ui/src/components/ThemeToggle.tsx
+++ b/ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+
+// Simple light/dark mode toggle that persists the choice in localStorage
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window === 'undefined') {
+      return 'light'
+    }
+    return window.localStorage.getItem('theme') === 'dark' ? 'dark' : 'light'
+  })
+
+  useEffect(() => {
+    const root = window.document.documentElement
+    if (theme === 'dark') {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+    window.localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'))
+  }
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="px-4 py-2 rounded-md border"
+    >
+      {theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+    </button>
+  )
+}
+
+export default ThemeToggle

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+import ThemeToggle from '@/components/ThemeToggle'
+import { Button } from '@/components/ui/button'
+
+function Settings() {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Profile Settings</h1>
+      <div className="space-y-2">
+        <label className="block">
+          <span className="text-sm">Name</span>
+          <input
+            className="w-full border p-2 rounded-md"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm">Email</span>
+          <input
+            className="w-full border p-2 rounded-md"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </label>
+      </div>
+      <div>
+        <ThemeToggle />
+      </div>
+      <Button type="button">Save</Button>
+    </div>
+  )
+}
+
+export default Settings

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -3,6 +3,7 @@ import tailwindcssAnimate from 'tailwindcss-animate'
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- add reusable ThemeToggle component for persistent light/dark mode switching
- create Settings page with basic profile form and theme control
- enable class-based dark mode in Tailwind config

## Testing
- `pytest tests/test_basic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7f95d8bc832aa08e27adaee7572b