### PR TITLE
Ensure settings endpoint requires auth

### DIFF
--- a/ai-stock-platform/ui/main.py
+++ b/ai-stock-platform/ui/main.py
@@ -92,6 +92,12 @@ if SENTRY_DSN:
 
 from fastapi.middleware.gzip import GZipMiddleware
 
+# Authentication middleware ensures protected routes require valid tokens
+try:  # pragma: no cover - prefer direct import but allow fallback
+    from ui.middleware.auth_middleware import AuthMiddleware
+except Exception:  # pragma: no cover - fallback path for compatibility
+    from middleware.auth_middleware import AuthMiddleware
+
 # Define BASE_DIR first
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -169,6 +175,9 @@ app.add_middleware(
     expose_headers=["X-Request-ID", "X-Process-Time"],
     max_age=86400,
 )
+
+# Apply authentication middleware to protect routes like /settings
+app.add_middleware(AuthMiddleware)
 
 # Setup templates and store in app.state
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))

--- a/ai-stock-platform/ui/routes/settings.py
+++ b/ai-stock-platform/ui/routes/settings.py
@@ -33,20 +33,22 @@ DEMO_USER_SETTINGS = {}
 async def settings_page(request: Request):
     """Main settings page"""
     try:
-        # Check authentication
-        auth_cookie = request.cookies.get("access_token")
-        if not auth_cookie:
-            return RedirectResponse(url="/auth/login?msg=Please log in to access settings", status_code=302)
+        # AuthMiddleware attaches validated user info to request.state
+        user = getattr(request.state, "user", None)
+        if not user:
+            return RedirectResponse(
+                url="/auth/login?msg=Please log in to access settings", status_code=302
+            )
 
-        logger.info("Loading settings page")
+        logger.info("Loading settings page for %s", user.get("username"))
 
         return get_templates(request).TemplateResponse(
             "settings.html",
             {
                 "request": request,
                 "settings": DEMO_USER_SETTINGS,
-                "page_title": "Settings - QuantumVestAI"
-            }
+                "page_title": "Settings - QuantumVestAI",
+            },
         )
         
     except Exception as e:
@@ -66,19 +68,17 @@ async def update_settings(request: Request):
     """Update user settings."""
     try:
         logger.info("Updating settings")
-        
-        # Check authentication
-        auth_cookie = request.cookies.get("access_token")
-        if not auth_cookie:
-            return JSONResponse({
-                "status": "error",
-                "message": "Authentication required"
-            }, status_code=401)
-        
-        return JSONResponse({
-            "status": "success",
-            "message": "Settings updated successfully"
-        })
+
+        user = getattr(request.state, "user", None)
+        if not user:
+            return JSONResponse(
+                {"status": "error", "message": "Authentication required"},
+                status_code=401,
+            )
+
+        return JSONResponse(
+            {"status": "success", "message": "Settings updated successfully"}
+        )
         
     except Exception as e:
         logger.error(f"Error updating settings: {str(e)}")
@@ -91,24 +91,28 @@ async def update_settings(request: Request):
 async def get_current_settings(request: Request):
     """Get current user settings via API"""
     try:
-        # Check authentication
-        auth_cookie = request.cookies.get("access_token")
-        if not auth_cookie:
-            return JSONResponse({
-                "status": "error",
-                "message": "Authentication required"
-            }, status_code=401)
-        
-        return JSONResponse({
-            "status": "success",
-            "settings": DEMO_USER_SETTINGS,
-            "timestamp": datetime.utcnow().isoformat()
-        })
-        
+        user = getattr(request.state, "user", None)
+        if not user:
+            return JSONResponse(
+                {"status": "error", "message": "Authentication required"},
+                status_code=401,
+            )
+
+        return JSONResponse(
+            {
+                "status": "success",
+                "settings": DEMO_USER_SETTINGS,
+                "timestamp": datetime.utcnow().isoformat(),
+            }
+        )
+
     except Exception as e:
         logger.error(f"Error getting current settings: {str(e)}")
-        return JSONResponse({
-            "status": "error",
-            "message": str(e),
-            "timestamp": datetime.utcnow().isoformat()
-        }, status_code=500)
+        return JSONResponse(
+            {
+                "status": "error",
+                "message": str(e),
+                "timestamp": datetime.utcnow().isoformat(),
+            },
+            status_code=500,
+        )

--- a/ai-stock-platform/ui/tests/test_routes/test_settings_routes.py
+++ b/ai-stock-platform/ui/tests/test_routes/test_settings_routes.py
@@ -1,0 +1,42 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi import status, HTTPException
+
+
+def test_settings_requires_auth(client):
+    """Unauthorized requests to /settings should be rejected."""
+    response = client.get("/settings/", headers={"Accept": "application/json"})
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_settings_with_valid_token(client, test_user):
+    """Access to /settings succeeds when token is valid."""
+    with patch(
+        "ui.middleware.auth_middleware.verify_token",
+        new=AsyncMock(return_value=test_user),
+    ):
+        response = client.get(
+            "/settings/",
+            headers={
+                "Authorization": "Bearer good",
+                "Accept": "text/html",
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert "Settings - QuantumVestAI" in response.text
+
+
+def test_settings_with_invalid_token(client):
+    """Invalid tokens should be rejected."""
+    with patch(
+        "ui.middleware.auth_middleware.verify_token",
+        new=AsyncMock(side_effect=HTTPException(status_code=401, detail="bad")),
+    ):
+        response = client.get(
+            "/settings/",
+            headers={
+                "Authorization": "Bearer bad",
+                "Accept": "application/json",
+            },
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
## Summary
- Protect all UI routes, including `/settings`, by adding `AuthMiddleware` to the FastAPI app
- Validate user tokens via `AuthMiddleware` in settings routes instead of checking raw cookies
- Add tests verifying `/settings` access requires a valid token

## Testing
- `pytest -q` *(fails: Interrupted: 9 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6892e4e8683c832a930b313933204c6e