### PR TITLE
Redirect users to settings after login

### DIFF
--- a/ai-stock-platform/main.py
+++ b/ai-stock-platform/main.py
@@ -94,8 +94,8 @@ class AuthRedirectMiddleware(BaseHTTPMiddleware):
             qvai_token = request.cookies.get("qvai_token")
             
             if access_token or qvai_token:
-                logger.info(f"AuthRedirectMiddleware: Authenticated user accessing {path}, redirecting to dashboard")
-                return RedirectResponse(url="/dashboard", status_code=status.HTTP_303_SEE_OTHER)
+                logger.info(f"AuthRedirectMiddleware: Authenticated user accessing {path}, redirecting to settings")
+                return RedirectResponse(url="/settings", status_code=status.HTTP_303_SEE_OTHER)
         
         # For all other paths, continue normally
         return await call_next(request)
@@ -405,8 +405,8 @@ async def direct_login_post(
             token_data = response.json()
             logger.info(f"Login successful for {username}")
             
-            # Redirect to dashboard
-            redirect_response = RedirectResponse(url="/dashboard", status_code=status.HTTP_302_FOUND)
+            # Redirect to settings
+            redirect_response = RedirectResponse(url="/settings", status_code=status.HTTP_302_FOUND)
             
             # Set the token in a secure cookie
             max_age = 30 * 24 * 60 * 60 if remember else None  # 30 days in seconds or session cookie
@@ -432,8 +432,8 @@ async def direct_login_post(
             expires = datetime.utcnow() + timedelta(hours=24)
             token = f"emergency_{username}_{expires.timestamp()}"
             
-            # Redirect to dashboard
-            response = RedirectResponse(url="/dashboard", status_code=status.HTTP_302_FOUND)
+            # Redirect to settings
+            response = RedirectResponse(url="/settings", status_code=status.HTTP_302_FOUND)
             response.set_cookie(
                 key="access_token",
                 value=f"Bearer {token}",
@@ -453,8 +453,8 @@ async def direct_login_post(
         expires = datetime.utcnow() + timedelta(hours=24)
         token = f"emergency_{username}_{expires.timestamp()}"
         
-        # Redirect to dashboard
-        response = RedirectResponse(url="/dashboard", status_code=status.HTTP_302_FOUND)
+        # Redirect to settings
+        response = RedirectResponse(url="/settings", status_code=status.HTTP_302_FOUND)
         response.set_cookie(
             key="access_token",
             value=f"Bearer {token}",
@@ -498,7 +498,7 @@ async def direct_emergency_login(request: Request):
                 "success": True,
                 "access_token": token,
                 "token_type": "bearer",
-                "redirect_url": "/dashboard"
+                "redirect_url": "/settings"
             },
             headers={
                 "Access-Control-Allow-Origin": "*",
@@ -546,13 +546,13 @@ async def index(request: Request):
         if access_token:
             logger.info("Found access_token cookie, redirecting to dashboard")
         if qvai_token:
-            logger.info("Found qvai_token cookie, redirecting to dashboard")
-            
-        # If any token exists, redirect to dashboard
+            logger.info("Found qvai_token cookie, redirecting to settings")
+
+        # If any token exists, redirect to settings
         if access_token or qvai_token:
-            logger.info("User is authenticated, redirecting to dashboard")
+            logger.info("User is authenticated, redirecting to settings")
             # Set a special header to indicate this is an auth redirect (client can use this to show preloader)
-            response = RedirectResponse(url="/dashboard", status_code=status.HTTP_303_SEE_OTHER)
+            response = RedirectResponse(url="/settings", status_code=status.HTTP_303_SEE_OTHER)
             response.headers["X-Auth-Redirect"] = "true"
             return response
         

--- a/ai-stock-platform/ui/controllers/auth_controller.py
+++ b/ai-stock-platform/ui/controllers/auth_controller.py
@@ -73,7 +73,7 @@ def format_error_message(error_data):
 
 
 @router.get("/auth/login", response_class=HTMLResponse)
-async def login_page(request: Request, next: str = "/dashboard", msg: str = None):
+async def login_page(request: Request, next: str = "/settings", msg: str = None):
     """Render login page"""
     templates = get_templates(request)
     return get_templates(request).TemplateResponse(
@@ -126,7 +126,7 @@ async def login_post(
                 emergency_token = f"emergency_{username}_{timestamp}"
 
                 # Create redirect response
-                redirect_url = request.query_params.get("next", "/dashboard")
+                redirect_url = request.query_params.get("next", "/settings")
                 response = RedirectResponse(
                     url=redirect_url, status_code=status.HTTP_302_FOUND
                 )
@@ -158,7 +158,7 @@ async def login_post(
             )
 
         # Create redirect response
-        redirect_url = request.query_params.get("next", "/dashboard")
+        redirect_url = request.query_params.get("next", "/settings")
         response = RedirectResponse(url=redirect_url, status_code=status.HTTP_302_FOUND)
 
         # Set cookie with token
@@ -218,7 +218,7 @@ async def login_post(
             emergency_token = f"emergency_{username}_{timestamp}"
 
             # Create redirect response
-            redirect_url = request.query_params.get("next", "/dashboard")
+            redirect_url = request.query_params.get("next", "/settings")
             response = RedirectResponse(
                 url=redirect_url, status_code=status.HTTP_302_FOUND
             )

--- a/ai-stock-platform/ui/main.py
+++ b/ai-stock-platform/ui/main.py
@@ -437,8 +437,8 @@ async def index(request: Request):
         if not user.get("is_authenticated"):
             return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
 
-        # If authenticated, redirect to dashboard
-        return RedirectResponse(url="/dashboard", status_code=status.HTTP_302_FOUND)
+        # If authenticated, redirect to settings
+        return RedirectResponse(url="/settings", status_code=status.HTTP_302_FOUND)
         # This route previously rendered a demo dashboard. It now simply
         # redirects authenticated users to the main dashboard and unauthenticated
         # users to the login page.
@@ -459,7 +459,7 @@ async def login_page(request: Request, msg: str = None):
         
         # Check if already authenticated
         if AuthUtils.is_authenticated(request):
-            return RedirectResponse(url="/dashboard", status_code=status.HTTP_302_FOUND)
+            return RedirectResponse(url="/settings", status_code=status.HTTP_302_FOUND)
         
         # Redirect to /auth/login for consistency
         redirect_url = "/auth/login"
@@ -520,7 +520,7 @@ async def enhanced_login_post(
         if not token:
             raise ValueError(api_resp.get("message", "Login failed"))
 
-        redirect_response = RedirectResponse(url="/dashboard", status_code=status.HTTP_302_FOUND)
+        redirect_response = RedirectResponse(url="/settings", status_code=status.HTTP_302_FOUND)
         max_age = 30 * 24 * 60 * 60 if remember else None
         redirect_response.set_cookie(
             key="access_token",
@@ -570,7 +570,7 @@ async def register_page(request: Request, msg: str = None):
         
         # Check if already authenticated
         if AuthUtils.is_authenticated(request):
-            return RedirectResponse(url="/dashboard", status_code=status.HTTP_302_FOUND)
+            return RedirectResponse(url="/settings", status_code=status.HTTP_302_FOUND)
         
         return get_templates(request).TemplateResponse(
             "register.html", 

--- a/ai-stock-platform/ui/routes/auth.py
+++ b/ai-stock-platform/ui/routes/auth.py
@@ -36,7 +36,7 @@ async def login_page(request: Request, msg: str = None, next: str = None):
         # Check if already authenticated
         auth_cookie = request.cookies.get("access_token")
         if auth_cookie:
-            return RedirectResponse(url="/dashboard", status_code=status.HTTP_302_FOUND)
+            return RedirectResponse(url="/settings", status_code=status.HTTP_302_FOUND)
         
         return get_templates(request).TemplateResponse(
             "auth/login.html",
@@ -101,7 +101,7 @@ async def login_post(
             logger.warning("Failed to fetch user info after login")
 
         # Determine redirect URL
-        redirect_url = next if next and next.startswith('/') else "/dashboard"
+        redirect_url = next if next and next.startswith('/') else "/settings"
 
         response = RedirectResponse(url=redirect_url, status_code=status.HTTP_302_FOUND)
 

--- a/ai-stock-platform/ui/routes/direct_routes.py
+++ b/ai-stock-platform/ui/routes/direct_routes.py
@@ -46,9 +46,9 @@ async def direct_login_post(
             # Login successful
             token_data = api_response.json()
             logger.info(f"Login successful for {username}")
-            
-            # Redirect to dashboard
-            redirect_response = RedirectResponse(url="/dashboard", status_code=status.HTTP_302_FOUND)
+
+            # Redirect to settings
+            redirect_response = RedirectResponse(url="/settings", status_code=status.HTTP_302_FOUND)
             
             # Set the token in a secure cookie
             max_age = 30 * 24 * 60 * 60 if remember else None  # 30 days in seconds or session cookie
@@ -73,8 +73,8 @@ async def direct_login_post(
             expires = datetime.utcnow() + timedelta(hours=24)
             token = f"emergency_{username}_{expires.timestamp()}"
             
-            # Redirect to dashboard
-            response = RedirectResponse(url="/dashboard", status_code=status.HTTP_302_FOUND)
+            # Redirect to settings
+            response = RedirectResponse(url="/settings", status_code=status.HTTP_302_FOUND)
             response.set_cookie(
                 key="access_token",
                 value=f"Bearer {token}",
@@ -94,8 +94,8 @@ async def direct_login_post(
         expires = datetime.utcnow() + timedelta(hours=24)
         token = f"emergency_{username}_{expires.timestamp()}"
         
-        # Redirect to dashboard
-        response = RedirectResponse(url="/dashboard", status_code=status.HTTP_302_FOUND)
+        # Redirect to settings
+        response = RedirectResponse(url="/settings", status_code=status.HTTP_302_FOUND)
         response.set_cookie(
             key="access_token",
             value=f"Bearer {token}",

--- a/ai-stock-platform/ui/src/components/auth/Login.tsx
+++ b/ai-stock-platform/ui/src/components/auth/Login.tsx
@@ -33,8 +33,8 @@ const Login: React.FC = () => {
       const response = await authService.login(username, password);
       console.log('Login successful:', response);
       
-      // Redirect to dashboard after successful login
-      navigate(ROUTES.DASHBOARD);
+      // Redirect to settings after successful login
+      navigate(ROUTES.SETTINGS);
     } catch (err: any) {
       console.error('Login error:', err);
       
@@ -59,7 +59,7 @@ const Login: React.FC = () => {
     setLoading(true);
     try {
       await authService.login('demo', 'password');
-      navigate(ROUTES.DASHBOARD);
+      navigate(ROUTES.SETTINGS);
     } catch (err: any) {
       console.error('Demo login error:', err);
       setError('Demo login failed. Please try again later.');

--- a/ai-stock-platform/ui/src/contexts/AuthContext.tsx
+++ b/ai-stock-platform/ui/src/contexts/AuthContext.tsx
@@ -97,9 +97,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       // Dispatch event for cross-tab communication
       window.dispatchEvent(new Event(AUTH_EVENT));
 
-      // Redirect to dashboard or intended page
-      const from = location.state?.from?.pathname || '/dashboard';
-      navigate(from, { replace: true });
+      // Redirect to settings after successful login
+      navigate('/settings', { replace: true });
     } catch (error) {
       console.error('Login failed:', error);
       throw error;

--- a/ai-stock-platform/ui/static/js/auth-sync.js
+++ b/ai-stock-platform/ui/static/js/auth-sync.js
@@ -86,10 +86,10 @@
                 document.cookie = `access_token=Bearer ${token}; path=/; samesite=lax`;
             }
             
-            // If we're on the login or register page, redirect to dashboard
+            // If we're on the login or register page, redirect to settings
             if (isLoginPage(currentPath) || isRegisterPage(currentPath)) {
-                console.log('On login/register page while logged in, redirecting to dashboard');
-                window.location.href = '/dashboard';
+                console.log('On login/register page while logged in, redirecting to settings');
+                window.location.href = '/settings';
             }
         }
     }

--- a/ai-stock-platform/ui/static/js/auth.js
+++ b/ai-stock-platform/ui/static/js/auth.js
@@ -16,7 +16,8 @@ function setupTokenRefresh() {
                 // For now, we'll just notify about potential issues
                 
                 // If on dashboard or protected page, might want to redirect to login
-                if (window.location.pathname.includes('/dashboard') || 
+                if (window.location.pathname.includes('/settings') ||
+                    window.location.pathname.includes('/dashboard') ||
                     window.location.pathname.includes('/portfolio')) {
                     // Instead of immediate redirect, show a warning first
                     if (!window._tokenWarningShown) {
@@ -110,8 +111,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 })
                 .then(response => {
                     if (response.ok) {
-                        // Check if we were redirected to dashboard (successful login)
-                        if (response.redirected && response.url.includes('/dashboard')) {
+                        // Check if we were redirected to settings (successful login)
+                        if (response.redirected && response.url.includes('/settings')) {
                             // Success! Parse cookies to extract token
                             const cookies = document.cookie.split(';');
                             let token = null;
@@ -396,9 +397,9 @@ window.authUtils = {
         const token = this.getToken();
         const isAuth = !!token;
         
-        // If we're on the home page and authenticated, redirect to dashboard
+        // If we're on the home page and authenticated, redirect to settings
         if (isAuth && window.location.pathname === '/') {
-            console.log('User is authenticated on home page, redirecting to dashboard');
+            console.log('User is authenticated on home page, redirecting to settings');
             
             // Add auth-redirecting class to prevent flashing content
             document.documentElement.classList.add('auth-redirecting');
@@ -412,7 +413,7 @@ window.authUtils = {
             
             // Redirect with a short delay to allow preloader to show
             setTimeout(() => {
-                window.location.href = '/dashboard';
+                window.location.href = '/settings';
             }, 100);
         }
         

--- a/ai-stock-platform/ui/static/js/login.js
+++ b/ai-stock-platform/ui/static/js/login.js
@@ -57,8 +57,8 @@ class Login {
       // Attempt login
       await authService.login(username, password);
       
-      // Redirect to dashboard on success
-      window.location.href = '/dashboard';
+      // Redirect to settings on success
+      window.location.href = '/settings';
     } catch (error) {
       console.error('Login failed', error);
       

--- a/ai-stock-platform/ui/tests/test_routes/test_auth_routes.py
+++ b/ai-stock-platform/ui/tests/test_routes/test_auth_routes.py
@@ -35,9 +35,9 @@ def test_login_post_success(client, test_user, monkeypatch):
                 data={"username": "testuser", "password": "password123"},
                 follow_redirects=False
             )
-            # Check redirect to dashboard
+            # Check redirect to settings
             assert response.status_code == status.HTTP_302_FOUND
-            assert response.headers["location"] == "/dashboard"
+            assert response.headers["location"] == "/settings"
             # Check authentication was called correctly
             mock_post_form.assert_called_once_with(
                 "/auth/login", data={"username": "testuser", "password": "password123"}


### PR DESCRIPTION
## Summary
- Update frontend and backend login flows to route authenticated users directly to `/settings`.
- Align authentication utilities and demo login handling with the new settings redirect.
- Adjust tests to expect the `/settings` destination after login.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.market_data')*

------
https://chatgpt.com/codex/tasks/task_e_6892e7594b20832a80fc6912f9debc2c