### PR TITLE
Handle live data config without global settings

### DIFF
--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -34,19 +34,25 @@ except Exception:  # pragma: no cover - Redis or package not available
 # This avoids accidentally importing the similarly named package located in
 # the repository root which lacks several attributes such as
 # ``ALPHA_VANTAGE_API_KEY``.
-# Attempt to import the settings object. When running inside the Docker
-# container the ``api`` package may not be available because the working
-# directory is already the package itself. In that case fall back to the
-# ``core`` compatibility package which exposes the same settings instance.
-try:
+# Attempt to import the settings object.  Some test environments load this
+# module directly via ``importlib`` without configuring ``PYTHONPATH``.  In
+# those cases importing ``api.core.config`` or the compatibility
+# ``core.config`` package fails which previously raised an ``ImportError`` and
+# prevented the service from being used.  To keep the service functional across
+# all environments, fall back to reading the required configuration directly
+# from environment variables when the settings modules cannot be imported.
+try:  # pragma: no cover - exercised indirectly in tests
     from api.core.config import settings
-except ModuleNotFoundError:
+except Exception:  # pragma: no cover - handle missing package gracefully
     try:
         from core.config import settings  # type: ignore[attr-defined]
-    except ModuleNotFoundError as e:  # pragma: no cover - explicit error path
-        raise ImportError(
-            "Could not import API configuration. Ensure PYTHONPATH includes the api package."
-        ) from e
+    except Exception:  # pragma: no cover - final fallback
+        from types import SimpleNamespace
+
+        settings = SimpleNamespace(
+            ALPHA_VANTAGE_API_KEY=os.getenv("ALPHA_VANTAGE_API_KEY"),
+            ENABLE_REAL_DATA=os.getenv("ENABLE_REAL_DATA", "false").lower() == "true",
+        )
 
 # Try to import aiohttp, fallback to None if not available
 try:
@@ -68,8 +74,8 @@ class TrendingStocksService:
         self.use_mock = not getattr(settings, "ENABLE_REAL_DATA", False)
 
         # Use configured API key, falling back to the settings value if provided
-        self.api_key = os.getenv(
-            "ALPHA_VANTAGE_API_KEY", settings.ALPHA_VANTAGE_API_KEY
+        self.api_key = os.getenv("ALPHA_VANTAGE_API_KEY") or getattr(
+            settings, "ALPHA_VANTAGE_API_KEY", None
         )
         if not self.api_key and not self.use_mock:
             raise RuntimeError(

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -3,7 +3,16 @@ from pathlib import Path
 import sys
 
 root = Path(__file__).resolve().parent
-_pkg = root / "ai-stock-platform" / "core"
+# The repository structure places the actual ``core`` package inside the
+# ``ai-stock-platform`` directory next to this compatibility wrapper.  The
+# previous implementation incorrectly assumed that directory was located
+# inside this package which resulted in an invalid search path like
+# ``core/ai-stock-platform/core``.  That path does not exist, preventing
+# imports such as ``core.config`` from resolving in the test environment.
+#
+# Compute the package location relative to the parent of this file so the
+# full path ``<repo>/ai-stock-platform/core`` is added to ``__path__``.
+_pkg = root.parent / "ai-stock-platform" / "core"
 __path__ = [str(_pkg)]
 if str(_pkg) not in sys.path:
     sys.path.insert(0, str(_pkg))


### PR DESCRIPTION
## Summary
- fix path resolution for compatibility `core` package used in tests
- allow trending stocks service to read `ENABLE_REAL_DATA` and API key directly from environment when settings modules are unavailable

## Testing
- `pytest ai-stock-platform/api/tests/test_trending_warning_cooldown.py::test_failure_warning_cooldown -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.exceptions', No module named 'core.security', No module named 'models.orders')*

------
https://chatgpt.com/codex/tasks/task_e_688feed95a30832a823e6ddc1d68a636