### PR TITLE
Add portfolio dashboard with watchlist and trade panel

### DIFF
--- a/ui/src/components/TradePanel.tsx
+++ b/ui/src/components/TradePanel.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+interface Trade {
+  symbol: string
+  quantity: number
+  side: 'buy' | 'sell'
+}
+
+/**
+ * Simple panel that simulates trade actions. Trades are stored locally
+ * and displayed in a list.
+ */
+export default function TradePanel() {
+  const [symbol, setSymbol] = useState('')
+  const [quantity, setQuantity] = useState(0)
+  const [log, setLog] = useState<Trade[]>([])
+
+  const handleTrade = (side: 'buy' | 'sell') => {
+    const s = symbol.trim().toUpperCase()
+    if (!s || quantity <= 0) return
+    setLog((prev) => [...prev, { symbol: s, quantity, side }])
+    setSymbol('')
+    setQuantity(0)
+  }
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-xl font-semibold">Trade</h2>
+      <div className="flex space-x-2">
+        <input
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value)}
+          placeholder="Symbol"
+          className="border px-2 py-1 rounded"
+        />
+        <input
+          type="number"
+          value={quantity}
+          onChange={(e) => setQuantity(parseInt(e.target.value) || 0)}
+          placeholder="Qty"
+          className="border px-2 py-1 rounded w-24"
+        />
+        <Button onClick={() => handleTrade('buy')}>Buy</Button>
+        <Button onClick={() => handleTrade('sell')}>Sell</Button>
+      </div>
+      <ul className="space-y-1">
+        {log.map((t, idx) => (
+          <li key={idx} className="text-sm">
+            {t.side.toUpperCase()} {t.quantity} {t.symbol}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+

--- a/ui/src/components/Watchlist.tsx
+++ b/ui/src/components/Watchlist.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+interface WatchItem {
+  symbol: string
+  price?: number
+}
+
+/**
+ * Displays a list of stock symbols and keeps their price updated using a WebSocket.
+ * Users can add or remove symbols from the list.
+ */
+export default function Watchlist() {
+  const [symbol, setSymbol] = useState('')
+  const [items, setItems] = useState<WatchItem[]>([])
+
+  // Establish a websocket connection for live price updates
+  useEffect(() => {
+    const ws = new WebSocket('ws://localhost:8000/ws/watchlist')
+    ws.onmessage = (event) => {
+      const data = JSON.parse(event.data) as WatchItem
+      setItems((prev) =>
+        prev.map((item) =>
+          item.symbol === data.symbol ? { ...item, price: data.price } : item
+        )
+      )
+    }
+    return () => ws.close()
+  }, [])
+
+  const addSymbol = () => {
+    const s = symbol.trim().toUpperCase()
+    if (!s) return
+    setItems((prev) =>
+      prev.some((i) => i.symbol === s) ? prev : [...prev, { symbol: s }]
+    )
+    setSymbol('')
+  }
+
+  const removeSymbol = (s: string) => {
+    setItems((prev) => prev.filter((i) => i.symbol !== s))
+  }
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-xl font-semibold">Watchlist</h2>
+      <div className="flex space-x-2">
+        <input
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value)}
+          placeholder="Symbol"
+          className="border px-2 py-1 rounded"
+        />
+        <Button onClick={addSymbol}>Add</Button>
+      </div>
+      <ul className="space-y-1">
+        {items.map((item) => (
+          <li
+            key={item.symbol}
+            className="flex justify-between items-center border-b pb-1"
+          >
+            <span>
+              {item.symbol}
+              {item.price !== undefined && (
+                <span className="ml-2 text-sm text-gray-500">
+                  {item.price.toFixed(2)}
+                </span>
+              )}
+            </span>
+            <button
+              onClick={() => removeSymbol(item.symbol)}
+              className="text-red-500 text-sm"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+

--- a/ui/src/pages/Portfolio.tsx
+++ b/ui/src/pages/Portfolio.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+import Watchlist from '@/components/Watchlist'
+import TradePanel from '@/components/TradePanel'
+
+interface Holding {
+  symbol: string
+  quantity: number
+  value: number
+}
+
+/**
+ * Portfolio dashboard displaying live performance of holdings along with
+ * watchlist and trade panel components.
+ */
+export default function Portfolio() {
+  const [holdings, setHoldings] = useState<Holding[]>([
+    { symbol: 'AAPL', quantity: 10, value: 0 },
+    { symbol: 'MSFT', quantity: 5, value: 0 },
+  ])
+
+  // WebSocket updates for live portfolio values
+  useEffect(() => {
+    const ws = new WebSocket('ws://localhost:8000/ws/portfolio')
+    ws.onmessage = (event) => {
+      const data = JSON.parse(event.data) as { symbol: string; value: number }
+      setHoldings((prev) =>
+        prev.map((h) =>
+          h.symbol === data.symbol ? { ...h, value: data.value } : h
+        )
+      )
+    }
+    return () => ws.close()
+  }, [])
+
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Portfolio Dashboard</h1>
+      <div className="grid gap-4 md:grid-cols-2">
+        {holdings.map((h) => (
+          <div key={h.symbol} className="border p-4 rounded">
+            <div className="font-semibold">{h.symbol}</div>
+            <div>Qty: {h.quantity}</div>
+            <div>Value: {h.value.toFixed(2)}</div>
+          </div>
+        ))}
+      </div>
+      <Watchlist />
+      <TradePanel />
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add watchlist component for managing symbols with websocket updates
- create trade panel for simulated buy/sell actions
- introduce portfolio page showing live holdings and integrating watchlist and trade panel

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.market_data')*


------
https://chatgpt.com/codex/tasks/task_e_688f7f4fd6ac832ab8e2cb133f8396a6