### PR TITLE
feat: add SPA fallback route

### DIFF
--- a/ai-stock-platform/ui/main.py
+++ b/ai-stock-platform/ui/main.py
@@ -1078,3 +1078,22 @@ async def direct_market_data(symbol: str, request: Request):
         return {"error": str(e), "status": "failed", "timestamp": datetime.utcnow().isoformat()}
 
 # Add routes from the `routes` module
+
+# ---------------------------------------------------------------------------
+# SPA Fallback Route
+# ---------------------------------------------------------------------------
+# When running behind an ALB or other infrastructure that serves the UI as a
+# single page application, direct navigation to client-side routes like
+# "/settings" or "/news" can result in a 404 at the edge.  To support these
+# routes we provide a catch-all handler that serves the main ``index.html``
+# template for any path that wasn't matched by earlier routes.  The React
+# application then takes over routing on the client side.
+@app.get("/{full_path:path}", response_class=HTMLResponse)
+async def spa_fallback(request: Request, full_path: str):
+    """Serve the SPA entrypoint for unmatched paths."""
+    # Preserve API 404 behaviour to avoid returning HTML for missing API
+    # endpoints.
+    if request.url.path.startswith("/api/"):
+        raise HTTPException(status_code=404)
+
+    return get_templates(request).TemplateResponse("index.html", {"request": request})

--- a/ai-stock-platform/ui/tests/test_routes/test_spa_fallback.py
+++ b/ai-stock-platform/ui/tests/test_routes/test_spa_fallback.py
@@ -1,0 +1,9 @@
+import pytest
+from fastapi import status
+
+
+def test_spa_fallback_serves_index(client):
+    """Unknown paths should serve the index.html template for SPA routing."""
+    response = client.get("/some/unknown/path", headers={"Accept": "text/html"})
+    assert response.status_code == status.HTTP_200_OK
+    assert "AI-Powered Investing for Everyone" in response.text


### PR DESCRIPTION
## Summary
- add FastAPI catch-all route serving index.html for unmatched paths
- test unknown paths return SPA entry point

## Testing
- `pytest -q` *(fails: connection to server at "quantumvestai-dev.cwbsqsiywwaa.us-east-1.rds.amazonaws.com" (10.0.37.138), port 5432 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68936b76b3e0832aaed194ec60db5a59