### PR TITLE
Fix trending stocks service return and add test

### DIFF
--- a/ai-stock-platform/api/services/trending_stocks_service.py
+++ b/ai-stock-platform/api/services/trending_stocks_service.py
@@ -282,6 +282,8 @@ class TrendingStocksService:
             logger.error("Failed to fetch any real stock data")
             raise RuntimeError("Unable to retrieve any stock data from live data source")
 
+        return stocks_data
+
     async def _fetch_stock_quote(
         self, session, symbol: str
     ) -> Optional[Dict[str, Any]]:

--- a/tests/test_trending_stocks_service_returns_data.py
+++ b/tests/test_trending_stocks_service_returns_data.py
@@ -1,0 +1,40 @@
+import os
+import importlib.util
+from datetime import datetime
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "trending_stocks_service",
+    os.path.join(os.path.dirname(__file__), "..", "services", "trending_stocks_service.py"),
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+TrendingStocksService = module.TrendingStocksService
+
+
+@pytest.mark.asyncio
+async def test_get_trending_stocks_returns_data(monkeypatch):
+    monkeypatch.setenv("ALPHA_VANTAGE_API_KEY", "test")
+    service = TrendingStocksService()
+
+    async def mock_fetch_yahoo_trending_symbols(self, retries=3, delay: float = 2.0):
+        return ["AAPL", "MSFT"]
+
+    async def mock_fetch_stock_quote(self, session, symbol: str):
+        return {
+            "symbol": symbol,
+            "name": f"{symbol} Corp.",
+            "price": 100.0,
+            "change": 0.0,
+            "change_percent": 0.0,
+            "volume": 0,
+            "last_updated": datetime.utcnow().isoformat(),
+        }
+
+    monkeypatch.setattr(TrendingStocksService, "_fetch_yahoo_trending_symbols", mock_fetch_yahoo_trending_symbols)
+    monkeypatch.setattr(TrendingStocksService, "_fetch_stock_quote", mock_fetch_stock_quote)
+
+    result = await service.get_trending_stocks(limit=2)
+    assert isinstance(result["stocks"], list)
+    assert len(result["stocks"]) == 2


### PR DESCRIPTION
## Summary
- ensure `_fetch_trending_stocks` returns collected data to prevent NoneType errors
- add unit test verifying `get_trending_stocks` yields a list of stocks when dependencies are patched

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.security')*

------
https://chatgpt.com/codex/tasks/task_e_689180c28a24832ab679ce643b29f9d0