### PR TITLE
fix: improve UI layout for navigation and dashboard

### DIFF
--- a/ai-stock-platform/ui/src/components/Sidebar.tsx
+++ b/ai-stock-platform/ui/src/components/Sidebar.tsx
@@ -86,7 +86,9 @@ const Sidebar: React.FC<SidebarProps> = ({ open, onClose }) => {
         flexShrink: 0,
         '& .MuiDrawer-paper': {
           width: collapsed ? collapsedWidth : drawerWidth,
-          boxSizing: 'border-box'
+          boxSizing: 'border-box',
+          top: isMobile ? 0 : 64,
+          height: isMobile ? '100%' : 'calc(100% - 64px)'
         }
       }}
     >

--- a/ui/src/components/LatestData.tsx
+++ b/ui/src/components/LatestData.tsx
@@ -16,11 +16,19 @@ export default function LatestData() {
   const twitterTrendingCount = data.twitterTrending?.trending_tickers?.length ?? 0
 
   return (
-    <div className="space-y-2">
-      <h2 className="text-xl font-semibold">Latest Data</h2>
-      <div>Trending Stocks: {trendingStocksCount}</div>
-      <div>Trending Topics: {trendingTopicsCount}</div>
-      <div>Twitter Trending: {twitterTrendingCount}</div>
+    <div className="p-4 bg-white rounded shadow-sm">
+      <h2 className="text-xl font-semibold mb-4">Latest Data</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
+        <div className="p-2 border rounded">
+          Trending Stocks: {trendingStocksCount}
+        </div>
+        <div className="p-2 border rounded">
+          Trending Topics: {trendingTopicsCount}
+        </div>
+        <div className="p-2 border rounded">
+          Twitter Trending: {twitterTrendingCount}
+        </div>
+      </div>
     </div>
   )
 }

--- a/ui/src/components/Navbar.tsx
+++ b/ui/src/components/Navbar.tsx
@@ -6,7 +6,7 @@ export default function Navbar() {
   const logout = useAuthStore((s) => s.logout)
 
   return (
-    <nav className="flex items-center justify-between p-4 border-b mb-4 bg-gray-50">
+    <nav className="flex items-center justify-between p-4 border-b bg-gray-50 shadow-sm sticky top-0 z-50 w-full">
       {user ? (
         <div className="flex items-center gap-4">
           <span>Welcome, {user.username}</span>


### PR DESCRIPTION
## Summary
- make main navbar sticky with shadow and full width
- display latest data metrics in responsive grid cards
- offset sidebar drawer below header to prevent overlap

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 9 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6892257d4750832ab972e8c24fca1fbf