### PR TITLE
feat: provide live market quotes for free users

### DIFF
--- a/ai-stock-platform/api/core/security/__init__.py
+++ b/ai-stock-platform/api/core/security/__init__.py
@@ -4,14 +4,15 @@ Created: 2025-08-04
 Author: gayatri
 """
 
-# Re-export everything from the original security.py module to maintain compatibility
-from core.security.tokens import create_access_token, validate_token
-from core.security.authentication import (
+# Re-export key security helpers using relative imports to avoid dependency on
+# the external compatibility wrapper.
+from .tokens import create_access_token, validate_token
+from .authentication import (
     get_current_user,
     get_current_active_user,
     check_admin_role,
     verify_password,
     get_password_hash,
     pwd_context,
-    oauth2_scheme
+    oauth2_scheme,
 )

--- a/ai-stock-platform/api/core/security/authentication.py
+++ b/ai-stock-platform/api/core/security/authentication.py
@@ -15,7 +15,7 @@ from core.config import settings
 from core.exceptions import AuthenticationError
 from db.models.user import User
 from db.session import get_db
-from core.security.tokens import validate_token
+from .tokens import validate_token
 
 # Password context for hashing
 pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")

--- a/ai-stock-platform/api/services/market_data_service.py
+++ b/ai-stock-platform/api/services/market_data_service.py
@@ -1,4 +1,53 @@
+"""Market data service that returns live quotes for free users."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, Optional
+
+from services.yahoo_rapidapi_service import YahooRapidAPIService
+
+
 class MarketDataService:
-    async def get_quote(self, symbol: str):
-        """Return a dummy market quote for the given symbol."""
-        return {"symbol": symbol, "bid": 100.0, "ask": 100.5, "last": 100.25}
+    """Provide access to live market quotes.
+
+    The previous implementation returned hard coded values which meant free tier
+    users never received real data.  This version fetches prices from Yahoo
+    Finance via ``YahooRapidAPIService``.  If the RapidAPI key is not configured
+    or the request fails the method returns ``None`` instead of raising an
+    exception so that callers can handle the failure gracefully.
+    """
+
+    async def get_quote(self, symbol: str) -> Optional[Dict[str, float]]:
+        """Return a live market quote for ``symbol``.
+
+        Args:
+            symbol: Stock ticker symbol.
+
+        Returns:
+            Dictionary containing price information or ``None`` if unavailable.
+        """
+
+        try:
+            # ``YahooRapidAPIService`` is synchronous; run it in a thread so the
+            # async interface remains non-blocking.
+            data = await asyncio.to_thread(
+                YahooRapidAPIService.get_live_price, symbol
+            )
+        except Exception:
+            return None
+
+        if not data:
+            return None
+
+        price = data.get("price")
+        return {
+            "symbol": symbol.upper(),
+            # Yahoo endpoint provides a single price; use it for bid/ask/last to
+            # maintain backwards compatibility with previous callers.
+            "bid": price,
+            "ask": price,
+            "last": price,
+            "change": data.get("change"),
+            "percent_change": data.get("percent_change"),
+        }

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -3,18 +3,18 @@ from pathlib import Path
 import sys
 
 root = Path(__file__).resolve().parent
-# The repository structure places the actual ``core`` package inside the
-# ``ai-stock-platform`` directory next to this compatibility wrapper.  The
-# previous implementation incorrectly assumed that directory was located
-# inside this package which resulted in an invalid search path like
-# ``core/ai-stock-platform/core``.  That path does not exist, preventing
-# imports such as ``core.config`` from resolving in the test environment.
+# The repository structure places the actual ``core`` packages inside the
+# ``ai-stock-platform`` directory next to this compatibility wrapper.  There
+# are two relevant packages:
+#   - ``ai-stock-platform/core``     (general utilities)
+#   - ``ai-stock-platform/api/core`` (API-specific utilities such as security)
 #
-# Compute the package location relative to the parent of this file so the
-# full path ``<repo>/ai-stock-platform/core`` is added to ``__path__``.
+# Both locations need to be on ``__path__`` so imports like ``core.config`` and
+# ``core.security`` resolve correctly during tests.
 _pkg = root.parent / "ai-stock-platform" / "core"
-__path__ = [str(_pkg)]
-if str(_pkg) not in sys.path:
-    sys.path.insert(0, str(_pkg))
-if str(_pkg.parent) not in sys.path:
-    sys.path.insert(0, str(_pkg.parent))
+_api_pkg = root.parent / "ai-stock-platform" / "api" / "core"
+__path__ = [str(_pkg), str(_api_pkg)]
+
+for p in [str(_pkg), str(_api_pkg), str(_pkg.parent), str(_api_pkg.parent)]:
+    if p not in sys.path:
+        sys.path.insert(0, p)

--- a/services/market_data_service.py
+++ b/services/market_data_service.py
@@ -1,0 +1,31 @@
+"""Compatibility wrapper for MarketDataService."""
+
+import importlib.util
+from pathlib import Path
+
+
+try:  # pragma: no cover - handle missing package gracefully
+    service_path = (
+        Path(__file__).resolve().parent.parent
+        / "ai-stock-platform"
+        / "api"
+        / "services"
+        / "market_data_service.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "market_data_service", service_path
+    )
+    if spec and spec.loader:
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        MarketDataService = module.MarketDataService
+    else:  # pragma: no cover - invalid spec
+        raise ImportError("Cannot load MarketDataService module")
+except Exception as exc:  # pragma: no cover - import failures
+    raise ImportError(
+        "MarketDataService implementation not found. Ensure the API package is on PYTHONPATH"
+    ) from exc
+
+
+__all__ = ["MarketDataService"]
+


### PR DESCRIPTION
## Summary
- add MarketDataService implementation that fetches live prices via Yahoo Finance for free users
- expose MarketDataService through a lightweight services wrapper
- fix core compatibility and security imports so tests can resolve modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: routes.market_data, models.orders, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68918ebb53d0832aae01cc7d3ab9d148