### PR TITLE
fix: ensure fallback trending symbols returned as list

### DIFF
--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -169,7 +169,18 @@ class TrendingStocksService:
         if last_exception:
             logger.error(f"Detailed error: {repr(last_exception)}")
         # Return default trending tech stocks as fallback
-        return {"stocks": ["AAPL", "MSFT", "GOOGL", "AMZN", "META", "TSLA", "NVDA", "AMD", "INTC", "NFLX"]}
+        return [
+            "AAPL",
+            "MSFT",
+            "GOOGL",
+            "AMZN",
+            "META",
+            "TSLA",
+            "NVDA",
+            "AMD",
+            "INTC",
+            "NFLX",
+        ]
 
     async def get_trending_stocks(
         self, page: int = 1, limit: int = 10


### PR DESCRIPTION
## Summary
- ensure `_fetch_yahoo_trending_symbols` returns a list of default symbols when Yahoo API fails

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891273fddb8832a8fe36ce4d0ecba21