### PR TITLE
Gracefully handle missing news API key and stabilize portfolio view

### DIFF
--- a/ai-stock-platform/ui/controllers/news_controller.py
+++ b/ai-stock-platform/ui/controllers/news_controller.py
@@ -52,8 +52,13 @@ async def fetch_news(category: str, page: int = 1, ttl: int = 600) -> Dict[str, 
     if cached and cached["expires"] > now:
         return cached["data"]
 
+    # If no external API key is configured, return demo news instead of failing
     if not NEWS_API_KEY:
-        raise HTTPException(status_code=503, detail="News API key not configured")
+        logger.warning("NEWS_API_KEY not configured - using demo news data")
+        demo_articles = await get_demo_news()
+        data = {"articles": demo_articles, "totalResults": len(demo_articles)}
+        _NEWS_CACHE[cache_key] = {"data": data, "expires": now + timedelta(seconds=ttl)}
+        return data
 
     params = {"apiKey": NEWS_API_KEY, "page": page, "pageSize": 10}
     if category != "market":

--- a/ai-stock-platform/ui/routes/dashboard.py
+++ b/ai-stock-platform/ui/routes/dashboard.py
@@ -110,10 +110,25 @@ async def dashboard_page(request: Request):
 async def portfolio_page(request: Request):
     """Portfolio overview page"""
     try:
-        # Demo portfolio data removed
-        portfolio_data = {}
+        # Provide default empty portfolio structure to avoid template errors
+        portfolio_data = {
+            "total_value": 0,
+            "daily_change": 0,
+            "total_gain_loss": 0,
+            "total_gain_loss_pct": 0,
+            "positions": [],
+        }
 
-        return get_templates(request).TemplateResponse(
+        templates_obj = get_templates(request)
+        # Ensure template filters are registered so function calls don't fail
+        try:  # pragma: no cover - defensive
+            from ui.utils import template_filters
+
+            template_filters.register_filters(request.app)
+        except Exception:  # pragma: no cover
+            pass
+
+        return templates_obj.TemplateResponse(
             "dashboard/portfolio.html",
             {
                 "request": request,


### PR DESCRIPTION
## Summary
- Fallback to demo news when `NEWS_API_KEY` is unavailable
- Provide default portfolio data and ensure template filters are registered for the portfolio page

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'logger' from '<unknown module name>' and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f8e5ebbc0832a8bd659dea1962168