### PR TITLE
Ensure settings template always receives data context

### DIFF
--- a/ai-stock-platform/ui/routes/settings.py
+++ b/ai-stock-platform/ui/routes/settings.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from core.config.settings import settings
+from utils.template_context import create_safe_template_context
 
 # Setup router
 router = APIRouter(prefix="/settings", tags=["settings"])
@@ -43,22 +44,20 @@ async def settings_page(request: Request):
         logger.info("Loading settings page for %s", user.get("username"))
 
         templates = get_templates(request)
-        return templates.TemplateResponse(
+        context = create_safe_template_context(
+            request,
+            templates,
             "settings.html",
-            {
-                "request": request,
-                # The settings template expects a ``data`` object for
-                # backward compatibility with earlier implementations.
-                # Provide the demo settings under this key so the template
-                # renders without raising ``UndefinedError`` when it tries to
-                # access ``data``.
-                "data": DEMO_USER_SETTINGS,
-                "page_title": "Settings - QuantumVestAI",
-                # Expose the asset helper so base templates can resolve static
-                # asset URLs even if the filter isn't registered globally.
-                "get_asset_url": templates.env.filters.get("get_asset_url"),
-            },
+            # The settings template expects a ``data`` object. Provide
+            # a default structure so Jinja doesn't raise ``UndefinedError``
+            # when rendering the page.
+            data=DEMO_USER_SETTINGS,
+            page_title="Settings - QuantumVestAI",
+            # Expose the asset helper so base templates can resolve static
+            # asset URLs even if the filter isn't registered globally.
+            get_asset_url=templates.env.filters.get("get_asset_url"),
         )
+        return templates.TemplateResponse("settings.html", context)
         
     except Exception as e:
         logger.error(f"Error loading settings: {str(e)}")

--- a/ai-stock-platform/ui/routes/settings_old.py
+++ b/ai-stock-platform/ui/routes/settings_old.py
@@ -121,6 +121,10 @@ async def settings_page(request: Request):
             {
                 "request": request,
                 "user": user,
+                # The template historically expects a ``data`` object. Include
+                # the user settings under this key to maintain compatibility
+                # and avoid ``UndefinedError`` exceptions during rendering.
+                "data": user_settings,
                 "settings": user_settings,
                 "options": available_options,
                 "page_title": "User Settings",
@@ -137,6 +141,10 @@ async def settings_page(request: Request):
             {
                 "request": request,
                 "user": None,
+                # Provide empty ``data`` and ``settings`` structures so the
+                # template renders without undefined variable errors even when
+                # an exception occurs.
+                "data": {},
                 "settings": {},
                 "options": {"themes": [], "languages": [], "timezones": [], "currencies": []},
                 "error": error_message,


### PR DESCRIPTION
## Summary
- prevent Jinja `UndefinedError` on `/settings` by always providing a `data` object using the shared template context helper
- update legacy settings route to supply compatible `data` placeholders during rendering and error cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893a50b6618832aa9b9213c24336d73