### PR TITLE
Fix profile route session handling

### DIFF
--- a/ai-stock-platform/ui/main.py
+++ b/ai-stock-platform/ui/main.py
@@ -57,6 +57,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from starlette.middleware.sessions import SessionMiddleware
+
+from core.config.settings import settings
 
 # Import the API client from the local services package. The project
 # originally referenced ``ui.services`` but the UI Docker image only
@@ -138,6 +141,9 @@ app = FastAPI(
     description="Complete Web UI for QuantumVestAI Platform - Production Ready with Demo Mode",
     version="2.0.0"
 )
+
+# Enable server-side sessions for authentication state management
+app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
 
 # CORS configuration
 origins = [origin.strip() for origin in os.environ.get("CORS_ORIGINS", "*").split(",")]

--- a/ai-stock-platform/ui/routes/profile.py
+++ b/ai-stock-platform/ui/routes/profile.py
@@ -119,7 +119,8 @@ async def profile_page(request: Request):
             "profile.html",
             {
                 "request": request,
-                "user": None,
+                # Provide empty user dict to prevent template attribute errors
+                "user": {},
                 "profile": {},
                 "activity": [],
                 "error": error_message,

--- a/ai-stock-platform/ui/tests/test_routes/test_profile_route.py
+++ b/ai-stock-platform/ui/tests/test_routes/test_profile_route.py
@@ -1,0 +1,8 @@
+from fastapi import status
+
+
+def test_profile_requires_authentication(client):
+    """Unauthenticated access to profile should redirect to login."""
+    response = client.get("/profile/", follow_redirects=False)
+    assert response.status_code == status.HTTP_302_FOUND
+    assert "/login" in response.headers["location"]


### PR DESCRIPTION
## Summary
- enable server-side sessions in UI app
- guard profile template rendering when user session missing
- add regression test ensuring unauthenticated profile access redirects

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ImportError: cannot import name 'logger')*


------
https://chatgpt.com/codex/tasks/task_e_688f8126cc98832ab58d8e2b01aab454