### PR TITLE
fix security import

### DIFF
--- a/ai-stock-platform/api/core/security/tokens.py
+++ b/ai-stock-platform/api/core/security/tokens.py
@@ -4,7 +4,7 @@ Token handling functionality.
 from datetime import datetime, timedelta
 from typing import Optional
 
-from jose import jwt
+from jose import jwt, JWTError
 from pydantic import BaseModel
 
 from core.config import get_settings
@@ -42,3 +42,12 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -
 def decode_token(token: str) -> Optional[BaseModel]:
     """Convenience wrapper to decode a JWT token."""
     return TokenHandler.decode_token(token)
+
+
+def validate_token(token: str) -> bool:
+    """Return ``True`` if the provided JWT is valid, ``False`` otherwise."""
+    try:
+        TokenHandler.decode_token(token)
+        return True
+    except JWTError:
+        return False

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,6 +1,13 @@
-"""Compatibility wrapper so ``import api`` works in tests."""
+"""Compatibility wrapper so ``import api`` works in tests.
+
+This module adjusts ``sys.path`` so the actual API package located under
+``ai-stock-platform/api`` can be imported as ``api``.  It also mirrors the
+real package's initialization logic to expose expected modules and aliases
+(such as ``core`` and ``db``).
+"""
 from pathlib import Path
 import sys
+import importlib
 
 root = Path(__file__).resolve().parent.parent
 _pkg = root / "ai-stock-platform" / "api"
@@ -9,3 +16,26 @@ if str(_pkg) not in sys.path:
     sys.path.insert(0, str(_pkg))
 if str(_pkg.parent) not in sys.path:
     sys.path.insert(0, str(_pkg.parent))
+
+# Replicate key side effects from the real package's ``__init__``
+core_pkg = importlib.import_module("api.core")
+sys.modules.setdefault("core", core_pkg)
+for name in ("exceptions", "responses", "validation", "database", "security", "models"):
+    submod = f"api.core.{name}"
+    try:
+        sys.modules.setdefault(f"core.{name}", importlib.import_module(submod))
+    except Exception:
+        pass
+
+db_pkg = importlib.import_module("api.db")
+sys.modules.setdefault("db", db_pkg)
+
+models_pkg = importlib.import_module("api.models")
+sys.modules.setdefault("models", models_pkg)
+
+try:  # pragma: no cover - optional dependency may be missing
+    from api.main import app
+except Exception:
+    app = None
+
+__all__ = ["app"]


### PR DESCRIPTION
## Summary
- expose `validate_token` via the security tokens module so websocket routes can verify JWTs
- mirror real package initialization in `api/__init__` to register core/db/models aliases

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.market_data')*


------
https://chatgpt.com/codex/tasks/task_e_689032eb06d0832a9888014ed836b23b