### PR TITLE
feat: add auth verify fallback

### DIFF
--- a/ai-stock-platform/ui/auth/dependencies.py
+++ b/ai-stock-platform/ui/auth/dependencies.py
@@ -223,14 +223,20 @@ async def decode_token(token: str) -> Dict[str, Any]:
         # First try to verify with API server using improved HTTPX client
         from core.http_client import safe_post_json
         
-        response_data = await safe_post_json(
-            url=f"{API_URL}/api/auth/verify",
-            json_data={"token": token},
-            auth_token=token
-        )
-        
-        if response_data is not None:
-            return response_data
+        verify_urls = [
+            f"{API_URL}/api/v1/auth/verify",
+            f"{API_URL}/api/auth/verify",
+        ]
+
+        for verify_url in verify_urls:
+            response_data = await safe_post_json(
+                url=verify_url,
+                json_data={"token": token},
+                auth_token=token
+            )
+
+            if response_data is not None:
+                return response_data
             
     except Exception as e:
         logger.error(f"API token verification failed: {str(e)}")

--- a/ai-stock-platform/ui/middleware/auth_middleware.py
+++ b/ai-stock-platform/ui/middleware/auth_middleware.py
@@ -57,16 +57,20 @@ async def verify_token(token: str) -> Dict[str, Any]:
         logger.warning(f"Local token validation failed: {decode_error}; attempting API verification")
 
         api_url = os.getenv("API_URL", settings.API_BASE_URL).rstrip("/")
-        verify_url = f"{api_url}/api/v1/auth/verify"
-        try:
-            resp = await safe_post_json(verify_url, json_data={"token": token})
-            if resp and resp.get("status") == "success":
-                user = resp.get("data", {}).get("user", {})
-                username = user.get("username") or user.get("id")
-                if username:
-                    return {"username": username}
-        except Exception as api_error:
-            logger.error(f"API token verification error: {api_error}")
+        verify_urls = [
+            f"{api_url}/api/v1/auth/verify",
+            f"{api_url}/api/auth/verify",
+        ]
+        for verify_url in verify_urls:
+            try:
+                resp = await safe_post_json(verify_url, json_data={"token": token})
+                if resp and resp.get("status") == "success":
+                    user = resp.get("data", {}).get("user", {})
+                    username = user.get("username") or user.get("id")
+                    if username:
+                        return {"username": username}
+            except Exception as api_error:
+                logger.error(f"API token verification error: {api_error}")
 
         raise HTTPException(status_code=401, detail="Invalid authentication token")
 

--- a/ai-stock-platform/ui/templates/auth/dependencies.py
+++ b/ai-stock-platform/ui/templates/auth/dependencies.py
@@ -62,14 +62,20 @@ async def decode_token(token: str) -> Dict[str, Any]:
         # First try to verify with API server using improved HTTPX client
         from core.http_client import safe_post_json
         
-        response_data = await safe_post_json(
-            url=f"{API_URL}/api/auth/verify",
-            json_data={"token": token},
-            auth_token=token
-        )
-        
-        if response_data is not None:
-            return response_data
+        verify_urls = [
+            f"{API_URL}/api/v1/auth/verify",
+            f"{API_URL}/api/auth/verify",
+        ]
+
+        for verify_url in verify_urls:
+            response_data = await safe_post_json(
+                url=verify_url,
+                json_data={"token": token},
+                auth_token=token
+            )
+
+            if response_data is not None:
+                return response_data
             
     except Exception as e:
         logger.error(f"API token verification failed: {str(e)}")


### PR DESCRIPTION
## Summary
- add fallback token verification hitting legacy auth endpoint when versioned route fails
- support both `/api/v1/auth/verify` and `/api/auth/verify` in middleware and dependencies

## Testing
- `./setup_env.sh`
- `source venv/bin/activate`
- `pytest -q` *(fails: 13 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6892f22ab120832aa70c886851223c3e