### PR TITLE
fix: refine auth store user type

### DIFF
--- a/ui/src/store/useAuthStore.ts
+++ b/ui/src/store/useAuthStore.ts
@@ -4,7 +4,7 @@ import { apiFetch } from '@/api/client'
 
 interface User {
   username: string
-  [key: string]: any
+  [key: string]: unknown
 }
 
 interface AuthState {


### PR DESCRIPTION
## Summary
- replace unsafe `any` index signature with `unknown` in auth store

## Testing
- `npm run lint -- --fix`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.market_data')*

------
https://chatgpt.com/codex/tasks/task_e_68921bb1cdd8832abc07e0692eace1ae