### PR TITLE
feat: add refresh auth and ingress updates

### DIFF
--- a/ai-stock-platform/api/app.py
+++ b/ai-stock-platform/api/app.py
@@ -103,6 +103,12 @@ async def health_check():
     # Return health status
     return health_data
 
+
+@app.get("/api/health")
+async def api_health_check():
+    """Health check endpoint under /api prefix for ALB"""
+    return await health_check()
+
 # Add startup event to verify database connection
 @app.on_event("startup")
 async def startup_event():

--- a/ai-stock-platform/api/core/security/__init__.py
+++ b/ai-stock-platform/api/core/security/__init__.py
@@ -6,7 +6,12 @@ Author: gayatri
 
 # Re-export key security helpers using relative imports to avoid dependency on
 # the external compatibility wrapper.
-from .tokens import create_access_token, validate_token, decode_token
+from .tokens import (
+    create_access_token,
+    create_refresh_token,
+    validate_token,
+    decode_token,
+)
 from .authentication import (
     get_current_user,
     get_current_active_user,
@@ -20,6 +25,7 @@ from .authentication import (
 
 __all__ = [
     "create_access_token",
+    "create_refresh_token",
     "validate_token",
     "decode_token",
     "get_current_user",

--- a/ai-stock-platform/api/core/security/tokens.py
+++ b/ai-stock-platform/api/core/security/tokens.py
@@ -29,6 +29,7 @@ class TokenHandler:
     SECRET_KEY = config.JWT_SECRET.get_secret_value() if hasattr(config, "JWT_SECRET") else config.SECRET_KEY
     ALGORITHM = config.ALGORITHM
     ACCESS_TOKEN_EXPIRE_MINUTES = config.ACCESS_TOKEN_EXPIRE_MINUTES
+    REFRESH_TOKEN_EXPIRE_MINUTES = getattr(config, "REFRESH_TOKEN_EXPIRE_MINUTES", 60 * 24 * 7)
 
     @classmethod
     def create_access_token(cls, data: dict, expires_delta: Optional[timedelta] = None) -> str:
@@ -43,6 +44,21 @@ class TokenHandler:
         return encoded_jwt
 
     @classmethod
+    def create_refresh_token(
+        cls, data: dict, expires_delta: Optional[timedelta] = None
+    ) -> str:
+        """Create a refresh token with a longer expiration."""
+        to_encode = data.copy()
+        if expires_delta:
+            expire = datetime.utcnow() + expires_delta
+        else:
+            expire = datetime.utcnow() + timedelta(
+                minutes=cls.REFRESH_TOKEN_EXPIRE_MINUTES
+            )
+        to_encode.update({"exp": expire, "type": "refresh"})
+        return jwt.encode(to_encode, cls.SECRET_KEY, algorithm=cls.ALGORITHM)
+
+    @classmethod
     def decode_token(cls, token: str) -> Optional[BaseModel]:
         return jwt.decode(token, cls.SECRET_KEY, algorithms=[cls.ALGORITHM])
 
@@ -50,6 +66,13 @@ class TokenHandler:
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     """Convenience wrapper to create an access token using :class:`TokenHandler`."""
     return TokenHandler.create_access_token(data, expires_delta)
+
+
+def create_refresh_token(
+    data: dict, expires_delta: Optional[timedelta] = None
+) -> str:
+    """Convenience wrapper to create a refresh token using :class:`TokenHandler`."""
+    return TokenHandler.create_refresh_token(data, expires_delta)
 
 
 def decode_token(token: str) -> Optional[BaseModel]:

--- a/ai-stock-platform/api/routers/auth.py
+++ b/ai-stock-platform/api/routers/auth.py
@@ -16,6 +16,7 @@ from core.security import (
     get_password_hash,
     verify_password,
     create_access_token,
+    create_refresh_token,
     decode_token,
 )
 # Use the SQLAlchemy model from the consolidated db.models package
@@ -90,6 +91,10 @@ class TokenVerifyData(BaseModel):
     user: TokenVerifyUser
 
 
+class RefreshTokenRequest(BaseModel):
+    refresh_token: str
+
+
 @router.post(
     "/login",
     response_model=StandardResponse,
@@ -128,19 +133,24 @@ async def login(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # Create access token
+    # Create access and refresh tokens
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     access_token = create_access_token(
         data={"sub": user.username, "role": user.role},
         expires_delta=access_token_expires,
     )
+    refresh_token = create_refresh_token({"sub": user.username, "role": user.role})
 
     logger.info(f"Successful login for user: {form_data.username}")
 
     return StandardResponse(
         status="success",
         message="Login successful",
-        data=TokenResponse(access_token=access_token, token_type="bearer"),
+        data=TokenResponse(
+            access_token=access_token,
+            token_type="bearer",
+            refresh_token=refresh_token,
+        ),
     )
 
 
@@ -197,6 +207,35 @@ async def verify_token_endpoint(token_data: TokenVerifyRequest):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token",
+        )
+
+
+@router.post(
+    "/refresh",
+    response_model=StandardResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Refresh Access Token",
+    description="Refresh an access token using a valid refresh token",
+)
+async def refresh_access_token(token_data: RefreshTokenRequest):
+    """Generate a new access token from a refresh token."""
+    try:
+        payload = decode_token(token_data.refresh_token)
+        if payload.get("type") != "refresh":
+            raise ValueError("Invalid token type")
+        username = payload.get("sub")
+        role = payload.get("role")
+        new_token = create_access_token({"sub": username, "role": role})
+        return StandardResponse(
+            status="success",
+            message="Token refreshed",
+            data=TokenResponse(access_token=new_token, token_type="bearer"),
+        )
+    except Exception as exc:  # pragma: no cover - runtime validation
+        logger.warning(f"Token refresh failed: {exc}")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid refresh token",
         )
 
 

--- a/ai-stock-platform/api/schemas/auth.py
+++ b/ai-stock-platform/api/schemas/auth.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, EmailStr, Field, validator
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str
+    refresh_token: Optional[str] = None
 
 class UserBase(BaseModel):
     username: str

--- a/ai-stock-platform/api/websocket/market_data.py
+++ b/ai-stock-platform/api/websocket/market_data.py
@@ -38,6 +38,11 @@ async def authorize_websocket(token: str) -> bool:
 async def websocket_handler(request):
     token = request.query.get("token")
     if not token:
+        auth_header = request.headers.get("Authorization")
+        if auth_header and auth_header.lower().startswith("bearer "):
+            token = auth_header.split(" ", 1)[1]
+
+    if not token:
         logger.error("No token provided in WebSocket request")
         return web.Response(status=403, text="Forbidden: No token provided")
     

--- a/ai-stock-platform/ui/src/components/Header.tsx
+++ b/ai-stock-platform/ui/src/components/Header.tsx
@@ -13,6 +13,7 @@ import {
 import MenuIcon from '@mui/icons-material/Menu';
 import SearchIcon from '@mui/icons-material/Search';
 import NotificationsIcon from '@mui/icons-material/Notifications';
+import { useAuth } from '../contexts/AuthContext';
 
 interface HeaderProps {
   /** Called when the sidebar menu icon is clicked */
@@ -21,6 +22,7 @@ interface HeaderProps {
 
 const Header: React.FC<HeaderProps> = ({ onMenuClick }) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const { user, isAuthenticated, logout } = useAuth();
 
   const handleProfileClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
@@ -88,7 +90,11 @@ const Header: React.FC<HeaderProps> = ({ onMenuClick }) => {
           </Badge>
         </IconButton>
         <IconButton color="inherit" onClick={handleProfileClick} sx={{ ml: 2 }} aria-label="account options">
-          <Avatar sx={{ width: 32, height: 32 }}>U</Avatar>
+          <Avatar sx={{ width: 32, height: 32 }}>
+            {isAuthenticated && user?.full_name
+              ? user.full_name.charAt(0).toUpperCase()
+              : 'U'}
+          </Avatar>
         </IconButton>
         <Menu
           anchorEl={anchorEl}
@@ -97,8 +103,17 @@ const Header: React.FC<HeaderProps> = ({ onMenuClick }) => {
           anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
           transformOrigin={{ vertical: 'top', horizontal: 'right' }}
         >
-          <MenuItem onClick={handleClose}>Profile</MenuItem>
-          <MenuItem onClick={handleClose}>Logout</MenuItem>
+          {isAuthenticated && (
+            <MenuItem onClick={handleClose}>{user?.username}</MenuItem>
+          )}
+          <MenuItem
+            onClick={() => {
+              handleClose();
+              logout();
+            }}
+          >
+            Logout
+          </MenuItem>
         </Menu>
       </Toolbar>
     </AppBar>

--- a/ai-stock-platform/ui/src/config/constants.ts
+++ b/ai-stock-platform/ui/src/config/constants.ts
@@ -13,6 +13,7 @@ export const API_BASE_URL =
 
 // Authentication
 export const ACCESS_TOKEN_KEY = 'qvai_token';
+export const REFRESH_TOKEN_KEY = 'qvai_refresh_token';
 
 // API Endpoints
 export const API_ENDPOINTS = {
@@ -24,6 +25,7 @@ export const API_ENDPOINTS = {
     CURRENT_USER: '/api/v1/auth/me',
     FORGOT_PASSWORD: '/api/v1/auth/password-reset/request',
     RESET_PASSWORD: '/api/v1/auth/password-reset/confirm',
+    REFRESH: '/api/v1/auth/refresh',
   },
   // Stock endpoints
   STOCKS: {

--- a/ai-stock-platform/ui/src/contexts/AuthContext.tsx
+++ b/ai-stock-platform/ui/src/contexts/AuthContext.tsx
@@ -12,6 +12,7 @@ interface AuthContextType {
   user: User | null;
   token: string | null;
   isAuthenticated: boolean;
+  isLoading: boolean;
   login: (username: string, password: string) => Promise<void>;
   logout: () => void;
 }
@@ -21,6 +22,7 @@ const AuthContext = createContext<AuthContextType>({
   user: null,
   token: null,
   isAuthenticated: false,
+  isLoading: true,
   login: async () => {},
   logout: () => {},
 });
@@ -58,6 +60,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   // Compute authentication status
   const isAuthenticated = !!token && !!user;
+  const [isLoading, setIsLoading] = useState(true);
 
   // Handle login across tabs
   useEffect(() => {
@@ -81,6 +84,25 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     return () => {
       window.removeEventListener('storage', handleStorageChange);
     };
+  }, []);
+
+  // Rehydrate auth state on mount
+  useEffect(() => {
+    if (token && !user) {
+      authService
+        .fetchCurrentUser()
+        .then((u) => {
+          setUser(u);
+          localStorage.setItem(USER_KEY, JSON.stringify(u));
+        })
+        .catch(() => {
+          authService.logout();
+          setToken(null);
+        })
+        .finally(() => setIsLoading(false));
+    } else {
+      setIsLoading(false);
+    }
   }, []);
 
   // Login function
@@ -124,6 +146,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     user,
     token,
     isAuthenticated,
+    isLoading,
     login,
     logout,
   };

--- a/ai-stock-platform/ui/src/services/auth.service.ts
+++ b/ai-stock-platform/ui/src/services/auth.service.ts
@@ -21,6 +21,7 @@ export interface AuthResponse {
   message: string;
   data: {
     access_token: string;
+    refresh_token?: string;
     token_type: string;
   };
 }
@@ -53,6 +54,7 @@ class AuthService {
   private tokenSubject = new BehaviorSubject<string | null>(
     localStorage.getItem('qvai_token')
   );
+  private refreshTokenKey = 'qvai_refresh_token';
 
   public currentUser = this.currentUserSubject.asObservable();
   public token = this.tokenSubject.asObservable();
@@ -65,6 +67,33 @@ class AuthService {
         this.logout();
       });
     }
+
+    // Setup axios interceptors for auth
+    axios.interceptors.request.use(async (config) => {
+      const token = this.getToken();
+      if (token) {
+        config.headers = config.headers || {};
+        config.headers['Authorization'] = `Bearer ${token}`;
+      }
+      return config;
+    });
+
+    axios.interceptors.response.use(
+      (response) => response,
+      async (error) => {
+        if (error.response && error.response.status === 401) {
+          try {
+            const newToken = await this.refreshToken();
+            error.config.headers['Authorization'] = `Bearer ${newToken}`;
+            return axios(error.config);
+          } catch (refreshError) {
+            this.logout();
+            return Promise.reject(refreshError);
+          }
+        }
+        return Promise.reject(error);
+      }
+    );
   }
 
   /**
@@ -92,9 +121,13 @@ class AuthService {
 
       if (response.data.status === 'success' && response.data.data.access_token) {
         const token = response.data.data.access_token;
+        const refreshToken = response.data.data.refresh_token;
 
         // Store token in local storage - this triggers storage event for cross-tab sync
         localStorage.setItem('qvai_token', token);
+        if (refreshToken) {
+          localStorage.setItem(this.refreshTokenKey, refreshToken);
+        }
 
         // Persist token in cookies so server-rendered pages stay authenticated
         document.cookie = `qvai_token=${token}; path=/; samesite=lax`;
@@ -183,6 +216,7 @@ class AuthService {
   logout(): void {
     // Clear token from storage
     localStorage.removeItem('qvai_token');
+    localStorage.removeItem(this.refreshTokenKey);
 
     // Remove authentication cookies
     document.cookie = 'qvai_token=; Max-Age=0; path=/';
@@ -208,6 +242,10 @@ class AuthService {
    */
   getToken(): string | null {
     return localStorage.getItem('qvai_token');
+  }
+
+  getRefreshToken(): string | null {
+    return localStorage.getItem(this.refreshTokenKey);
   }
 
   /**
@@ -269,14 +307,13 @@ class AuthService {
    */
   async refreshToken(): Promise<string> {
     try {
+      const refreshToken = this.getRefreshToken();
+      if (!refreshToken) {
+        throw new Error('No refresh token available');
+      }
       const response = await axios.post<AuthResponse>(
-        `${API_BASE_URL}/api/v1/auth/refresh-token`,
-        {},
-        {
-          headers: {
-            Authorization: `Bearer ${this.getToken()}`,
-          },
-        }
+        `${API_BASE_URL}/api/v1/auth/refresh`,
+        { refresh_token: refreshToken }
       );
 
       if (response.data.status === 'success' && response.data.data.access_token) {

--- a/ci-cd/k8s/db-migration-job.yaml
+++ b/ci-cd/k8s/db-migration-job.yaml
@@ -12,6 +12,9 @@ metadata:
     environment: development
     app: quantumvestai
     component: db-migration
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   ttlSecondsAfterFinished: 100
   backoffLimit: 3

--- a/ci-cd/k8s/db-seed-job.yaml
+++ b/ci-cd/k8s/db-seed-job.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-seed
+  namespace: dev
+  labels:
+    environment: development
+    app: quantumvestai
+    component: db-seed
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 100
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        environment: development
+        app: quantumvestai
+        component: db-seed
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: db-seed
+          image: 921930869047.dkr.ecr.us-east-1.amazonaws.com/quantumvestai:db-init-dev-latest
+          command: ['python', 'scripts/seed_db.py']
+          envFrom:
+            - configMapRef:
+                name: quantumvestai-config
+            - secretRef:
+                name: quantumvestai-cluster-rds-credentials
+          volumeMounts:
+            - name: seed-data
+              mountPath: /app/seed_data.json
+              subPath: seed-data.json
+      volumes:
+        - name: seed-data
+          configMap:
+            name: db-init-config
+            items:
+              - key: seed-data.json
+                path: seed-data.json

--- a/ci-cd/k8s/dev/05-ingress.yaml
+++ b/ci-cd/k8s/dev/05-ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:921930869047:certificate/94eec8e0-cf9a-4184-8e27-2c3c845c390a
-    alb.ingress.kubernetes.io/healthcheck-path: "/api/v1/health"
+    alb.ingress.kubernetes.io/healthcheck-path: "/api/health"
     alb.ingress.kubernetes.io/healthcheck-port: "8000"
     alb.ingress.kubernetes.io/healthcheck-protocol: "HTTP"
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
@@ -19,6 +19,8 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: "2"
     alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
     alb.ingress.kubernetes.io/success-codes: "200-399"
+    alb.ingress.kubernetes.io/websocket-enabled: "true"
+    alb.ingress.kubernetes.io/headers.Authorization: "keep"
 spec:
   rules:
     - host: dev.quantumvestai.com


### PR DESCRIPTION
## Summary
- support refresh tokens in API and frontend
- add ALB ingress and helm jobs with health checks
- display authenticated user info and reconnect websockets with JWT

## Testing
- `pytest tests/test_settings_endpoint.py -q` *(fails: assert 401 == 200)*
- `pytest -q` *(fails: 11 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68936b96ba8c832ab6ea10b86ecf75d1