### PR TITLE
feat(websocket): support cookie auth

### DIFF
--- a/ai-stock-platform/api/routers/websocket.py
+++ b/ai-stock-platform/api/routers/websocket.py
@@ -50,6 +50,18 @@ async def websocket_endpoint(
                 await websocket.close(code=1008)
                 return
 
+        # Gather token from query params, cookies, or headers
+        cookie_token = websocket.cookies.get("access_token")
+        auth_header = websocket.headers.get("authorization")
+
+        if not token:
+            token = cookie_token
+        if not token and auth_header:
+            if auth_header.lower().startswith("bearer "):
+                token = auth_header.split(" ", 1)[1]
+        if token and token.startswith("Bearer "):
+            token = token.split(" ", 1)[1]
+
         # Require and verify token, except for public market data stream
         user = None
         if not token:
@@ -60,7 +72,7 @@ async def websocket_endpoint(
                 return
         if token:
             try:
-                user = await get_current_user(token)
+                user = await get_current_user(token=token)
             except Exception:
                 await websocket.close(code=4001, reason="Invalid token")
                 return

--- a/ai-stock-platform/api/tests/test_websocket_broadcast.py
+++ b/ai-stock-platform/api/tests/test_websocket_broadcast.py
@@ -38,3 +38,14 @@ def test_websocket_broadcasts_updates():
         event = ws.receive_json()
         assert event["type"] == "top_movers"
         assert event["data"][0]["symbol"] == "AAPL"
+
+
+def test_websocket_accepts_token_from_cookie():
+    client = TestClient(app)
+    token = create_access_token({"sub": "cookietester"})
+    client.cookies.set("access_token", f"Bearer {token}")
+    with client.websocket_connect("/ws/test-client") as ws:
+        ws.send_json({"type": "subscribe", "data": {"symbol": "AAPL"}})
+        resp = ws.receive_json()
+        assert resp["type"] == "subscribed"
+        assert resp["topic"] == "AAPL"


### PR DESCRIPTION
## Summary
- accept WebSocket auth tokens from cookies or Authorization headers
- test WebSocket connection using cookie-based token

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: No module named 'core.exceptions', ...)*

------
https://chatgpt.com/codex/tasks/task_e_689025458264832a8e890e973accd3a5