### PR TITLE
Fix login persistence and market user context

### DIFF
--- a/ai-stock-platform/ui/controllers/auth_controller.py
+++ b/ai-stock-platform/ui/controllers/auth_controller.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import requests
+import jwt
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
@@ -171,6 +172,25 @@ async def login_post(
             samesite="lax",
             secure=request.url.scheme == "https",
         )
+
+        # Store basic user info for UI convenience
+        secret = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "your-secret-key")
+        try:
+            payload = jwt.decode(access_token, secret, algorithms=["HS256"])
+            uname = payload.get("sub", username)
+            role = payload.get("role", "user")
+            full_name = payload.get("name", uname)
+            response.set_cookie(
+                key="user_info",
+                value=f"{uname}|{role}|{full_name}",
+                httponly=False,
+                max_age=max_age,
+                samesite="lax",
+                secure=request.url.scheme == "https",
+            )
+        except Exception:
+            # If decoding fails, continue without user_info cookie
+            pass
 
         logger.info(f"User {username} successfully logged in")
         return response

--- a/ai-stock-platform/ui/controllers/market_controller.py
+++ b/ai-stock-platform/ui/controllers/market_controller.py
@@ -100,6 +100,9 @@ def get_templates(request: Request):
 async def market_overview(request: Request, response: Response):
     """Market overview page showing indices, trends, and top movers."""
     try:
+        # Get current user first
+        user = await get_optional_current_user(request, response)
+
         # Get API URL from app state or environment
         api_url_base = getattr(request.app.state, "settings", {}).get(
             "API_URL", os.getenv("API_URL", "http://quantumvestai-dev-api.dev.svc.cluster.local:8000")
@@ -112,8 +115,6 @@ async def market_overview(request: Request, response: Response):
 
         if market_data is None:
             try:
-                # Get current user for authentication
-                user = await get_optional_current_user(request, response)
                 auth_token = user.get("token") if user else None
 
                 # Fetch market data from API using centralized HTTP client
@@ -139,23 +140,22 @@ async def market_overview(request: Request, response: Response):
         # Get templates
         templates = get_templates(request)
 
-        # Render template
+        # Render template with user context
         return get_templates(request).TemplateResponse(
             "market/overview.html",
             {
                 "request": request,
-                "user": None,
+                "user": user,
                 "page_title": "Market Overview",
                 "market_data": market_data,
                 "last_updated": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC"),
-                "is_authenticated": False,
+                "is_authenticated": bool(user),
             },
         )
 
     except Exception as e:
         logger.exception(f"Market overview error: {str(e)}")
 
-        # Get templates
         templates = get_templates(request)
 
         return get_templates(request).TemplateResponse(
@@ -164,7 +164,7 @@ async def market_overview(request: Request, response: Response):
                 "request": request,
                 "message": "An error occurred while loading market data.",
                 "error_code": "MARKET_ERR",
-                "user": None,
+                "user": user if 'user' in locals() else None,
             },
             status_code=500,
         )
@@ -178,6 +178,9 @@ async def stock_details(
 ):
     """Stock details page showing price, charts, news, and fundamentals for a specific stock."""
     try:
+        # Get current user for authentication
+        user = await get_optional_current_user(request, response)
+
         # Get API URL from app state or environment
         api_url_base = getattr(request.app.state, "settings", {}).get(
             "API_URL", os.getenv("API_URL", "http://quantumvestai-dev-api.dev.svc.cluster.local:8000")
@@ -191,8 +194,6 @@ async def stock_details(
 
         if stock_data is None:
             try:
-                # Get current user for authentication
-                user = await get_optional_current_user(request, response)
                 auth_token = user.get("token") if user else None
 
                 # Fetch stock data from API using centralized HTTP client
@@ -242,12 +243,12 @@ async def stock_details(
             "market/stock_details.html",
             {
                 "request": request,
-                "user": None,
+                "user": user,
                 "page_title": f"{stock_data.get('name')} ({stock_data.get('symbol')})",
                 "stock": stock_data,
                 "last_updated": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC"),
-                "is_authenticated": False,
-                "is_in_watchlist": False,
+                "is_authenticated": bool(user),
+                "is_in_watchlist": is_in_watchlist,
             },
         )
 
@@ -263,7 +264,7 @@ async def stock_details(
                 "request": request,
                 "message": f"An error occurred while loading data for {symbol}.",
                 "error_code": "STOCK_ERR",
-                "user": None,
+                "user": user if 'user' in locals() else None,
             },
             status_code=500,
         )

--- a/ai-stock-platform/ui/main.py
+++ b/ai-stock-platform/ui/main.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Optional
 
 from fastapi import Form
+import jwt
 
 # Ensure the repository root is first on ``sys.path`` so imports like
 # ``ui.routes`` resolve to the compatibility packages located at the
@@ -399,7 +400,26 @@ class AuthUtils:
                     "is_authenticated": True,
                 }
 
-        # Fallback to demo user if cookie format unexpected
+        # Fallback: decode access_token cookie if available
+        token_cookie = request.cookies.get("access_token")
+        if token_cookie:
+            token = token_cookie.replace("Bearer ", "")
+            secret = os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY", "your-secret-key")
+            try:
+                payload = jwt.decode(token, secret, algorithms=["HS256"])
+                username = payload.get("sub", "")
+                role = payload.get("role", "user")
+                full_name = payload.get("name", username)
+                return {
+                    "username": username,
+                    "full_name": full_name,
+                    "role": role,
+                    "is_authenticated": True,
+                }
+            except Exception:
+                return {"is_authenticated": True}
+
+        # No authentication information found
         return {"is_authenticated": False}
 
 # Enhanced route handlers


### PR DESCRIPTION
## Summary
- decode access token to recover user info when cookie missing
- store basic user details in `user_info` cookie after login
- include authenticated user context on market overview and stock pages

## Testing
- `./setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68918e33b928832abfb5881c5db72a04