### PR TITLE
Fix market data WebSocket endpoint for free tier

### DIFF
--- a/ui/src/api/marketData.ts
+++ b/ui/src/api/marketData.ts
@@ -1,11 +1,5 @@
 export function connectMarketData(token: string): WebSocket {
-  // Try connecting to the direct endpoint first (without /ws/ prefix)
-  // as it's more permissive with token validation
-  try {
-    return new WebSocket(`wss://dev.quantumvestai.com/market-data?token=${token}`);
-  } catch (err) {
-    console.warn("Failed to connect to direct market-data endpoint, falling back to /ws/ path");
-    return new WebSocket(`wss://dev.quantumvestai.com/ws/market-data?token=${token}`);
-  }
+  // Connect directly to the market-data endpoint which allows free-tier access.
+  return new WebSocket(`wss://dev.quantumvestai.com/market-data?token=${token}`);
 }
 


### PR DESCRIPTION
## Summary
- always connect UI to `/market-data` WebSocket endpoint, which permits free tier tokens

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ai-stock-platform/api/tests/test_auth.py, ai-stock-platform/api/tests/test_docs.py, ai-stock-platform/api/tests/test_market_data_websocket.py, ai-stock-platform/api/tests/test_trending_stocks.py, ai-stock-platform/api/tests/test_websocket_broadcast.py, ai-stock-platform/api/tests/test_websocket_permissions.py, tests/test_ai_analysis.py, tests/test_market_overview_endpoint.py, tests/test_market_ws.py, tests/test_most_predictable_endpoint.py, tests/test_pre_market_endpoint.py)*

------
https://chatgpt.com/codex/tasks/task_e_689127718e60832abe29b6cf74bf9331