### PR TITLE
Improve database startup and websocket resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,3 +234,25 @@ If API endpoints aren't responding:
 3. Run the diagnostic script: `python test_trending_stocks_fixed.py`
 4. Check logs for error messages: `tail -n 100 logs/api.log`
 
+## Kubernetes Deployment Notes
+
+When deploying with Helm, ensure that database migrations and seeding run in the
+correct order. Annotate the jobs with pre/post hooks so migrations finish before
+the seeding job starts:
+
+```yaml
+# db-init job
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+
+# db-seed job
+metadata:
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+```
+
+These hooks guarantee the schema is created before `seed_db.py` attempts to
+insert data.
+

--- a/ai-stock-platform/api/config/alembic.ini
+++ b/ai-stock-platform/api/config/alembic.ini
@@ -35,7 +35,10 @@ script_location = alembic
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = postgresql://%(DB_USER)s:%(DB_PASSWORD)s@%(DB_HOST)s:%(DB_PORT)s/%(DB_NAME)s
+# Database URL is configured at runtime via environment variables.  Leaving
+# this value blank avoids stale hard coded credentials and allows ``env.py`` to
+# supply the appropriate connection string dynamically.
+sqlalchemy.url =
 
 [post_write_hooks]
 # post_write_hooks defines scripts or Python functions that are run

--- a/ai-stock-platform/api/scripts/wait-for-db.sh
+++ b/ai-stock-platform/api/scripts/wait-for-db.sh
@@ -26,17 +26,31 @@ DELAY=10
 
 log "Waiting for RDS PostgreSQL to be available at ${DB_HOST}:${DB_PORT}..."
 
+# Helper to verify DNS resolution for the DB host. Kubernetes service names
+# sometimes take a moment to propagate which previously resulted in immediate
+# failures from ``pg_isready``.  This additional check makes the script more
+# tolerant of internal DNS delays.
+resolve_host() {
+  getent hosts "$DB_HOST" >/dev/null 2>&1
+}
+
 # Loop to check database availability
 for i in $(seq 1 $MAX_ATTEMPTS); do
   log "Attempt $i of $MAX_ATTEMPTS"
-  
+
+  if ! resolve_host; then
+    log "Host $DB_HOST not yet resolvable - sleeping for ${DELAY}s"
+    sleep $DELAY
+    continue
+  fi
+
   # Use PGPASSWORD environment variable for authentication
   export PGPASSWORD="$DB_PASSWORD"
-  
+
   # Try connecting to the database using TCP/IP (-h flag)
   if pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -t 5; then
     log "Database is available!"
-    
+
     # Try a simple query to verify credentials and database access
     if psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -c "SELECT 1" >/dev/null 2>&1; then
       log "Database connection successful!"
@@ -45,7 +59,7 @@ for i in $(seq 1 $MAX_ATTEMPTS); do
       log "Connected to database server but could not execute query. Checking credentials..."
     fi
   fi
-  
+
   log "Database is unavailable - sleeping for ${DELAY}s"
   sleep $DELAY
 done

--- a/market-data-fix.js
+++ b/market-data-fix.js
@@ -11,11 +11,39 @@
   // Override WebSocket creation for market data connections
   const originalWebSocket = window.WebSocket;
   
+  const MAX_RETRIES = 5;
+  const RETRY_DELAY = 3000; // ms
+
+  function createWebSocket(url, protocols) {
+    let attempts = 0;
+    let ws;
+
+    const connect = () => {
+      attempts += 1;
+      ws = new originalWebSocket(url, protocols);
+
+      ws.addEventListener('close', () => {
+        if (attempts <= MAX_RETRIES) {
+          console.warn(`WebSocket closed. Reconnecting in ${RETRY_DELAY}ms (attempt ${attempts}/${MAX_RETRIES})`);
+          setTimeout(connect, RETRY_DELAY);
+        }
+      });
+
+      ws.addEventListener('error', (err) => {
+        console.error('WebSocket error:', err);
+        ws.close();
+      });
+    };
+
+    connect();
+    return ws;
+  }
+
   window.WebSocket = function(url, protocols) {
     // Check if this is a market-data WebSocket connection
     if (url && typeof url === 'string' && url.includes('/ws/market-data')) {
       console.log('Intercepting WebSocket connection to /ws/market-data');
-      
+
       // Get token from the original URL
       let token = '';
       try {
@@ -24,15 +52,15 @@
       } catch (e) {
         console.error('Error parsing WebSocket URL:', e);
       }
-      
+
       // Modify the URL to use the direct endpoint instead of the /ws/ prefixed one
       // The direct endpoint is more permissive with role checks
       url = url.replace('/ws/market-data', '/market-data');
       console.log('Redirecting WebSocket to more permissive endpoint:', url.split('?')[0]);
     }
-    
-    // Create the WebSocket with the possibly modified URL
-    return new originalWebSocket(url, protocols);
+
+    // Create the WebSocket with the possibly modified URL and auto-reconnect
+    return createWebSocket(url, protocols);
   };
   
   // Preserve the WebSocket prototype and properties

--- a/startup-wrapper.sh
+++ b/startup-wrapper.sh
@@ -27,6 +27,19 @@ if [ "${INSTALL_MISSING_DEPS:-true}" = "true" ]; then
     echo "⚠ install-dependencies.sh not found, installing critical dependencies directly"
     pip install --no-cache-dir fastapi uvicorn aiohttp requests jinja2
   fi
+
+  # Install project specific dependencies if manifests are present. This ensures
+  # containers started in ephemeral environments (like CI or ephemeral pods)
+  # have all requirements prior to launching the application.
+  if [ -f requirements.txt ]; then
+    echo "Installing Python requirements..."
+    pip install --no-cache-dir -r requirements.txt
+  fi
+
+  if command -v npm >/dev/null 2>&1 && [ -f package.json ]; then
+    echo "Installing Node.js packages..."
+    npm ci --omit=dev || npm install --production
+  fi
 fi
 
 # Start the application using the original start script


### PR DESCRIPTION
## Summary
- ensure DB wait script checks DNS resolution before readiness checks
- let alembic URL be supplied entirely by environment
- install Python/Node dependencies in startup wrapper
- add auto-reconnect logic for market-data WebSocket fix
- document Helm hooks for db-init and db-seed jobs

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: 9 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6892dc7991e0832ab75dcea44c1d8038