### PR TITLE
Add settings health endpoint and failed request logging

### DIFF
--- a/ai-stock-platform/api/main.py
+++ b/ai-stock-platform/api/main.py
@@ -163,11 +163,17 @@ async def log_requests(request: Request, call_next):
         response.headers["Referrer-Policy"] = "no-referrer-when-downgrade"
         response.headers["Cache-Control"] = "public, max-age=60"
         response.headers["Content-Encoding"] = "gzip"
-        
+
         REQUEST_COUNT.labels(method=method, endpoint=path, http_status=response.status_code).inc()
-        
+
+        # Explicitly log failed requests for easier debugging
+        if response.status_code >= 400:
+            logger.error(
+                f"[{request_id}] Failed request: {method} {path} - Status: {response.status_code}"
+            )
+
         return response
-        
+
     except Exception as e:
         duration = (datetime.now() - start_time).total_seconds()
         REQUEST_COUNT.labels(method=method, endpoint=path, http_status=500).inc()
@@ -201,6 +207,12 @@ async def root(request: Request):
         message="Welcome to QuantumVestAI API",
         request_id=getattr(request.state, 'request_id', None)
     )
+
+
+@app.get("/api/settings")
+async def settings_health():
+    """Simple health endpoint for routing tests"""
+    return {"status": "ok"}
 
 
 @app.get("/health")

--- a/tests/test_settings_endpoint.py
+++ b/tests/test_settings_endpoint.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+ROOT = os.path.join(os.path.dirname(__file__), "..", "ai-stock-platform")
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "api"))
+
+from api.main import app
+
+
+def test_settings_endpoint():
+    client = TestClient(app)
+    resp = client.get("/api/settings")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+


### PR DESCRIPTION
## Summary
- add `/api/settings` health endpoint returning a basic ok response
- log failed HTTP requests for easier debugging
- cover the new endpoint with a test

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.market_data')*

------
https://chatgpt.com/codex/tasks/task_e_6892e74e2700832a98c3dd6c18822fb2