### PR TITLE
feat: add spa wildcard ingress

### DIFF
--- a/ci-cd/k8s/dev/05-ingress.yaml
+++ b/ci-cd/k8s/dev/05-ingress.yaml
@@ -24,8 +24,8 @@ spec:
     - host: dev.quantumvestai.com
       http:
         paths:
-          - path: /api/v1
-            pathType: Prefix
+          - path: /api/*
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: quantumvestai-dev-api
@@ -59,8 +59,8 @@ spec:
                 name: quantumvestai-dev-api
                 port:
                   number: 8000
-          - path: /
-            pathType: Prefix
+          - path: /*
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: ui-service


### PR DESCRIPTION
## Summary
- route any /api/* request to backend service
- use wildcard path to send SPA routes to ui-service

## Testing
- `./setup_env.sh` *(fails: installation interrupted)*
- `pytest -q` *(fails: connection to RDS unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892e73c4d1c832a931e04051e1dcc46