### PR TITLE
chore: add warnings for missing JWT config and invalid tokens

### DIFF
--- a/ai-stock-platform/api/core/security/tokens.py
+++ b/ai-stock-platform/api/core/security/tokens.py
@@ -1,15 +1,28 @@
-"""
-Token handling functionality.
-"""
+"""Token handling functionality with improved debugging support."""
 from datetime import datetime, timedelta
 from typing import Optional
 
+import logging
 from jose import jwt, JWTError
 from pydantic import BaseModel
 
 from core.config import get_settings
 
+# Setup module-level logger
+logger = logging.getLogger(__name__)
+
 config = get_settings()
+
+# Warn when critical security settings are missing or using defaults
+secret_value = (
+    config.JWT_SECRET.get_secret_value()
+    if getattr(config, "JWT_SECRET", None)
+    else getattr(config, "SECRET_KEY", "")
+)
+if not secret_value or secret_value == "your-secret-key":
+    logger.warning(
+        "JWT secret key is not configured or using insecure default. Token validation may be compromised."
+    )
 
 class TokenHandler:
     # Use JWT_SECRET value if provided, falling back to SECRET_KEY
@@ -46,8 +59,13 @@ def decode_token(token: str) -> Optional[BaseModel]:
 
 def validate_token(token: str) -> bool:
     """Return ``True`` if the provided JWT is valid, ``False`` otherwise."""
+    if not token:
+        logger.warning("Token validation attempted with missing token")
+        return False
+
     try:
         TokenHandler.decode_token(token)
         return True
-    except JWTError:
+    except JWTError as exc:
+        logger.warning("Token validation failed: %s", exc)
         return False


### PR DESCRIPTION
## Summary
- warn when JWT secret uses insecure default
- log failed or missing token validations

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892e4dc5c40832abb42de1274a5e265