### PR TITLE
feat: persist auth and broadcast market data

### DIFF
--- a/ui/src/api/marketData.ts
+++ b/ui/src/api/marketData.ts
@@ -1,5 +1,24 @@
-export function connectMarketData(token: string): WebSocket {
-  // Connect directly to the market-data endpoint which allows free-tier access.
-  return new WebSocket(`wss://dev.quantumvestai.com/market-data?token=${token}`);
+import { useAuthStore } from '@/store/useAuthStore'
+
+const CHANNEL_NAME = 'market-data'
+
+/**
+ * Open a WebSocket connection for market data and broadcast messages across tabs.
+ */
+export function connectMarketData(token?: string): WebSocket {
+  const t = token ?? useAuthStore.getState().token ?? ''
+  const ws = new WebSocket(`wss://dev.quantumvestai.com/market-data?token=${t}`)
+  const channel = new BroadcastChannel(CHANNEL_NAME)
+  ws.onmessage = (event) => channel.postMessage(event.data)
+  return ws
+}
+
+/**
+ * Listen for market data updates broadcast by any tab.
+ */
+export function subscribeMarketData(handler: (data: string) => void): () => void {
+  const channel = new BroadcastChannel(CHANNEL_NAME)
+  channel.onmessage = (event) => handler(event.data as string)
+  return () => channel.close()
 }
 

--- a/ui/src/store/useAuthStore.ts
+++ b/ui/src/store/useAuthStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
 import { apiFetch } from '@/api/client'
 
 interface User {
@@ -8,34 +9,61 @@ interface User {
 
 interface AuthState {
   user: User | null
+  token: string | null
   login: (username: string, password: string) => Promise<void>
   logout: () => Promise<void>
   refresh: () => Promise<void>
 }
 
-export const useAuthStore = create<AuthState>()((set, get) => ({
-  user: null,
-  async login(username, password) {
-    await apiFetch('/auth/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password }),
-    })
-    await get().refresh()
-  },
-  async logout() {
-    try {
-      await apiFetch('/auth/logout', { method: 'POST' })
-    } finally {
-      set({ user: null })
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      user: null,
+      token: null,
+      async login(username, password) {
+        const { data } = await apiFetch<{ data: { access_token: string } }>(
+          '/auth/login',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username, password }),
+          },
+        )
+        set({ token: data?.access_token ?? null })
+        await get().refresh()
+      },
+      async logout() {
+        try {
+          await apiFetch('/auth/logout', { method: 'POST' })
+        } finally {
+          set({ user: null, token: null })
+        }
+      },
+      async refresh() {
+        try {
+          const user = await apiFetch<User>('/auth/me')
+          set({ user })
+        } catch {
+          set({ user: null, token: null })
+        }
+      },
+    }),
+    {
+      name: 'auth',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ user: state.user, token: state.token }),
+    },
+  ),
+)
+
+// Synchronize auth state across browser tabs
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (e) => {
+    if (e.key === 'auth' && e.newValue) {
+      const parsed = JSON.parse(e.newValue)
+      if (parsed?.state) {
+        useAuthStore.setState(parsed.state)
+      }
     }
-  },
-  async refresh() {
-    try {
-      const user = await apiFetch<User>('/auth/me')
-      set({ user })
-    } catch {
-      set({ user: null })
-    }
-  },
-}))
+  })
+}


### PR DESCRIPTION
## Summary
- persist auth state and token with Zustand storage
- broadcast market data across tabs and allow subscriptions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core.security')*

------
https://chatgpt.com/codex/tasks/task_e_6891841ab438832a855c2d19c35853df