### PR TITLE
feat: support token auth via cookies

### DIFF
--- a/ai-stock-platform/api/core/dependencies.py
+++ b/ai-stock-platform/api/core/dependencies.py
@@ -1,18 +1,15 @@
 """
 Common dependencies for API endpoints.
 """
-from typing import Generator, Optional
+from typing import Generator
 
-from core.exceptions import AuthenticationError
-from core.security import decode_token
+from core.exceptions import AuthenticationError, PermissionError
+from core.security import decode_token, get_token
 from db.session import SessionLocal
-from fastapi import Depends, Request
-from fastapi.security import OAuth2PasswordBearer
+from fastapi import Depends
 from sqlalchemy.orm import Session
 
 from models.user import User
-
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/auth/login")
 
 async def get_db() -> Generator[Session, None, None]:
     """Get database session."""
@@ -24,7 +21,7 @@ async def get_db() -> Generator[Session, None, None]:
 
 async def get_current_user(
     db: Session = Depends(get_db),
-    token: str = Depends(oauth2_scheme)
+    token: str = Depends(get_token)
 ) -> User:
     """Get current authenticated user."""
     try:
@@ -51,5 +48,5 @@ async def get_current_admin_user(
 ) -> User:
     """Get current admin user."""
     if not current_user.is_admin:
-        raise AuthorizationError("Admin privileges required")
+        raise PermissionError("Admin privileges required")
     return current_user

--- a/ai-stock-platform/api/core/security.py
+++ b/ai-stock-platform/api/core/security.py
@@ -11,7 +11,7 @@ from core.config import settings
 from core.exceptions import AuthenticationError
 from db.models.user import User
 from db.session import get_db
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from passlib.context import CryptContext
@@ -21,7 +21,24 @@ from sqlalchemy.orm import Session
 pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 
 # OAuth2 scheme for token
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f"{settings.API_V1_STR}/auth/token")
+oauth2_scheme = OAuth2PasswordBearer(
+    tokenUrl=f"{settings.API_V1_STR}/auth/token", auto_error=False
+)
+
+
+def _strip_token(token: str) -> str:
+    token = token.strip().strip('"')
+    if token.startswith("Bearer "):
+        token = token[7:]
+    return token
+
+
+async def get_token(request: Request, token: Optional[str] = Depends(oauth2_scheme)) -> str:
+    """Retrieve JWT from Authorization header or cookie."""
+    token = token or request.cookies.get("access_token")
+    if not token:
+        raise AuthenticationError("Not authenticated")
+    return _strip_token(token)
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Verify password against hash."""
@@ -76,7 +93,7 @@ def validate_token(token: str) -> bool:
         return False
 
 async def get_current_user(
-    token: str = Depends(oauth2_scheme),
+    token: str = Depends(get_token),
     db: Session = Depends(get_db)
 ):
     """Get current user from token."""

--- a/ai-stock-platform/api/core/security/__init__.py
+++ b/ai-stock-platform/api/core/security/__init__.py
@@ -6,7 +6,7 @@ Author: gayatri
 
 # Re-export key security helpers using relative imports to avoid dependency on
 # the external compatibility wrapper.
-from .tokens import create_access_token, validate_token
+from .tokens import create_access_token, validate_token, decode_token
 from .authentication import (
     get_current_user,
     get_current_active_user,
@@ -15,4 +15,19 @@ from .authentication import (
     get_password_hash,
     pwd_context,
     oauth2_scheme,
+    get_token,
 )
+
+__all__ = [
+    "create_access_token",
+    "validate_token",
+    "decode_token",
+    "get_current_user",
+    "get_current_active_user",
+    "check_admin_role",
+    "verify_password",
+    "get_password_hash",
+    "pwd_context",
+    "oauth2_scheme",
+    "get_token",
+]

--- a/ai-stock-platform/api/core/security/authentication.py
+++ b/ai-stock-platform/api/core/security/authentication.py
@@ -5,7 +5,7 @@ Author: gayatri
 """
 from typing import Optional
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from passlib.context import CryptContext
@@ -21,7 +21,25 @@ from .tokens import validate_token
 pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 
 # OAuth2 scheme for token
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f"{settings.API_V1_STR}/auth/token")
+oauth2_scheme = OAuth2PasswordBearer(
+    tokenUrl=f"{settings.API_V1_STR}/auth/token", auto_error=False
+)
+
+
+def _strip_token(token: str) -> str:
+    """Remove Bearer prefix and surrounding quotes from a token."""
+    token = token.strip().strip('"')
+    if token.startswith("Bearer "):
+        token = token[7:]
+    return token
+
+
+async def get_token(request: Request, token: Optional[str] = Depends(oauth2_scheme)) -> str:
+    """Retrieve access token from Authorization header or cookies."""
+    token = token or request.cookies.get("access_token")
+    if not token:
+        raise AuthenticationError("Not authenticated")
+    return _strip_token(token)
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Verify password against hash."""
@@ -32,7 +50,7 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 async def get_current_user(
-    token: str = Depends(oauth2_scheme),
+    token: str = Depends(get_token),
     db: Session = Depends(get_db)
 ):
     """Get current user from token."""

--- a/ai-stock-platform/api/main.py
+++ b/ai-stock-platform/api/main.py
@@ -26,7 +26,8 @@ from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse
-from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from fastapi.security import OAuth2PasswordRequestForm
+from core.security import get_token
 from core.middleware.error_handler import ErrorHandlerMiddleware
 from core.middleware.rate_limit import RateLimitMiddleware
 from routers.auth import router as auth_router
@@ -302,8 +303,6 @@ async def api_health_check(request: Request):
 
 # --- ENHANCED AUTHENTICATION ENDPOINTS ---
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/v1/auth/login")
-
 
 @app.post("/api/v1/auth/login")
 async def login(request: Request, form_data: OAuth2PasswordRequestForm = Depends()):
@@ -361,7 +360,9 @@ async def login_get(request: Request):
 
 
 @app.get("/api/v1/auth/me")
-async def get_current_user(request: Request, token: str = Depends(oauth2_scheme)):
+
+
+async def get_current_user(request: Request, token: str = Depends(get_token)):
     """Get current user endpoint with enhanced response"""
     logger.info("Current user endpoint accessed")
     


### PR DESCRIPTION
## Summary
- allow API endpoints to read JWT tokens from Authorization header or `access_token` cookie
- expose shared `get_token` helper and update dependencies to use it
- wire new token handling into `/api/v1/auth/me` endpoint

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.market_data')*


------
https://chatgpt.com/codex/tasks/task_e_6892f1ca86d4832aaeb03f7cd2545485