### PR TITLE
Fix Yahoo fallback trending symbols list

### DIFF
--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -169,7 +169,18 @@ class TrendingStocksService:
         if last_exception:
             logger.error(f"Detailed error: {repr(last_exception)}")
         # Return default trending tech stocks as fallback
-        return {"stocks": ["AAPL", "MSFT", "GOOGL", "AMZN", "META", "TSLA", "NVDA", "AMD", "INTC", "NFLX"]}
+        return [
+            "AAPL",
+            "MSFT",
+            "GOOGL",
+            "AMZN",
+            "META",
+            "TSLA",
+            "NVDA",
+            "AMD",
+            "INTC",
+            "NFLX",
+        ]
 
     async def get_trending_stocks(
         self, page: int = 1, limit: int = 10

--- a/tests/test_trending_symbols_fallback.py
+++ b/tests/test_trending_symbols_fallback.py
@@ -1,0 +1,25 @@
+import os
+import importlib.util
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "trending_stocks_service",
+    os.path.join(os.path.dirname(__file__), "..", "services", "trending_stocks_service.py"),
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+TrendingStocksService = module.TrendingStocksService
+
+
+@pytest.mark.asyncio
+async def test_fetch_yahoo_trending_symbols_fallback_returns_list(monkeypatch):
+    # Ensure API key is set to avoid runtime error in service initialization
+    monkeypatch.setenv("ALPHA_VANTAGE_API_KEY", "test")
+    service = TrendingStocksService()
+
+    symbols = await service._fetch_yahoo_trending_symbols(retries=0)
+
+    assert isinstance(symbols, list)
+    assert "AAPL" in symbols
+    assert len(symbols) >= 5


### PR DESCRIPTION
## Summary
- return a list of default symbols when Yahoo trending lookup fails
- add regression test for fallback symbols helper

## Testing
- `pytest tests/test_trending_symbols_fallback.py -q`
- `pytest -q` *(fails: connection to remote PostgreSQL server is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68912884dff8832ab465422fdda4d641