### PR TITLE
Exempt auth verify endpoint from rate limiting

### DIFF
--- a/API_RATE_LIMITING.md
+++ b/API_RATE_LIMITING.md
@@ -48,6 +48,7 @@ This document summarizes the restrictions and rate limiting measures implemented
 - Updated API endpoints to reflect the new limits:
   - Changed Twitter sentiment endpoint to limit days to max 7 (default 3)
   - Set hard limit of 100 tweets for Twitter sentiment analysis
+  - Exempted `/api/v1/auth/verify` from rate limiting to allow frequent token checks
 
 ## Best Practices
 

--- a/ai-stock-platform/api/core/middleware/rate_limit.py
+++ b/ai-stock-platform/api/core/middleware/rate_limit.py
@@ -84,7 +84,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             "/health",
             "/docs",
             "/openapi.json",
-            "/favicon.ico"
+            "/favicon.ico",
+            "/api/v1/auth/verify",
+            "/api/auth/verify",
         ]
     
     def get_client_id(self, request: Request) -> str:

--- a/tests/test_auth_verify_rate_limit.py
+++ b/tests/test_auth_verify_rate_limit.py
@@ -1,0 +1,19 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+ROOT = os.path.join(os.path.dirname(__file__), "..", "ai-stock-platform")
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "api"))
+
+from api.main import app
+from core.security import create_access_token
+
+
+def test_verify_endpoint_not_rate_limited():
+    client = TestClient(app)
+    token = create_access_token({"sub": "tester"})
+    for _ in range(15):
+        resp = client.post("/api/v1/auth/verify", json={"token": token})
+        assert resp.status_code == 200
+        assert resp.json()["data"]["valid"] is True


### PR DESCRIPTION
## Summary
- exclude `/api/v1/auth/verify` from rate limiting to prevent 429 responses
- document verification endpoint exemption in API rate limiting guidelines
- add regression test confirming token verification isn't rate limited

## Testing
- `./setup_env.sh`
- `pytest -q` *(fails: connection to server at "quantumvestai-dev.cwbsqsiywwaa.us-east-1.rds.amazonaws.com" (10.0.37.138), port 5432 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68938188f670832aa62d355d5f427590