### PR TITLE
Graceful handling for missing news API and portfolio defaults

### DIFF
--- a/ai-stock-platform/ui/controllers/news_controller.py
+++ b/ai-stock-platform/ui/controllers/news_controller.py
@@ -45,15 +45,23 @@ _NEWS_CACHE: Dict[str, Dict[str, Any]] = {}
 
 
 async def fetch_news(category: str, page: int = 1, ttl: int = 600) -> Dict[str, Any]:
-    """Fetch news articles from the external API with basic caching."""
+    """Fetch news articles from the external API with basic caching.
+
+    Falls back to demo news when the external API isn't configured so that the
+    `/news` page can still render without errors.
+    """
     cache_key = f"{category}_{page}"
     cached = _NEWS_CACHE.get(cache_key)
     now = datetime.utcnow()
     if cached and cached["expires"] > now:
         return cached["data"]
 
+    # If the real news API isn't configured, serve demo news instead
     if not NEWS_API_KEY:
-        raise HTTPException(status_code=503, detail="News API key not configured")
+        demo_articles = await get_demo_news()
+        data = {"articles": demo_articles, "totalResults": len(demo_articles)}
+        _NEWS_CACHE[cache_key] = {"data": data, "expires": now + timedelta(seconds=ttl)}
+        return data
 
     params = {"apiKey": NEWS_API_KEY, "page": page, "pageSize": 10}
     if category != "market":
@@ -78,18 +86,25 @@ async def news_page(
     try:
         data = await fetch_news(category, page)
 
-        articles = [
-            {
-                "id": idx,
-                "title": art.get("title"),
-                "summary": art.get("description"),
-                "source": art.get("source", {}).get("name"),
-                "published_at": art.get("publishedAt"),
-                "category": category,
-                "sentiment": "neutral",
-            }
-            for idx, art in enumerate(data.get("articles", []))
-        ]
+        articles = []
+        for idx, art in enumerate(data.get("articles", [])):
+            source = art.get("source")
+            if isinstance(source, dict):
+                source = source.get("name")
+            summary = art.get("description") or art.get("summary")
+            published = art.get("publishedAt") or art.get("timestamp")
+
+            articles.append(
+                {
+                    "id": idx,
+                    "title": art.get("title"),
+                    "summary": summary,
+                    "source": source,
+                    "published_at": published,
+                    "category": category,
+                    "sentiment": "neutral",
+                }
+            )
 
         news_data = {
             "articles": articles,

--- a/ai-stock-platform/ui/routes/dashboard.py
+++ b/ai-stock-platform/ui/routes/dashboard.py
@@ -110,8 +110,14 @@ async def dashboard_page(request: Request):
 async def portfolio_page(request: Request):
     """Portfolio overview page"""
     try:
-        # Demo portfolio data removed
-        portfolio_data = {}
+        # Provide default portfolio structure so template logic works
+        portfolio_data = {
+            "total_value": 0.0,
+            "daily_change": 0.0,
+            "total_gain_loss": 0.0,
+            "total_gain_loss_pct": 0.0,
+            "positions": [],
+        }
 
         return get_templates(request).TemplateResponse(
             "dashboard/portfolio.html",


### PR DESCRIPTION
## Summary
- Serve demo news when external API key is missing and parse news items defensively
- Provide default portfolio values to keep dashboard pages rendering

## Testing
- `./setup_env.sh` *(failed: large dependencies)*
- `pytest -q` *(errors: connection to external database; KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688f8cfa7ea8832a91bd93af64306776