### PR TITLE
feat: improve settings endpoint handling

### DIFF
--- a/ai-stock-platform/api/app.py
+++ b/ai-stock-platform/api/app.py
@@ -17,7 +17,16 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from jinja2 import Environment
-from routers import alerts, analytics, auth, social, stocks, users, watchlists
+from routers import (
+    alerts,
+    analytics,
+    auth,
+    settings,
+    social,
+    stocks,
+    users,
+    watchlists,
+)
 from sqlalchemy import text
 
 # Create API application
@@ -53,6 +62,7 @@ app.include_router(watchlists.router, prefix="/watchlists", tags=["Watchlists"])
 app.include_router(analytics.router, prefix="/analytics", tags=["Analytics"])
 app.include_router(analytics.public_router, tags=["Analytics Public"])
 app.include_router(social.router, prefix="/api/v1", tags=["Social Media"])
+app.include_router(settings.router, prefix="/api", tags=["Settings"])
 
 @app.get("/")
 async def api_root():

--- a/ai-stock-platform/api/main.py
+++ b/ai-stock-platform/api/main.py
@@ -35,6 +35,7 @@ from routers.websocket import router as websocket_router
 from routers.social import router as social_router
 from routers.docs import router as docs_router
 from routers.analytics import public_router as analytics_public_router
+from routers.settings import router as settings_router
 from routes.market_data import router as market_data_router
 import sentry_sdk
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
@@ -126,6 +127,7 @@ app.include_router(social_router)
 app.include_router(docs_router)
 app.include_router(analytics_public_router, prefix="/api/v1")
 app.include_router(market_data_router, prefix="/market-data")
+app.include_router(settings_router, prefix="/api")
 
 # Request logging middleware
 @app.middleware("http")

--- a/ai-stock-platform/api/routers/settings.py
+++ b/ai-stock-platform/api/routers/settings.py
@@ -1,0 +1,57 @@
+"""
+Settings Router
+Created: 2025-08-10
+Author: OpenAI Assistant
+"""
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from core.security import get_current_user
+from db.session import get_db
+from db.models.user import User
+from db.models.user_setting import UserSetting
+
+router = APIRouter()
+
+# Default settings inserted for new users
+DEFAULT_SETTINGS: List[Dict[str, str]] = [
+    {"category": "general", "key": "theme", "value": "light"},
+    {"category": "notifications", "key": "email", "value": "true"},
+]
+
+@router.get("/settings")
+async def get_user_settings(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """Return settings for the authenticated user.
+
+    If the user has no settings stored, insert default settings and
+    return them instead of raising an error.
+    """
+    try:
+        user_settings = (
+            db.query(UserSetting)
+            .filter(UserSetting.user_id == current_user.id)
+            .all()
+        )
+
+        if not user_settings:
+            defaults = [
+                UserSetting(user_id=current_user.id, **s) for s in DEFAULT_SETTINGS
+            ]
+            db.add_all(defaults)
+            db.commit()
+            for setting in defaults:
+                db.refresh(setting)
+            user_settings = defaults
+
+        return {"settings": [s.to_dict() for s in user_settings]}
+    except Exception as exc:  # pragma: no cover - unexpected DB errors
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to load settings: {exc}",
+        )


### PR DESCRIPTION
## Summary
- add settings router that validates JWT and seeds defaults if none exist
- register settings router with API applications

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.market_data')*

------
https://chatgpt.com/codex/tasks/task_e_6892e4b694d4832a8b8269f71b8faad9