### PR TITLE
fix: handle lowercase DATABASE env var

### DIFF
--- a/ai-stock-platform/api/core/config/settings.py
+++ b/ai-stock-platform/api/core/config/settings.py
@@ -111,18 +111,21 @@ class Settings(BaseSettings):
 def get_settings() -> Settings:
     """Return an initialized :class:`Settings` instance.
 
-    The hosting environment may define an environment variable named
-    ``DATABASE`` which conflicts with Pydantic's handling of the nested
-    ``database`` model.  Temporarily removing this variable prevents JSON
-    decoding errors during instantiation.
+    The hosting environment may define environment variables named
+    ``DATABASE`` or ``database`` which conflict with Pydantic's handling of the
+    nested ``database`` model. Temporarily removing these variables prevents
+    JSON decoding errors during instantiation.
     """
 
-    removed = os.environ.pop("DATABASE", None)
+    removed_vars = {
+        key: os.environ.pop(key)
+        for key in ("DATABASE", "database")
+        if key in os.environ
+    }
     try:
         return Settings()
     finally:
-        if removed is not None:
-            os.environ["DATABASE"] = removed
+        os.environ.update(removed_vars)
 
 # Global settings instance
 settings = get_settings()

--- a/ai-stock-platform/core/config/settings.py
+++ b/ai-stock-platform/core/config/settings.py
@@ -83,18 +83,21 @@ class Settings(BaseSettings):
 def get_settings() -> Settings:
     """Return an initialized :class:`Settings` instance.
 
-    The Kubernetes deployment defines an environment variable named ``DATABASE``
-    which conflicts with Pydantic's handling of the nested ``database`` model.
-    Removing this variable before instantiation prevents JSON decoding errors
-    when the settings object is created.
+    The Kubernetes deployment defines environment variables named ``DATABASE``
+    or ``database`` which conflict with Pydantic's handling of the nested
+    ``database`` model. Removing these variables before instantiation prevents
+    JSON decoding errors when the settings object is created.
     """
 
-    removed = os.environ.pop("DATABASE", None)
+    removed_vars = {
+        key: os.environ.pop(key)
+        for key in ("DATABASE", "database")
+        if key in os.environ
+    }
     try:
         return Settings()
     finally:
-        if removed is not None:
-            os.environ["DATABASE"] = removed
+        os.environ.update(removed_vars)
 
 
 settings = get_settings()

--- a/ai-stock-platform/ui/core/config/settings.py
+++ b/ai-stock-platform/ui/core/config/settings.py
@@ -187,20 +187,24 @@ class Settings:
 def get_settings() -> Settings:
     """Return a cached settings instance.
 
-    Some hosting environments define a ``DATABASE`` variable which Pydantic
-    interprets as a JSON representation of our nested ``database`` model.  The
-    UI service only expects individual ``DB_*`` variables, so this unexpected
-    variable results in ``JSONDecodeError`` when instantiating :class:`Settings`.
-    Temporarily removing ``DATABASE`` avoids the parsing error while preserving
-    the original environment for any callers that rely on it.
+    Some hosting environments define ``DATABASE`` or ``database`` variables
+    which Pydantic interprets as JSON representations of our nested
+    ``database`` model. The UI service only expects individual ``DB_*``
+    variables, so these unexpected variables result in ``JSONDecodeError`` when
+    instantiating :class:`Settings`. Temporarily removing them avoids the
+    parsing error while preserving the original environment for any callers
+    that rely on it.
     """
 
-    removed = os.environ.pop("DATABASE", None)
+    removed_vars = {
+        key: os.environ.pop(key)
+        for key in ("DATABASE", "database")
+        if key in os.environ
+    }
     try:
         return Settings()
     finally:
-        if removed is not None:
-            os.environ["DATABASE"] = removed
+        os.environ.update(removed_vars)
 
 
 # Instantiate settings for modules that import ``settings`` directly


### PR DESCRIPTION
## Summary
- remove lowercase `database` env vars before instantiating settings to avoid JSON parsing errors

## Testing
- `./setup_env.sh`
- `pip install pydantic-settings==2.1.0`
- `pip install fastapi==0.105.0`
- `export PYTHONPATH="$(pwd)/ai-stock-platform:$PYTHONPATH"`
- `pip install openai`
- `pytest -q` *(fails: connection to server at "quantumvestai-dev.cwbsqsiywwaa.us-east-1.rds.amazonaws.com" (10.0.37.138), port 5432 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68901ff705d8832aa698db366963954a