### PR TITLE
feat: integrate redux provider for global state

### DIFF
--- a/ai-stock-platform/ui/src/main.tsx
+++ b/ai-stock-platform/ui/src/main.tsx
@@ -1,12 +1,16 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import 'bootstrap/dist/css/bootstrap.min.css'
-import 'react-toastify/dist/ReactToastify.css'
-import './styles/global.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import App from './App.tsx';
+import { store } from './store';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'react-toastify/dist/ReactToastify.css';
+import './styles/global.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
-)
+);


### PR DESCRIPTION
## Summary
- add Redux store provider to root React render for global state

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.market_data')*

------
https://chatgpt.com/codex/tasks/task_e_68929896d678832a99d831ec4b7c6370