### PR TITLE
feat(ui): handle empty settings response

### DIFF
--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -1,5 +1,50 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { fetchJSON } from '@/services/api'
+
+interface SettingsResponse {
+  [key: string]: unknown
+}
 
 export default function Settings() {
-  return <div className="p-4">Settings Page</div>
+  const [settings, setSettings] = useState<SettingsResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const data = await fetchJSON<SettingsResponse>('/api/settings')
+        setSettings(data)
+      } catch (err) {
+        console.error('Failed to load settings', err)
+        setError('Failed to load settings')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadSettings()
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-4">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-500"></div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return <div className="p-4 text-red-500">{error}</div>
+  }
+
+  if (!settings || Object.keys(settings).length === 0) {
+    return <div className="p-4">No settings found</div>
+  }
+
+  return (
+    <div className="p-4">
+      <pre className="text-sm">{JSON.stringify(settings, null, 2)}</pre>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- fetch settings data and track loading state in Settings page
- show loading spinner and display 'No settings found' when backend returns empty

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892e4c3a68c832aa2f9a3cca69790c5