### PR TITLE
feat(ui): add subscription type to registration

### DIFF
--- a/ai-stock-platform/ui/routes/auth.py
+++ b/ai-stock-platform/ui/routes/auth.py
@@ -200,6 +200,7 @@ async def register_post(
     password: str = Form(...),
     confirm_password: str = Form(...),
     full_name: str = Form(...),
+    subscription_type: str = Form("free"),
     terms: bool = Form(False)
 ):
     """Handle registration form submission (production)"""
@@ -236,6 +237,7 @@ async def register_post(
                     "password": password,
                     "confirm_password": confirm_password,
                     "full_name": full_name,
+                    "subscription_type": subscription_type,
                     "terms_accepted": terms,
                 },
             )
@@ -262,6 +264,7 @@ async def register_post(
                 "username": username,
                 "email": email,
                 "full_name": full_name,
+                "subscription_type": subscription_type,
                 "terms": terms,
                 "page_title": "Register - QuantumVestAI",
             },
@@ -275,6 +278,7 @@ async def register_post(
                 "request": request,
                 "msg": "Registration failed due to a technical error. Please try again.",
                 "msg_type": "danger",
+                "subscription_type": subscription_type,
                 "terms": terms,
                 "page_title": "Register - QuantumVestAI"
             },

--- a/ai-stock-platform/ui/templates/auth/register.html
+++ b/ai-stock-platform/ui/templates/auth/register.html
@@ -81,7 +81,16 @@
                     </button>
                 </div>
             </div>
-            
+
+            <div class="form-group">
+                <label for="subscription_type">Subscription Type</label>
+                <select id="subscription_type" name="subscription_type" class="form-control" required>
+                    <option value="free" {% if subscription_type|default('free') == 'free' %}selected{% endif %}>Free</option>
+                    <option value="basic" {% if subscription_type == 'basic' %}selected{% endif %}>Basic</option>
+                    <option value="premium" {% if subscription_type == 'premium' %}selected{% endif %}>Premium</option>
+                </select>
+            </div>
+
             <div class="form-group form-check">
                 <input type="checkbox" class="form-check-input" id="terms" name="terms" required>
                 <label class="form-check-label" for="terms">

--- a/ai-stock-platform/ui/tests/test_routes/test_auth_routes.py
+++ b/ai-stock-platform/ui/tests/test_routes/test_auth_routes.py
@@ -100,6 +100,7 @@ def test_register_page_get(client):
     assert "Username" in response.text
     assert "Email" in response.text
     assert "Password" in response.text
+    assert "Subscription Type" in response.text
 
 def test_register_post_success(client, monkeypatch):
     monkeypatch.setenv("API_BASE_URL", "http://testserver/api")
@@ -114,6 +115,7 @@ def test_register_post_success(client, monkeypatch):
                 "password": "Password123!",
                 "confirm_password": "Password123!",
                 "full_name": "Test User",
+                "subscription_type": "free",
                 "terms": "on"
             },
             follow_redirects=False
@@ -129,6 +131,7 @@ def test_register_post_success(client, monkeypatch):
                 "password": "Password123!",
                 "confirm_password": "Password123!",
                 "full_name": "Test User",
+                "subscription_type": "free",
                 "terms_accepted": True,
             },
         )
@@ -146,6 +149,7 @@ def test_register_post_username_taken(client, monkeypatch):
                 "password": "Password123!",
                 "confirm_password": "Password123!",
                 "full_name": "Test User",
+                "subscription_type": "free",
                 "terms": "on"
             },
             follow_redirects=False
@@ -161,6 +165,7 @@ def test_register_post_username_taken(client, monkeypatch):
                 "password": "Password123!",
                 "confirm_password": "Password123!",
                 "full_name": "Test User",
+                "subscription_type": "free",
                 "terms_accepted": True,
             },
         )
@@ -175,6 +180,7 @@ def test_register_post_password_mismatch(client, monkeypatch):
             "password": "Password123!",
             "confirm_password": "DifferentPassword123!",
             "full_name": "Test User",
+            "subscription_type": "free",
             "terms": "on"
         },
         follow_redirects=False


### PR DESCRIPTION
## Summary
- add subscription plan dropdown on registration page
- handle `subscription_type` in auth registration route
- extend auth route tests for subscription plans

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.market_data')*


------
https://chatgpt.com/codex/tasks/task_e_68921f932c64832abf3c6080fc613562