### PR TITLE
Add Redis caching and deployment assets

### DIFF
--- a/ai-stock-platform/api/requirements.txt
+++ b/ai-stock-platform/api/requirements.txt
@@ -20,6 +20,8 @@ textblob==0.17.1
 nltk==3.8.1
 apscheduler==3.11.0
 aiosqlite==0.19.0
+# Caching
+redis==5.0.1
 # Monitoring & Observability
 sentry-sdk
 prometheus_client

--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -15,6 +15,15 @@ import json
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
+# Optional Redis cache support
+try:  # pragma: no cover - cache is optional in tests
+    from api.core.cache import cache as redis_cache  # type: ignore
+except Exception:  # pragma: no cover - Redis or package not available
+    try:
+        from core.cache import cache as redis_cache  # type: ignore
+    except Exception:  # pragma: no cover - final fallback
+        redis_cache = None
+
 # Explicitly import the settings instance to avoid ambiguity with the
 # `core.config` package which also contains a `settings` submodule.
 # Import settings directly from the API package to avoid the compatibility
@@ -134,7 +143,18 @@ class TrendingStocksService:
             Dict containing stocks data and pagination info
         """
         try:
-            # Check cache first
+            cache_key = "trending_stocks"
+            # Prefer Redis cache if available
+            if redis_cache:
+                cached = redis_cache.get(cache_key)
+                if cached:
+                    logger.info("Returning trending stocks from Redis cache")
+                    cached_data = json.loads(cached)
+                    return self._get_paginated_data(
+                        cached_data.get("stocks", []), page, limit
+                    )
+
+            # Fallback to in-memory cache
             if self._is_cache_valid():
                 logger.info("Returning trending stocks from cache")
                 return self._get_paginated_data(self._cache["stocks"], page, limit)
@@ -160,8 +180,18 @@ class TrendingStocksService:
 
             stocks_data = await self._fetch_trending_stocks()
 
-            # Update cache
-            self._update_cache(stocks_data)
+            # Update caches
+            if redis_cache:
+                try:
+                    redis_cache.set(
+                        cache_key,
+                        json.dumps({"stocks": stocks_data}),
+                        ttl_seconds=self.cache_ttl,
+                    )
+                except Exception as exc:  # pragma: no cover - logging only
+                    logger.warning(f"Failed to set Redis cache: {exc}")
+            else:
+                self._update_cache(stocks_data)
 
             return self._get_paginated_data(stocks_data, page, limit)
 

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+CMD ["uvicorn", "ai_stock_platform.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/ui.Dockerfile
+++ b/docker/ui.Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY ui/package*.json ./
+RUN npm ci
+COPY ui/ .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/k8s/api/Chart.yaml
+++ b/k8s/api/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: quantumvest-api
+description: Helm chart for QuantumVest API
+version: 0.1.0
+appVersion: "1.0"

--- a/k8s/api/templates/deployment.yaml
+++ b/k8s/api/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-api
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-api
+    spec:
+      containers:
+        - name: api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: 8000

--- a/k8s/api/templates/service.yaml
+++ b/k8s/api/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-api
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Release.Name }}-api
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8000

--- a/k8s/api/values.yaml
+++ b/k8s/api/values.yaml
@@ -1,0 +1,6 @@
+image:
+  repository: quantumvest/api
+  tag: latest
+service:
+  type: ClusterIP
+  port: 8000

--- a/k8s/ui/Chart.yaml
+++ b/k8s/ui/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: quantumvest-ui
+description: Helm chart for QuantumVest UI
+version: 0.1.0
+appVersion: "1.0"

--- a/k8s/ui/templates/deployment.yaml
+++ b/k8s/ui/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-ui
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-ui
+    spec:
+      containers:
+        - name: ui
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: 80

--- a/k8s/ui/templates/service.yaml
+++ b/k8s/ui/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-ui
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Release.Name }}-ui
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 80

--- a/k8s/ui/values.yaml
+++ b/k8s/ui/values.yaml
@@ -1,0 +1,6 @@
+image:
+  repository: quantumvest/ui
+  tag: latest
+service:
+  type: ClusterIP
+  port: 80

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,9 @@
-import { Button } from '@/components/ui/button'
+import { Suspense, lazy } from 'react'
 import { useAppStore } from '@/store/useAppStore'
 import { usePing } from '@/api/hooks/usePing'
+
+// Lazy load non-critical UI components
+const Button = lazy(() => import('@/components/ui/button'))
 
 function App() {
   const count = useAppStore((s) => s.count)
@@ -12,7 +15,9 @@ function App() {
       <h1 className="text-2xl font-bold">QuantumVest AI UI</h1>
       <p>{data?.message ?? 'Loading...'}</p>
       <div>Count: {count}</div>
-      <Button onClick={increment}>Increment</Button>
+      <Suspense fallback={<div>Loading button...</div>}>
+        <Button onClick={increment}>Increment</Button>
+      </Suspense>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- cache trending stock data in Redis with fallback to in-memory cache
- lazy-load UI button component for faster initial load
- add Dockerfiles and Helm charts for API and UI deployments

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ImportError: cannot import name 'logger' from '<unknown module name>')*


------
https://chatgpt.com/codex/tasks/task_e_688f7faa16d4832a8158d6608c96b521