### PR TITLE
Add Yahoo RapidAPI price service with caching

### DIFF
--- a/services/yahoo_rapidapi_service.py
+++ b/services/yahoo_rapidapi_service.py
@@ -1,0 +1,69 @@
+"""Yahoo Finance price service using RapidAPI with caching."""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class YahooRapidAPIService:
+    """Fetch live price data from Yahoo Finance via RapidAPI."""
+
+    _cache: dict[str, tuple[float, Dict[str, float]]] = {}
+    _cache_ttl = 5.0  # seconds
+
+    @classmethod
+    def get_live_price(cls, symbol: str, region: str = "US") -> Optional[Dict[str, float]]:
+        """Return price, change, and percent change for ``symbol``.
+
+        The result is cached for ``_cache_ttl`` seconds to avoid hitting rate
+        limits during high-frequency requests.  If the ``RAPIDAPI_KEY``
+        environment variable is missing the function returns ``None`` without
+        making a network request.
+        """
+        host = os.getenv("RAPIDAPI_HOST", "apidojo-yahoo-finance-v1.p.rapidapi.com")
+        api_key = os.getenv("RAPIDAPI_KEY")
+        if not api_key:
+            logger.warning("RAPIDAPI_KEY not configured")
+            return None
+
+        key = symbol.upper()
+        now = time.time()
+        cached = cls._cache.get(key)
+        if cached and now - cached[0] < cls._cache_ttl:
+            return cached[1]
+
+        url = f"https://{host}/market/v2/get-quotes"
+        headers = {"x-rapidapi-host": host, "x-rapidapi-key": api_key}
+        params = {"symbols": symbol, "region": region}
+        try:
+            resp = requests.get(url, headers=headers, params=params, timeout=10)
+            resp.raise_for_status()
+            normalized = cls._normalize_quote(resp.json())
+            if normalized is not None:
+                cls._cache[key] = (now, normalized)
+            return normalized
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.error("Failed to fetch live price: %s", exc)
+            return None
+
+    @staticmethod
+    def _normalize_quote(data: Dict[str, Any]) -> Optional[Dict[str, float]]:
+        """Extract price fields from the raw API response."""
+        try:
+            quote = data["quoteResponse"]["result"][0]
+            return {
+                "price": float(quote["regularMarketPrice"]),
+                "change": float(quote["regularMarketChange"]),
+                "percent_change": float(quote["regularMarketChangePercent"]),
+            }
+        except Exception:  # pragma: no cover - unexpected format
+            return None
+
+
+__all__ = ["YahooRapidAPIService"]

--- a/tests/test_yahoo_rapidapi_service.py
+++ b/tests/test_yahoo_rapidapi_service.py
@@ -1,31 +1,60 @@
-import os
 from services.yahoo_rapidapi_service import YahooRapidAPIService
 
 
 class DummyResp:
     def __init__(self, data):
         self._data = data
+
     def raise_for_status(self):
         pass
+
     def json(self):
         return self._data
 
 
+def setup_function():
+    YahooRapidAPIService._cache.clear()
+
+
 def test_no_api_key(monkeypatch):
     monkeypatch.delenv("RAPIDAPI_KEY", raising=False)
-    assert YahooRapidAPIService.get_timeseries("IBM") is None
+    assert YahooRapidAPIService.get_live_price("IBM") is None
 
 
-def test_success(monkeypatch):
+def test_fetch_and_cache(monkeypatch):
     monkeypatch.setenv("RAPIDAPI_KEY", "test")
     monkeypatch.setenv("RAPIDAPI_HOST", "example.com")
 
+    data = {
+        "quoteResponse": {
+            "result": [
+                {
+                    "regularMarketPrice": 101.0,
+                    "regularMarketChange": 1.5,
+                    "regularMarketChangePercent": 1.49,
+                }
+            ]
+        }
+    }
+
+    calls = {"count": 0}
+
     def fake_get(url, headers, params, timeout):
-        assert url == "https://example.com/stock/v2/get-timeseries"
+        calls["count"] += 1
+        assert url == "https://example.com/market/v2/get-quotes"
         assert headers["x-rapidapi-key"] == "test"
-        assert params["symbol"] == "IBM"
-        return DummyResp({"ok": True})
+        assert params["symbols"] == "IBM"
+        return DummyResp(data)
 
     monkeypatch.setattr("requests.get", fake_get)
-    result = YahooRapidAPIService.get_timeseries("IBM")
-    assert result == {"ok": True}
+    result = YahooRapidAPIService.get_live_price("IBM")
+    assert result == {
+        "price": 101.0,
+        "change": 1.5,
+        "percent_change": 1.49,
+    }
+
+    # Second call should hit the cache
+    result2 = YahooRapidAPIService.get_live_price("IBM")
+    assert result2 == result
+    assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- implement `YahooRapidAPIService` to fetch live prices from Yahoo Finance via RapidAPI with in-memory caching
- normalize quote response (price, change, percent change)
- add unit tests covering API key handling, request formatting, and cache behavior

## Testing
- `PYTHONPATH=. pytest tests/test_yahoo_rapidapi_service.py -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f8bd0a3d8832a8065c24d9ae02d73