### PR TITLE
feat: seed default user preferences

### DIFF
--- a/ci-cd/k8s/dev/ci-cd_k8s_dev_db-seed-job_Version7.yaml
+++ b/ci-cd/k8s/dev/ci-cd_k8s_dev_db-seed-job_Version7.yaml
@@ -76,6 +76,18 @@ data:
                 updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
             );
         """
+        'user_preferences': """
+            CREATE TABLE IF NOT EXISTS user_preferences (
+                id SERIAL PRIMARY KEY,
+                user_id INTEGER REFERENCES users(id),
+                theme VARCHAR(20) DEFAULT 'light',
+                default_forecast_days INTEGER DEFAULT 7,
+                default_model VARCHAR(50) DEFAULT 'ensemble',
+                created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(user_id)
+            );
+        """,
     }
     
     INDEXES = [
@@ -84,7 +96,8 @@ data:
         "CREATE INDEX IF NOT EXISTS idx_portfolios_user_id ON portfolios(user_id);",
         "CREATE INDEX IF NOT EXISTS idx_investments_portfolio_id ON investments(portfolio_id);",
         "CREATE INDEX IF NOT EXISTS idx_investments_symbol ON investments(symbol);",
-        "CREATE INDEX IF NOT EXISTS idx_investments_purchase_date ON investments(purchase_date);"
+        "CREATE INDEX IF NOT EXISTS idx_investments_purchase_date ON investments(purchase_date);",
+        "CREATE INDEX IF NOT EXISTS idx_user_preferences_user_id ON user_preferences(user_id);"
     ]
     
     SAMPLE_DATA = [
@@ -108,6 +121,20 @@ data:
         JOIN users u ON p.user_id = u.id
         WHERE u.username = 'testuser1'
         ON CONFLICT DO NOTHING;
+        """
+        """
+        INSERT INTO user_preferences (user_id, theme, default_forecast_days, default_model)
+        SELECT id, 'light', 7, 'ensemble'
+        FROM users
+        WHERE username = 'testuser1'
+        ON CONFLICT (user_id) DO NOTHING;
+        """
+        """
+        INSERT INTO user_preferences (user_id, theme, default_forecast_days, default_model)
+        SELECT id, 'dark', 14, 'ensemble'
+        FROM users
+        WHERE username = 'testuser2'
+        ON CONFLICT (user_id) DO NOTHING;
         """
     ]
     


### PR DESCRIPTION
## Summary
- add user_preferences table and default preferences for test users in seeding script
- index preferences table and insert default rows for test accounts

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'routes.market_data')*

------
https://chatgpt.com/codex/tasks/task_e_6892e4d1df68832a86259aec6208e5e6