### PR TITLE
Fix middleware imports

### DIFF
--- a/ai-stock-platform/ui/middleware/__init__.py
+++ b/ai-stock-platform/ui/middleware/__init__.py
@@ -10,29 +10,32 @@ logger = logging.getLogger(__name__)
 
 # Safely export middleware components
 try:
-    from .auth import AuthMiddleware
+    from .auth_middleware import AuthMiddleware
     from .error_handlers import setup_error_handlers
-    from .metrics import MetricsMiddleware
+    from .metrics_middleware import MetricsMiddleware
     logger.info("Successfully imported middleware components")
 except Exception as e:
     logger.error(f"Error importing middleware components: {e}")
-    
+
     # Define fallback middleware classes and functions
     class AuthMiddleware:
         def __init__(self, app):
             self.app = app
-            
+
         async def __call__(self, scope, receive, send):
             await self.app(scope, receive, send)
-    
+
     class MetricsMiddleware:
         def __init__(self, app):
             self.app = app
-            
+
         async def __call__(self, scope, receive, send):
             await self.app(scope, receive, send)
-    
+
     def setup_error_handlers(app):
+        """Fallback no-op error handler setup."""
         pass
-    
+
     logger.warning("Using fallback middleware components")
+
+__all__ = ["AuthMiddleware", "MetricsMiddleware", "setup_error_handlers"]


### PR DESCRIPTION
## Summary
- Correct middleware package imports to match actual module names
- Export AuthMiddleware, MetricsMiddleware, and setup_error_handlers from middleware package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi' and other missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68935dffff18832a9ff2a716cc6fbe3f