### PR TITLE
feat(ui): aggregate latest data from multiple APIs

### DIFF
--- a/ui/src/api/hooks/useLatestData.ts
+++ b/ui/src/api/hooks/useLatestData.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '../client'
+
+interface LatestData {
+  trendingStocks: any
+  trendingTopics: any
+  twitterTrending: any
+}
+
+export function useLatestData() {
+  return useQuery<LatestData>({
+    queryKey: ['latest-data'],
+    queryFn: async () => {
+      const [trendingStocks, trendingTopics, twitterTrending] = await Promise.all([
+        apiFetch('/v1/stocks/trending'),
+        apiFetch('/v1/sentiment/trending/topics'),
+        apiFetch('/social/twitter/trending'),
+      ])
+      return { trendingStocks, trendingTopics, twitterTrending }
+    },
+  })
+}

--- a/ui/src/components/Home.tsx
+++ b/ui/src/components/Home.tsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy } from 'react'
 import { useAppStore } from '@/store/useAppStore'
 import { usePing } from '@/api/hooks/usePing'
+import LatestData from '@/components/LatestData'
 
 const Button = lazy(() => import('@/components/ui/button'))
 
@@ -17,6 +18,7 @@ export default function Home() {
       <Suspense fallback={<div>Loading button...</div>}>
         <Button onClick={increment}>Increment</Button>
       </Suspense>
+      <LatestData />
     </div>
   )
 }

--- a/ui/src/components/LatestData.tsx
+++ b/ui/src/components/LatestData.tsx
@@ -1,0 +1,26 @@
+import { useLatestData } from '@/api/hooks/useLatestData'
+
+export default function LatestData() {
+  const { data, isLoading, error } = useLatestData()
+
+  if (isLoading) {
+    return <div>Loading latest data...</div>
+  }
+
+  if (error || !data) {
+    return <div>Failed to load latest data</div>
+  }
+
+  const trendingStocksCount = data.trendingStocks?.stocks?.length ?? 0
+  const trendingTopicsCount = data.trendingTopics?.topics?.length ?? 0
+  const twitterTrendingCount = data.twitterTrending?.trending_tickers?.length ?? 0
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-xl font-semibold">Latest Data</h2>
+      <div>Trending Stocks: {trendingStocksCount}</div>
+      <div>Trending Topics: {trendingTopicsCount}</div>
+      <div>Twitter Trending: {twitterTrendingCount}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add hook to gather trending stocks, sentiment topics, and twitter data concurrently
- display aggregated latest data in new `LatestData` component
- show latest API data on home screen

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 9 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68921bc676e8832a81a329fa5afb84e1