### PR TITLE
refactor: use server-side session for auth

### DIFF
--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -1,9 +1,17 @@
 const API_BASE = '/api'
 
-export async function apiFetch<T>(url: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(`${API_BASE}${url}`, options)
+export async function apiFetch<T>(
+  url: string,
+  options: RequestInit = {},
+): Promise<T> {
+  const res = await fetch(`${API_BASE}${url}`, {
+    credentials: 'include',
+    ...options,
+    headers: new Headers(options.headers),
+  })
   if (!res.ok) {
     throw new Error('Network response was not ok')
   }
   return res.json() as Promise<T>
 }
+

--- a/ui/src/store/useAuthStore.ts
+++ b/ui/src/store/useAuthStore.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
 import { apiFetch } from '@/api/client'
 
 interface User {
@@ -9,44 +8,34 @@ interface User {
 
 interface AuthState {
   user: User | null
-  token: string | null
   login: (username: string, password: string) => Promise<void>
-  logout: () => void
+  logout: () => Promise<void>
   refresh: () => Promise<void>
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set, get) => ({
-      user: null,
-      token: null,
-      async login(username, password) {
-        const res = await apiFetch<{ token: string; user: User }>(
-          '/auth/login',
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ username, password }),
-          }
-        )
-        set({ token: res.token, user: res.user })
-      },
-      logout() {
-        set({ user: null, token: null })
-      },
-      async refresh() {
-        const token = get().token
-        if (!token) return
-        try {
-          const user = await apiFetch<User>('/auth/me', {
-            headers: { Authorization: `Bearer ${token}` },
-          })
-          set({ user })
-        } catch {
-          set({ user: null, token: null })
-        }
-      },
-    }),
-    { name: 'auth' }
-  )
-)
+export const useAuthStore = create<AuthState>()((set, get) => ({
+  user: null,
+  async login(username, password) {
+    await apiFetch('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    })
+    await get().refresh()
+  },
+  async logout() {
+    try {
+      await apiFetch('/auth/logout', { method: 'POST' })
+    } finally {
+      set({ user: null })
+    }
+  },
+  async refresh() {
+    try {
+      const user = await apiFetch<User>('/auth/me')
+      set({ user })
+    } catch {
+      set({ user: null })
+    }
+  },
+}))


### PR DESCRIPTION
## Summary
- send credentials with each request and drop localStorage persistence
- refactor auth store to use server-managed session for login/logout/refresh

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.security')*

------
https://chatgpt.com/codex/tasks/task_e_68911279926c832a8a07865e1dd73e3e