### PR TITLE
feat: persist auth state in navbar

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,23 +1,21 @@
-import { Suspense, lazy } from 'react'
-import { useAppStore } from '@/store/useAppStore'
-import { usePing } from '@/api/hooks/usePing'
-
-// Lazy load non-critical UI components
-const Button = lazy(() => import('@/components/ui/button'))
+import { useEffect } from 'react'
+import Navbar from '@/components/Navbar'
+import LoginForm from '@/components/LoginForm'
+import Home from '@/components/Home'
+import { useAuthStore } from '@/store/useAuthStore'
 
 function App() {
-  const count = useAppStore((s) => s.count)
-  const increment = useAppStore((s) => s.increment)
-  const { data } = usePing()
+  const user = useAuthStore((s) => s.user)
+  const refresh = useAuthStore((s) => s.refresh)
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
 
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">QuantumVest AI UI</h1>
-      <p>{data?.message ?? 'Loading...'}</p>
-      <div>Count: {count}</div>
-      <Suspense fallback={<div>Loading button...</div>}>
-        <Button onClick={increment}>Increment</Button>
-      </Suspense>
+    <div>
+      <Navbar />
+      {user ? <Home /> : <LoginForm />}
     </div>
   )
 }

--- a/ui/src/components/Home.tsx
+++ b/ui/src/components/Home.tsx
@@ -1,0 +1,22 @@
+import { Suspense, lazy } from 'react'
+import { useAppStore } from '@/store/useAppStore'
+import { usePing } from '@/api/hooks/usePing'
+
+const Button = lazy(() => import('@/components/ui/button'))
+
+export default function Home() {
+  const count = useAppStore((s) => s.count)
+  const increment = useAppStore((s) => s.increment)
+  const { data } = usePing()
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">QuantumVest AI UI</h1>
+      <p>{data?.message ?? 'Loading...'}</p>
+      <div>Count: {count}</div>
+      <Suspense fallback={<div>Loading button...</div>}>
+        <Button onClick={increment}>Increment</Button>
+      </Suspense>
+    </div>
+  )
+}

--- a/ui/src/components/LoginForm.tsx
+++ b/ui/src/components/LoginForm.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { useAuthStore } from '@/store/useAuthStore'
+
+export default function LoginForm() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const login = useAuthStore((s) => s.login)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await login(username, password)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 p-4 max-w-sm">
+      <input
+        className="border p-2"
+        placeholder="Username"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+      />
+      <input
+        className="border p-2"
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit" className="border p-2">
+        Login
+      </button>
+    </form>
+  )
+}

--- a/ui/src/components/Navbar.tsx
+++ b/ui/src/components/Navbar.tsx
@@ -1,0 +1,22 @@
+import { useAuthStore } from '@/store/useAuthStore'
+
+export default function Navbar() {
+  const user = useAuthStore((s) => s.user)
+  const logout = useAuthStore((s) => s.logout)
+
+  return (
+    <nav className="flex gap-4 p-4 border-b mb-4">
+      {user ? (
+        <>
+          <span>Welcome, {user.username}</span>
+          <button onClick={logout}>Logout</button>
+        </>
+      ) : (
+        <>
+          <a href="#login">Login</a>
+          <a href="#register">Register</a>
+        </>
+      )}
+    </nav>
+  )
+}

--- a/ui/src/store/useAuthStore.ts
+++ b/ui/src/store/useAuthStore.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { apiFetch } from '@/api/client'
+
+interface User {
+  username: string
+  [key: string]: any
+}
+
+interface AuthState {
+  user: User | null
+  token: string | null
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+  refresh: () => Promise<void>
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      user: null,
+      token: null,
+      async login(username, password) {
+        const res = await apiFetch<{ token: string; user: User }>(
+          '/auth/login',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username, password }),
+          }
+        )
+        set({ token: res.token, user: res.user })
+      },
+      logout() {
+        set({ user: null, token: null })
+      },
+      async refresh() {
+        const token = get().token
+        if (!token) return
+        try {
+          const user = await apiFetch<User>('/auth/me', {
+            headers: { Authorization: `Bearer ${token}` },
+          })
+          set({ user })
+        } catch {
+          set({ user: null, token: null })
+        }
+      },
+    }),
+    { name: 'auth' }
+  )
+)


### PR DESCRIPTION
## Summary
- add Zustand auth store to handle login, logout, and token refresh with persistence
- show logged-in user or login/register links in new Navbar
- include login form and refresh auth on app startup

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689021d60fc0832a938142403707641f