### PR TITLE
Add unit tests and CI workflow for market data and websockets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}/ai-stock-platform
+        run: |
+          pytest tests ai-stock-platform/api/tests -q

--- a/tests/test_alpha_vantage_market_data.py
+++ b/tests/test_alpha_vantage_market_data.py
@@ -1,0 +1,54 @@
+from api.utils.market_data import MarketDataClient
+
+
+class DummyResp:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self.payload
+
+
+def test_get_data(monkeypatch):
+    monkeypatch.setenv("ALPHA_VANTAGE_API_KEY", "demo")
+    client = MarketDataClient()
+
+    def fake_get(url, params, timeout):
+        assert params["symbol"] == "IBM"
+        return DummyResp({"foo": "bar"})
+
+    monkeypatch.setattr("requests.get", fake_get)
+    result = client.get_data("IBM")
+    assert result["symbol"] == "IBM"
+    assert result["data"] == {"foo": "bar"}
+    assert result["source"] == "alphavantage"
+
+
+def test_get_latest_price(monkeypatch):
+    monkeypatch.setenv("ALPHA_VANTAGE_API_KEY", "demo")
+    data = {"Time Series (1min)": {"2021-01-01 00:00:00": {"4. close": "123.45"}}}
+    monkeypatch.setattr("requests.get", lambda url, params, timeout: DummyResp(data))
+    client = MarketDataClient()
+    price = client.get_latest_price("IBM")
+    assert price == 123.45
+
+
+def test_get_historical(monkeypatch):
+    monkeypatch.setenv("ALPHA_VANTAGE_API_KEY", "demo")
+    data = {
+        "Time Series (Daily)": {
+            "2021-01-01": {"close": "1"},
+            "2021-01-02": {"close": "2"},
+            "2021-01-03": {"close": "3"},
+        }
+    }
+    monkeypatch.setattr("requests.get", lambda url, params, timeout: DummyResp(data))
+    client = MarketDataClient()
+    hist = client.get_historical("IBM", "2021-01-02", "2021-01-03")
+    assert hist == [
+        {"date": "2021-01-02", "close": "2"},
+        {"date": "2021-01-03", "close": "3"},
+    ]

--- a/tests/test_linear_regression_predict.py
+++ b/tests/test_linear_regression_predict.py
@@ -1,0 +1,10 @@
+import pandas as pd
+from ai_stock_platform.api.ml.ensemble_model import linear_regression_predict
+
+
+def test_linear_regression_prediction_shape():
+    dates = pd.date_range(end="2024-01-10", periods=30)
+    df = pd.DataFrame({'adjusted_close': range(30)}, index=dates)
+    result = linear_regression_predict('TEST', df, days_ahead=3)
+    assert len(result) == 3
+    assert 'predicted_close' in result.columns

--- a/tests/test_websocket_manager.py
+++ b/tests/test_websocket_manager.py
@@ -1,0 +1,37 @@
+import pytest
+
+from api.websocket.manager import ConnectionManager
+
+
+class DummyWebSocket:
+    def __init__(self):
+        self.accepted = False
+        self.messages = []
+
+    async def accept(self):
+        self.accepted = True
+
+    async def send_json(self, message):
+        self.messages.append(message)
+
+
+@pytest.mark.asyncio
+async def test_connection_manager_flow():
+    manager = ConnectionManager()
+    ws = DummyWebSocket()
+
+    await manager.connect(ws, "client1")
+    assert ws.accepted
+    assert "client1" in manager.active_connections
+
+    await manager.subscribe(ws, "AAPL")
+    assert ws in manager.symbol_subscribers["AAPL"]
+
+    await manager.broadcast_stock_update("AAPL", {"price": 10})
+    assert ws.messages[0]["data"]["price"] == 10
+
+    await manager.unsubscribe(ws, "AAPL")
+    assert "AAPL" not in manager.symbol_subscribers
+
+    await manager.disconnect(ws, "client1")
+    assert manager.active_connections == {}

--- a/tests/test_yahoo_rapidapi_service.py
+++ b/tests/test_yahoo_rapidapi_service.py
@@ -1,4 +1,3 @@
-import os
 from services.yahoo_rapidapi_service import YahooRapidAPIService
 
 
@@ -29,3 +28,15 @@ def test_success(monkeypatch):
     monkeypatch.setattr("requests.get", fake_get)
     result = YahooRapidAPIService.get_timeseries("IBM")
     assert result == {"ok": True}
+
+
+def test_request_failure(monkeypatch):
+    """Service should return None when the request raises an error."""
+    monkeypatch.setenv("RAPIDAPI_KEY", "test")
+
+    def boom(*args, **kwargs):
+        raise Exception("network down")
+
+    monkeypatch.setattr("requests.get", boom)
+    result = YahooRapidAPIService.get_timeseries("IBM")
+    assert result is None


### PR DESCRIPTION
## Summary
- expand YahooRapidAPIService tests to cover request failures
- add unit tests for Alpha Vantage market data client, linear regression forecasting, and websocket connection manager
- introduce GitHub Actions workflow to run API and AI tests on push and PR

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.market_data')*
- `pytest tests/test_yahoo_rapidapi_service.py tests/test_alpha_vantage_market_data.py tests/test_linear_regression_predict.py tests/test_websocket_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688f8c16c014832a9a1ea5cd433356fc