### PR TITLE
feat(ui): add reusable Tailwind card component

### DIFF
--- a/ui/src/components/LatestData.tsx
+++ b/ui/src/components/LatestData.tsx
@@ -1,4 +1,5 @@
 import { useLatestData } from '@/api/hooks/useLatestData'
+import { Card } from '@/components/ui/card'
 
 export default function LatestData() {
   const { data, isLoading, error } = useLatestData()
@@ -16,8 +17,7 @@ export default function LatestData() {
   const twitterTrendingCount = data.twitterTrending?.trending_tickers?.length ?? 0
 
   return (
-    <div className="p-4 bg-white dark:bg-gray-800 rounded shadow-sm">
-      <h2 className="text-xl font-semibold mb-4">Latest Data</h2>
+    <Card title="Latest Data" className="space-y-4">
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
         <div className="p-2 border rounded">
           Trending Stocks: {trendingStocksCount}
@@ -29,6 +29,6 @@ export default function LatestData() {
           Twitter Trending: {twitterTrendingCount}
         </div>
       </div>
-    </div>
+    </Card>
   )
 }

--- a/ui/src/components/TradePanel.tsx
+++ b/ui/src/components/TradePanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Card } from '@/components/ui/card'
 
 interface Trade {
   symbol: string
@@ -26,8 +27,7 @@ export default function TradePanel() {
   }
 
   return (
-    <div className="p-4 bg-white dark:bg-gray-800 rounded shadow-sm space-y-2">
-      <h2 className="text-xl font-semibold">Trade</h2>
+    <Card title="Trade" className="space-y-2">
       <div className="flex space-x-2">
         <Input
           value={symbol}
@@ -52,7 +52,7 @@ export default function TradePanel() {
           </li>
         ))}
       </ul>
-    </div>
+    </Card>
   )
 }
 

--- a/ui/src/components/Watchlist.tsx
+++ b/ui/src/components/Watchlist.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Modal } from '@/components/ui/modal'
+import { Card } from '@/components/ui/card'
 
 interface WatchItem {
   symbol: string
@@ -45,8 +46,7 @@ export default function Watchlist() {
   }
 
   return (
-    <div className="p-4 bg-white dark:bg-gray-800 rounded shadow-sm space-y-2">
-      <h2 className="text-xl font-semibold">Watchlist</h2>
+    <Card title="Watchlist" className="space-y-2">
       <div className="flex space-x-2">
         <Input
           value={symbol}
@@ -100,7 +100,7 @@ export default function Watchlist() {
           </Button>
         </div>
       </Modal>
-    </div>
+    </Card>
   )
 }
 

--- a/ui/src/components/ui/card.tsx
+++ b/ui/src/components/ui/card.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  title?: string
+}
+
+export function Card({ title, className, children, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'p-4 bg-white dark:bg-gray-800 rounded shadow-sm',
+        className
+      )}
+      {...props}
+    >
+      {title && <h2 className="text-xl font-semibold">{title}</h2>}
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable `Card` component using TailwindCSS
- refactor data panels (LatestData, Watchlist, TradePanel) to use new component for consistent styling

## Testing
- `pytest -q` *(fails: connection to server at "quantumvestai-dev.cwbsqsiywwaa.us-east-1.rds.amazonaws.com" (10.0.37.138), port 5432 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892986d58a4832abb3eafe1778cd283