### PR TITLE
Add websockets dependency to API requirements

### DIFF
--- a/ai-stock-platform/api/requirements.txt
+++ b/ai-stock-platform/api/requirements.txt
@@ -28,3 +28,4 @@ prometheus_client
 torch==2.2.2
 transformers==4.30.0
 requests==2.31.0
+websockets==12.0


### PR DESCRIPTION
## Summary
- include websockets package for WebSocket router

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.security')*


------
https://chatgpt.com/codex/tasks/task_e_68911ecba550832aab62e2a0d1c9d584